### PR TITLE
Place `projects` before `builds` in INSTALLED_APPS

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -186,11 +186,11 @@ INSTALLED_APPS = [
 
     # our apps
     'bookmarks',
+    'projects',
     'builds',
     'core',
     'doc_builder',
     'oauth',
-    'projects',
     'redirects',
     'rtd_tests',
     'restapi',


### PR DESCRIPTION
When attempting to install readthedocs from scratch, installation fails because the migrations in `builds` depend on migrations from `projects`.  While these dependencies can be explicitly modelled in newer versions of South, they are implicitly modelled in older versions via app ordering.

This commit fixes the installation, but a better solution might be to update to the latest South and model this dependency explicitly.