### PR TITLE
Remove pyquery as it is already in the pip_requirements

### DIFF
--- a/onebox_requirements.txt
+++ b/onebox_requirements.txt
@@ -3,7 +3,6 @@ dnspython
 gunicorn
 #For resizing images
 pillow
-pyquery
 python-memcached
 whoosh
 django-redis


### PR DESCRIPTION
pip will complain about the duplication with the error:

    Double requirement given: pyquery (from -r onebox_requirements.txt
    (line 6)) (already in pyquery==1.2.2 (from -r pip_requirements.txt
    (line 47)), name='pyquery')