### PR TITLE
Use python optimise

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -116,7 +116,9 @@ class BaseSphinx(BaseBuilder):
         project = self.version.project
         os.chdir(project.conf_dir(self.version.slug))
         force_str = " -E " if self._force else ""
-        build_command = "%s -T %s -b %s -D language=%s . %s " % (
+        build_command = "%s -O %s -T %s -b %s -D language=%s . %s " % (
+            project.venv_bin(version='latest',
+                             bin='python'),
             project.venv_bin(version=self.version.slug,
                              bin='sphinx-build'),
             force_str,
@@ -206,9 +208,12 @@ class PdfBuilder(BaseSphinx):
         os.chdir(project.conf_dir(self.version.slug))
         # Default to this so we can return it always.
         results = {}
-        latex_results = run('%s -b latex -D language=%s -d _build/doctrees . _build/latex'
-                            % (project.venv_bin(version=self.version.slug,
-                                                bin='sphinx-build'), project.language))
+        latex_results = run('%s -O %s -b latex -D language=%s -d _build/doctrees . _build/latex'
+                            % (project.venv_bin(version='latest',
+                                                bin='python'),
+                               project.venv_bin(version=self.version.slug,
+                                                bin='sphinx-build'),
+                               project.language))
 
         if latex_results[0] == 0:
             os.chdir('_build/latex')

--- a/readthedocs/projects/signals.py
+++ b/readthedocs/projects/signals.py
@@ -1,0 +1,7 @@
+import django.dispatch
+
+before_vcs = django.dispatch.Signal(providing_args=["version"])
+after_vcs = django.dispatch.Signal(providing_args=["version"])
+
+before_build = django.dispatch.Signal(providing_args=["version"])
+after_build = django.dispatch.Signal(providing_args=["version"])


### PR DESCRIPTION
This might need to be a project advanced setting, as projects that use the __debug__ flag will likely have different expectations about whether it should be enabled/disabled when importing code for the purpose of documentation.  I use -O it to remove some decorators, and I dont want those decorators and the effect they have, appearing in documentation.