### PR TITLE
Show warning when build queue is backed up

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -283,6 +283,11 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 
 .notification { padding: 30px 0; color: #a55; }
 
+
+/* warning banner */
+
+.banner { padding: 5px; }
+
 /* sidebar + main content */
 
 .navigable { width: 100%; }

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -1,11 +1,16 @@
 from django.conf import settings
-from redis import Redis
+from redis import Redis, ConnectionError
 
 redis = Redis(**settings.REDIS)
 
 def readthedocs_processor(request):
+    try:
+        queue_length = redis.llen('celery')
+    except ConnectionError:
+        queue_length = None
+
     exports = {
-        'BUILD_QUEUE_DEPTH': redis.llen('celery'),
+        'BUILD_QUEUE_DEPTH': queue_length,
         'PRODUCTION_DOMAIN': getattr(settings, 'PRODUCTION_DOMAIN', None),
         'USE_SUBDOMAINS': getattr(settings, 'USE_SUBDOMAINS', None),
         'GLOBAL_ANALYTICS_CODE': getattr(settings, 'GLOBAL_ANALYTICS_CODE', 'UA-17997319-1'),

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -1,7 +1,11 @@
 from django.conf import settings
+from redis import Redis
+
+redis = Redis(**settings.REDIS)
 
 def readthedocs_processor(request):
     exports = {
+        'BUILD_QUEUE_DEPTH': redis.llen('celery'),
         'PRODUCTION_DOMAIN': getattr(settings, 'PRODUCTION_DOMAIN', None),
         'USE_SUBDOMAINS': getattr(settings, 'USE_SUBDOMAINS', None),
         'GLOBAL_ANALYTICS_CODE': getattr(settings, 'GLOBAL_ANALYTICS_CODE', 'UA-17997319-1'),

--- a/readthedocs/templates/core/header.html
+++ b/readthedocs/templates/core/header.html
@@ -56,3 +56,13 @@
       </div>
     </div>
     <!-- END header-->
+
+    <!-- BEGIN queue depth warning -->
+    {% if BUILD_QUEUE_DEPTH > 10 %}
+    <div class='banner'>
+      {% blocktrans with BUILD_QUEUE_DEPTH as queue_length %}
+        Whoa! The build queue is {{ queue_length }} long, new builds may take a while.
+      {% endblocktrans %}
+    </div>
+    {% endif %}
+    <!-- END queue depth warning -->


### PR DESCRIPTION
https://github.com/rtfd/readthedocs.org/issues/758

Started taking a pop at this. Have taken a different approach to the linked issue, I've added a context processor
instead of making another request on page load. Are there any obvious issues with this approach? 

It's not yet ready to merge, I could use a hand with the styling, not sure how you want to handle that. I imagine you'll want to tweak the copy too.