### PR TITLE
Add some project import onboarding for first project/builds

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -273,7 +273,10 @@ div.menu-user div.menu-dropdown.menu-dropped {
 
 /* search */
 
-.search { border-bottom: solid 1px #bfbfbf; }
+.search {
+    border-bottom: solid 1px #bfbfbf;
+    margin-bottom: 24px;
+}
 .search input[type=text] { float: left; margin-right: 10px; padding: 8px 10px; }
 .search input[type=submit] { margin-top: 0; }
 

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -272,3 +272,8 @@ class Build(models.Model):
     @models.permalink
     def get_absolute_url(self):
         return ('builds_detail', [self.project.slug, self.pk])
+
+    @property
+    def finished(self):
+        '''Return if build has a finished state'''
+        return self.state == 'finished'

--- a/readthedocs/projects/backends/views.py
+++ b/readthedocs/projects/backends/views.py
@@ -15,3 +15,10 @@ ImportWizardView = import_by_path(getattr(
     'PROJECT_IMPORT_VIEW',
     'projects.views.private.ImportWizardView'
 ))
+
+# Project demo import
+ImportDemoView = import_by_path(getattr(
+    settings,
+    'PROJECT_IMPORT_DEMO_VIEW',
+    'projects.views.private.ImportDemoView'
+))

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -625,11 +625,17 @@ class Project(models.Model):
                 matches.append(os.path.join(root, filename))
         return matches
 
-    def get_latest_build(self):
-        try:
-            return self.builds.filter(type='html', state='finished')[0]
-        except IndexError:
-            return None
+    def get_latest_build(self, finished=True):
+        """
+        Get latest build for project
+
+        finished
+            Return only builds that are in a finished state
+        """
+        kwargs = {'type': 'html'}
+        if finished:
+            kwargs['state'] = 'finished'
+        return self.builds.filter(**kwargs).first()
 
     def api_versions(self):
         ret = []

--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 from projects.views.private import AliasList, ProjectDashboard, ImportView
-from projects.backends.views import ImportWizardView
+from projects.backends.views import ImportWizardView, ImportDemoView
 
 
 urlpatterns = patterns(
@@ -20,6 +20,10 @@ urlpatterns = patterns(
         ImportWizardView.as_view(),
         name='projects_import_manual'),
 
+    url(r'^import/manual/demo/$',
+        ImportDemoView.as_view(),
+        name='projects_import_demo'),
+
     url(r'^import/github/$',
         'projects.views.private.project_import_github',
         {'sync': False},
@@ -29,7 +33,7 @@ urlpatterns = patterns(
         'projects.views.private.project_import_github',
         {'sync': True},
         name='projects_sync_github'),
-    
+
     url(r'^import/bitbucket/$',
         'projects.views.private.project_import_bitbucket',
         {'sync': False},

--- a/readthedocs/projects/urls/public.py
+++ b/readthedocs/projects/urls/public.py
@@ -1,6 +1,7 @@
 from django.conf.urls import patterns, url
 
-from projects.views.public import ProjectIndex
+from projects.views.public import ProjectIndex, ProjectDetailView
+
 
 urlpatterns = patterns(
     # base view, flake8 complains if it is on the previous line.
@@ -26,7 +27,7 @@ urlpatterns = patterns(
         name='projects_tag_detail'),
 
     url(r'^(?P<project_slug>[-\w]+)/$',
-        'projects.views.public.project_detail',
+        ProjectDetailView.as_view(),
         name='projects_detail'),
 
     url(r'^(?P<project_slug>[-\w]+)/downloads/$',

--- a/readthedocs/projects/views/base.py
+++ b/readthedocs/projects/views/base.py
@@ -1,0 +1,27 @@
+from readthedocs.projects.models import Project
+
+
+class ProjectOnboardMixin(object):
+    '''Add project onboard context data to project object views'''
+
+    def get_context_data(self, **kwargs):
+        '''Add onboard context data'''
+        context = super(ProjectOnboardMixin, self).get_context_data(**kwargs)
+        # If more than 1 project, don't show onboarding at all. This could
+        # change in the future, to onboard each user maybe?
+        if Project.objects.for_admin_user(self.request.user).count() > 1:
+            return context
+
+        onboard = {}
+        project = self.get_object()
+
+        # Show for the first few builds, return last build state
+        if project.builds.count() <= 5:
+            onboard['build'] = project.get_latest_build(finished=False)
+            if 'github' in project.repo:
+                onboard['provider'] = 'github'
+            elif 'bitbucket' in project.repo:
+                onboard['provider'] = 'bitbucket'
+            context['onboard'] = onboard
+
+        return context

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -319,7 +319,8 @@ class ImportDemoView(View):
         self.kwargs = kwargs
 
         data = self.get_form_data()
-        project = Project.objects.filter(repo=data['repo']).first()
+        project = (Project.objects.for_admin_user(request.user)
+                   .filter(repo=data['repo']).first())
         if project is not None:
             messages.success(
                 request, _('The demo project is already imported!'))

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -10,7 +10,7 @@ from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotAllow
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
-from django.views.generic import ListView, TemplateView
+from django.views.generic import View, ListView, TemplateView
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.formtools.wizard.views import SessionWizardView
@@ -302,6 +302,56 @@ class ImportView(TemplateView):
             initial_data['extra'][key] = request.POST.get(key)
         request.method = 'GET'
         return self.wizard_class.as_view(initial_dict=initial_data)(request)
+
+
+class ImportDemoView(View):
+    '''View to pass request on to import form to import demo project'''
+
+    form_class = ProjectBasicsForm
+    request = None
+    args = None
+    kwargs = None
+
+    def get(self, request, *args, **kwargs):
+        '''Process link request as a form post to the project import form'''
+        self.request = request
+        self.args = args
+        self.kwargs = kwargs
+
+        data = self.get_form_data()
+        project = Project.objects.filter(repo=data['repo']).first()
+        if project is not None:
+            messages.success(
+                request, _('The demo project is already imported!'))
+        else:
+            kwargs = self.get_form_kwargs()
+            form = self.form_class(data=data, **kwargs)
+            if form.is_valid():
+                project = form.save()
+                project.save()
+                trigger_build(project, basic=True)
+                messages.success(
+                    request, _('Your demo project is currently being imported'))
+            else:
+                for (_f, msg) in form.errors.items():
+                    log.error(msg)
+                messages.error(request,
+                               _('There was a problem adding the demo project'))
+                return HttpResponseRedirect(reverse('projects_dashboard'))
+        return HttpResponseRedirect(reverse('projects_detail',
+                                            args=[project.slug]))
+
+    def get_form_data(self):
+        '''Get form data to post to import form'''
+        return {
+            'name': '{0}-demo'.format(self.request.user.username),
+            'repo_type': 'git',
+            'repo': 'https://github.com/readthedocs/template.git'
+        }
+
+    def get_form_kwargs(self):
+        '''Form kwargs passed in during instantiation'''
+        return {'user': self.request.user}
 
 
 @login_required

--- a/readthedocs/rtd_tests/base.py
+++ b/readthedocs/rtd_tests/base.py
@@ -23,6 +23,13 @@ class RTDTestCase(TestCase):
         shutil.rmtree(self.build_dir)
 
 
+@patch('projects.views.private.trigger_build', lambda x, basic: None)
+@patch('readthedocs.projects.views.private.trigger_build', lambda x, basic: None)
+class MockBuildTestCase(TestCase):
+    '''Mock build triggers for test cases'''
+    pass
+
+
 class WizardTestCase(TestCase):
     '''Test case for testing wizard forms'''
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -1,3 +1,9 @@
+import re
+
+from mock import patch
+from django.test import TestCase
+from django.contrib.messages import constants as MSG
+
 from rtd_tests.base import WizardTestCase
 from projects.models import Project
 
@@ -95,3 +101,91 @@ class TestAdvancedForm(TestBasicsForm):
         self.assertWizardFailure(resp, 'default_version')
         self.assertWizardFailure(resp, 'privacy_level')
         self.assertWizardFailure(resp, 'python_interpreter')
+
+
+@patch('projects.views.private.trigger_build', lambda x, basic: None)
+@patch('readthedocs.projects.views.private.trigger_build', lambda x, basic: None)
+class TestImportDemoView(TestCase):
+    '''Test project import demo view'''
+
+    fixtures = ["eric"]
+
+    def setUp(self):
+        self.client.login(username='eric', password='test')
+
+    def test_import_demo_pass(self):
+        resp = self.client.get('/dashboard/import/manual/demo/')
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp['Location'],
+                         'http://testserver/projects/eric-demo/')
+        resp_redir = self.client.get(resp['Location'])
+        self.assertEqual(resp_redir.status_code, 200)
+        messages = list(resp_redir.context['messages'])
+        self.assertEqual(messages[0].level, MSG.SUCCESS)
+
+    def test_import_demo_already_imported(self):
+        '''Import demo project multiple times, expect failure 2nd post'''
+        self.test_import_demo_pass()
+        project = Project.objects.get(slug='eric-demo')
+
+        resp = self.client.get('/dashboard/import/manual/demo/')
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp['Location'],
+                         'http://testserver/projects/eric-demo/')
+
+        resp_redir = self.client.get(resp['Location'])
+        self.assertEqual(resp_redir.status_code, 200)
+        messages = list(resp_redir.context['messages'])
+        self.assertEqual(messages[0].level, MSG.SUCCESS)
+
+        self.assertEqual(project,
+                         Project.objects.get(slug='eric-demo'))
+
+    def test_import_demo_imported_renamed(self):
+        '''If the demo project is renamed, don't import another'''
+        self.test_import_demo_pass()
+        project = Project.objects.get(slug='eric-demo')
+        project.name = 'eric-demo-foobar'
+        project.save()
+
+        resp = self.client.get('/dashboard/import/manual/demo/')
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp['Location'],
+                         'http://testserver/projects/eric-demo/')
+
+        resp_redir = self.client.get(resp['Location'])
+        self.assertEqual(resp_redir.status_code, 200)
+        messages = list(resp_redir.context['messages'])
+        self.assertEqual(messages[0].level, MSG.SUCCESS)
+        self.assertRegexpMatches(messages[0].message,
+                                 r'already imported')
+
+        self.assertEqual(project,
+                         Project.objects.get(slug='eric-demo'))
+
+    def test_import_demo_imported_duplicate(self):
+        '''If a project exists with same name, expect a failure importing demo
+
+        This should be edge case, user would have to import a project (not the
+        demo project), named user-demo, and then manually enter the demo import
+        URL, as the onboarding isn't shown when projects > 0
+        '''
+        self.test_import_demo_pass()
+        project = Project.objects.get(slug='eric-demo')
+        project.repo = 'file:///foobar'
+        project.save()
+
+        resp = self.client.get('/dashboard/import/manual/demo/')
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp['Location'],
+                         'http://testserver/dashboard/')
+
+        resp_redir = self.client.get(resp['Location'])
+        self.assertEqual(resp_redir.status_code, 200)
+        messages = list(resp_redir.context['messages'])
+        self.assertEqual(messages[0].level, MSG.ERROR)
+        self.assertRegexpMatches(messages[0].message,
+                                 r'There was a problem')
+
+        self.assertEqual(project,
+                         Project.objects.get(slug='eric-demo'))

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -1,10 +1,8 @@
 import re
 
-from mock import patch
-from django.test import TestCase
-from django.contrib.messages import constants as MSG
+from django.contrib.messages import constants as message_const
 
-from rtd_tests.base import WizardTestCase
+from rtd_tests.base import WizardTestCase, MockBuildTestCase
 from projects.models import Project
 
 
@@ -103,9 +101,7 @@ class TestAdvancedForm(TestBasicsForm):
         self.assertWizardFailure(resp, 'python_interpreter')
 
 
-@patch('projects.views.private.trigger_build', lambda x, basic: None)
-@patch('readthedocs.projects.views.private.trigger_build', lambda x, basic: None)
-class TestImportDemoView(TestCase):
+class TestImportDemoView(MockBuildTestCase):
     '''Test project import demo view'''
 
     fixtures = ["eric"]
@@ -121,7 +117,7 @@ class TestImportDemoView(TestCase):
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
         messages = list(resp_redir.context['messages'])
-        self.assertEqual(messages[0].level, MSG.SUCCESS)
+        self.assertEqual(messages[0].level, message_const.SUCCESS)
 
     def test_import_demo_already_imported(self):
         '''Import demo project multiple times, expect failure 2nd post'''
@@ -136,7 +132,7 @@ class TestImportDemoView(TestCase):
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
         messages = list(resp_redir.context['messages'])
-        self.assertEqual(messages[0].level, MSG.SUCCESS)
+        self.assertEqual(messages[0].level, message_const.SUCCESS)
 
         self.assertEqual(project,
                          Project.objects.get(slug='eric-demo'))
@@ -156,7 +152,7 @@ class TestImportDemoView(TestCase):
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
         messages = list(resp_redir.context['messages'])
-        self.assertEqual(messages[0].level, MSG.SUCCESS)
+        self.assertEqual(messages[0].level, message_const.SUCCESS)
         self.assertRegexpMatches(messages[0].message,
                                  r'already imported')
 
@@ -183,7 +179,7 @@ class TestImportDemoView(TestCase):
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
         messages = list(resp_redir.context['messages'])
-        self.assertEqual(messages[0].level, MSG.ERROR)
+        self.assertEqual(messages[0].level, message_const.ERROR)
         self.assertRegexpMatches(messages[0].message,
                                  r'There was a problem')
 

--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -15,11 +15,17 @@
     <input type="submit" value="{% trans "Search" %}">
   </form>
 </div>
-<br>
 <!-- END search bar -->
 
 <div class="module">
+  {% if onboard %}
+  <!-- BEGIN onboard -->
+    {% include 'projects/onboard_detail.html' %}
+  <!-- END onboard -->
+  {% endif %}
+
 {% if versions %}
+
   <div class="module-header">
     <h3>{% trans "Versions" %}</h3>
   </div>

--- a/readthedocs/templates/projects/onboard_detail.html
+++ b/readthedocs/templates/projects/onboard_detail.html
@@ -1,0 +1,72 @@
+{% load i18n %}
+
+<!-- BEGIN onboard first build -->
+<div class="onboard onboard-detail">
+
+  {% if not onboard.build %}
+    <h2>{% trans "Start building your documentation" %}</h2>
+    <p>
+      {% blocktrans %}
+        This project has not been built yet.
+        Try building the latest version now,
+        or if you would like to build a specific verison,
+        select the version below and your documentation build will be triggered.
+      {% endblocktrans %}
+    </p>
+
+    <form method="post" action="{% url "generic_build" project.pk %}">
+      <input type="hidden" name="version_slug" value="latest" />
+      <input type="submit" value="{% trans "Build latest version" %}" />
+    </form>
+  {% else %}
+
+    {% if onboard.build.finished %}
+      {% if onboard.build.success %}
+        {% comment %}Last build passed{% endcomment %}
+        <h2>{% trans "Your documentation is ready to use" %}</h2>
+
+        <form method="get" action="{% url "docs_detail" project_slug=project.slug %}">
+          <p>
+          {% blocktrans %}
+            Your documentation has been built.
+            Ensure your documentation is kept up to date with every commit to
+            your respository, by
+            <a href="http://docs.readthedocs.org/en/latest/webhooks.html">setting up a webhook</a>.
+          {% endblocktrans %}
+          </p>
+
+          <input type="submit" value="View your documentation" />
+        </form>
+      {% else %}
+        {% comment %}Last build failed{% endcomment %}
+        <h2>{% trans "Your documentation failed to build" %}</h2>
+
+        <form method="get" action="{% url "builds_detail" project_slug=project.slug pk=onboard.build.pk %}">
+          <p>
+          {% blocktrans %}
+            There was a problem building your documentation,
+            you can see what went wrong in the build output.
+            If you need more help, check out some of the
+            <a href="http://docs.readthedocs.org/en/latest/faq.html">problems frequently encountered</a>
+            during builds.
+          {% endblocktrans %}
+          </p>
+
+          <input type="submit" value="View build output" />
+        </form>
+      {% endif %}
+    {% else %}
+      <h2>{% trans "Your documentation is building" %}</h2>
+
+      <p>
+      {% blocktrans %}
+        You'll be able to view your documentation in a minute or two,
+        once your project is done building.
+      {% endblocktrans %}
+      </p>
+    {% endif %}
+
+  {% endif %}
+
+</div>
+<!-- END onboard import project -->

--- a/readthedocs/templates/projects/onboard_import.html
+++ b/readthedocs/templates/projects/onboard_import.html
@@ -14,6 +14,10 @@
         {% endblocktrans %}
       </p>
 
+      <p>
+        Want to try a demo? <a href="{% url "projects_import_demo" %}">Import our own demo project</a>.
+      </p>
+
       <input type="submit" value="Import a Project" />
     </form>
   {% endwith %}

--- a/readthedocs/templates/projects/onboard_import.html
+++ b/readthedocs/templates/projects/onboard_import.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+<!-- BEGIN onboard import project -->
+<div class="onboard onboard-import-project">
+  <h2>Ready to share your documentation{% if request.user.first_name %}, {{ request.user.first_name }}{% endif %}?</h2>
+
+  {% with getting_started_url="http://docs.readthedocs.org/en/latest/getting_started.html" %}
+    <form method="get" action="{% url "projects_import" %}">
+      <p>
+        {% blocktrans %}
+          You don't have any projects yet, but you can start building documentation by importing one.
+          Not sure how to start documenting your project?
+          Check out the <a href="{{ getting_started_url }}">Getting Started Guide</a> to learn how.
+        {% endblocktrans %}
+      </p>
+
+      <input type="submit" value="Import a Project" />
+    </form>
+  {% endwith %}
+</div>
+<!-- END onboard import project -->

--- a/readthedocs/templates/projects/project_dashboard_base.html
+++ b/readthedocs/templates/projects/project_dashboard_base.html
@@ -100,25 +100,7 @@
 
     {% else %}
 
-      <!-- BEGIN onboard import project -->
-      <div class="module onboard onboard-import-project">
-        <h2>Ready to share your documentation{% if request.user.first_name %}, {{ request.user.first_name }}{% endif %}?</h2>
-
-        {% with getting_started_url="http://docs.readthedocs.org/en/latest/getting_started.html" %}
-          <form method="get" action="{{ projects_import_url }}">
-            <p>
-              {% blocktrans %}
-                You don't have any projects yet, but you can start building documentation by importing one.
-                Not sure how to start documenting your project?
-                Check out the <a href="{{ getting_started_url }}">Getting Started Guide</a> to learn how.
-              {% endblocktrans %}
-            </p>
-
-            <input type="submit" value="Import a Project" />
-          </form>
-        {% endwith %}
-      </div>
-      <!-- END onboard import project -->
+      {% include 'projects/onboard_import.html' %}
 
     {% endif %}
   </div>


### PR DESCRIPTION
This adds some messaging for the first project import, but only for the first 5 builds. This also adds a demo project import, which is currently our template project, which is imported with one click. Some guidance is added for the following scenarios on the project detail page:

* Project has no builds (should never be the case, but added anyways)
* Project is building, please wait
* Project has a failing build, link to FAQ for now
* Project has a passing build, set up a webhook

In the future, this should track user input, so onboarding can be closed -- though it isn't intrusive messaging right now either.

On the dashboard page, onboard messaging prompts the user to import a new project, or import the demo project. Clicking this button will attempt to import the project for the current user. The project is be named "<username>-demo", this could be randomized in the future. Possibly outcomes are:

* Template project not imported yet, import project
* Template project already imported by user, redirect to project page
* Template project imported by user and renamed, redirect to project page (detection is done by repo url)
* Project named for collision by another user -- this should maybe back down to a randomized name? This is not implemented, it will simply throw an error