### PR TITLE
Docker compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.tox
+dockerfiles
+user_builds

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 .git
+.gitignore
 .tox
+tox.ini
+.shipwright.json
+acceptance
+docs
 dockerfiles
 user_builds

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 .coverage
 .idea
+.tox/
 .vagrant
 _build
 cnames

--- a/.shipwright.json
+++ b/.shipwright.json
@@ -1,0 +1,11 @@
+{
+    "version": 1.0,
+    "namespace": "readthedocs",
+    "names": {
+        "/": "readthedocs/base",
+        "/dockerfiles/builder":  "readthedocs/builder",
+        "/dockerfiles/configs":  "readthedocs/configs",
+        "/dockerfiles/database": "readthedocs/database",
+        "/dockerfiles/webapp":   "readthedocs/webapp"
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+#
+# readthedocs.org - webapp
+#
+
+FROM    ubuntu:14.10
+MAINTAINER  dnephin@gmail.com
+
+RUN     apt-get update && apt-get install -y \
+            python-dev \
+            python-pip \
+            python-virtualenv \
+            git \
+            build-essential \
+            libxml2-dev \
+            libxslt1-dev \
+            zlib1g-dev \
+            libpq-dev
+
+ADD     deploy_requirements.txt /rtd/deploy_requirements.txt
+ADD     pip_requirements.txt    /rtd/pip_requirements.txt
+ADD     deploy  /rtd/deploy
+WORKDIR /rtd
+RUN     virtualenv venv && venv/bin/pip install \
+            -r deploy_requirements.txt \
+            --find-links /rtd/deploy/wheels
+
+ADD     .   /rtd
+RUN     mkdir /rtd/user_builds
+RUN     mkdir /rtd/readthedocs/webapp_settings/
+
+EXPOSE  8000
+
+ENV     PYTHONPATH  /rtd/
+WORKDIR /rtd/readthedocs
+
+# TODO: use gunicorn
+CMD     ../venv/bin/python ./manage.py runserver 0.0.0.0:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# readthedocs.org - webapp
+# readthedocs.org - base image
 #
 
 FROM    ubuntu:14.10
@@ -28,10 +28,5 @@ ADD     .   /rtd
 RUN     mkdir /rtd/user_builds
 RUN     mkdir /rtd/readthedocs/webapp_settings/
 
-EXPOSE  8000
-
 ENV     PYTHONPATH  /rtd/
 WORKDIR /rtd/readthedocs
-
-# TODO: use gunicorn
-CMD     ../venv/bin/python ./manage.py runserver 0.0.0.0:8000

--- a/acceptance/builds.feature
+++ b/acceptance/builds.feature
@@ -1,7 +1,0 @@
-
-
-Feature: Build documentation for projects
-
-  Scenario: View a list of builds for a project
-    When I view /builds/pip
-    Then I should see a list of builds

--- a/acceptance/builds.feature
+++ b/acceptance/builds.feature
@@ -1,0 +1,7 @@
+
+
+Feature: Build documentation for projects
+
+  Scenario: View a list of builds for a project
+    When I view /builds/pip
+    Then I should see a list of builds

--- a/acceptance/environment.py
+++ b/acceptance/environment.py
@@ -1,0 +1,4 @@
+
+
+def before_all(context):
+    context.base_url = 'http://localhost:8080'

--- a/acceptance/steps/websteps.py
+++ b/acceptance/steps/websteps.py
@@ -8,9 +8,9 @@ def step_impl(context, url):
     context.response = requests.get(context.base_url + url)
 
 
-@then(u'I should see a list of builds')
+@then(u'I should see a list of projects')
 def step_impl(context):
     assert context.response.status_code == 200
     page = pq(context.response.text)
-    builds = page("li.module-item div[id^=build-]")
-    assert len(builds) > 1
+    projects = page("li.module-item")
+    assert len(projects) == 14

--- a/acceptance/steps/websteps.py
+++ b/acceptance/steps/websteps.py
@@ -1,0 +1,16 @@
+
+from pyquery import PyQuery as pq
+import requests
+
+
+@when(u'I view {url}')
+def step_impl(context, url):
+    context.response = requests.get(context.base_url + url)
+
+
+@then(u'I should see a list of builds')
+def step_impl(context):
+    assert context.response.status_code == 200
+    page = pq(context.response.text)
+    builds = page("li.module-item div[id^=build-]")
+    assert len(builds) > 1

--- a/acceptance/web.feature
+++ b/acceptance/web.feature
@@ -1,0 +1,7 @@
+
+
+Feature: View projects
+
+  Scenario: View a list of projects
+    When I view /projects
+    Then I should see a list of projects

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 # main application
 #
 webapp:
-    build: .
+    image: readthedocs/webapp
     environment:
         DJANGO_SETTINGS_MODULE: 'webapp_settings'
     volumes_from:
@@ -22,13 +22,13 @@ webapp:
 # data volume container with a dev version of django settings
 #
 configs:
-    build: dockerfiles/configs
+    image: readthedocs/configs
 
 #
 # database for the webapp
 #
 database:
-    build: dockerfiles/database
+    image: readthedocs/database
 
 #
 # task queue broker, and cache
@@ -40,7 +40,7 @@ redis:
 # search index for documentation and projects
 #
 search:
-    build: readthedocs/search
+    image: readthedocs/search
     ports: 
         - 8081:9200
 
@@ -48,7 +48,7 @@ search:
 # task workers for building documentation
 #
 builder:
-    build: dockerfiles/builder
+    image: readthedocs/builder
     environment:
         DJANGO_SETTINGS_MODULE: 'webapp_settings'
     volumes_from:

--- a/dockerfiles/builder/Dockerfile
+++ b/dockerfiles/builder/Dockerfile
@@ -1,8 +1,8 @@
+#
+# readthedocs.org - documentation builder image
+#
 
-
-# TODO: It would be nice to have a separate code repo for the task workers, or
-# a common base image for python dependencies
-FROM    rtd_webapp
+FROM    readthedocs/base
 
 # For some reason the task running runs virtualenv-2.7
 RUN     ln -s /usr/bin/virtualenv /usr/bin/virtualenv-2.7

--- a/dockerfiles/builder/Dockerfile
+++ b/dockerfiles/builder/Dockerfile
@@ -1,0 +1,17 @@
+
+
+# TODO: It would be nice to have a separate code repo for the task workers, or
+# a common base image for python dependencies
+FROM    rtd_webapp
+
+# For some reason the task running runs virtualenv-2.7
+RUN     ln -s /usr/bin/virtualenv /usr/bin/virtualenv-2.7
+
+# Dependencies for building documentation
+RUN     apt-get update && apt-get install -y \
+            texlive-latex-base \
+            texlive-latex-extra \
+            texlive-latex-recommended \
+            texlive-fonts-recommended
+
+CMD     ../venv/bin/python manage.py celery worker -l INFO

--- a/dockerfiles/configs/Dockerfile
+++ b/dockerfiles/configs/Dockerfile
@@ -1,4 +1,6 @@
-
+#
+# readthedocs.org - configs image
+#
 
 FROM    busybox:latest
 ADD     . /rtd/readthedocs/webapp_settings/

--- a/dockerfiles/configs/Dockerfile
+++ b/dockerfiles/configs/Dockerfile
@@ -1,0 +1,6 @@
+
+
+FROM    busybox:latest
+ADD     . /rtd/readthedocs/webapp_settings/
+VOLUME  /rtd/readthedocs/webapp_settings/
+CMD     echo

--- a/dockerfiles/configs/__init__.py
+++ b/dockerfiles/configs/__init__.py
@@ -1,0 +1,83 @@
+from readthedocs.settings.base import *  # noqa
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'docs',
+        'USER': 'docs',
+        'PASSWORD': 'password',
+        'HOST': 'database_1',
+        'PORT': '5432',
+    }
+}
+
+
+LOG_FORMAT = "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s"
+LOGGING['loggers'] = {
+    '': {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+    },
+}
+
+DEBUG = True
+TEMPLATE_DEBUG = False
+CELERY_ALWAYS_EAGER = False
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+SESSION_COOKIE_DOMAIN = None
+SESSION_COOKIE_HTTPONLY = False
+
+CACHES = {
+    'default': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': 'redis_1:6379',
+        'PREFIX': 'docs',
+        'OPTIONS': {
+            'DB': 1,
+            'PARSER_CLASS': 'redis.connection.HiredisParser'
+        },
+    },
+}
+
+
+REDIS = {
+    'host': 'redis_1',
+    'port': 6379,
+    'db': 0,
+}
+
+
+BROKER_URL = 'redis://redis_1:6379/0'
+CELERY_RESULT_BACKEND = 'redis://redis_1:6379/0'
+
+
+# Elasticsearch settings.
+ES_HOSTS = ['search_1:9200']
+
+
+SLUMBER_USERNAME = 'test'
+SLUMBER_PASSWORD = 'test'
+SLUMBER_API_HOST = 'http://webapp:8000'
+WEBSOCKET_HOST = 'localhost:8088'
+PRODUCTION_DOMAIN = 'localhost:8080'
+
+USE_SUBDOMAIN = False
+NGINX_X_ACCEL_REDIRECT = True
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# Lock builds for 10 minutes
+REPO_LOCK_SECONDS = 300
+
+# Don't re-confirm existing accounts
+ACCOUNT_EMAIL_VERIFICATION = 'none'
+
+# For testing locally.
+CORS_ORIGIN_WHITELIST = (
+    'localhost:8080',
+    'webapp_1:8000',
+)
+
+

--- a/dockerfiles/database/Dockerfile
+++ b/dockerfiles/database/Dockerfile
@@ -1,15 +1,12 @@
 #
-# readthedocs.org - database 
+# readthedocs.org - database image
 #
 
-# TODO: It would be nice to not have to install all the python stuff
-# just to run ./manage.py syncdb/migration
-FROM    rtd_webapp
-MAINTAINER  dnephin@gmail.com
+FROM    readthedocs/base
 
 RUN     apt-get update && apt-get install -y \
-            postgresql-9.3 \
-            postgresql-contrib-9.3
+            postgresql-9.4 \
+            postgresql-contrib-9.4
 
 ADD     local_settings.py /rtd/readthedocs/local_settings.py
 ADD     create_superuser.py /rtd/readthedocs/create_superuser.py
@@ -28,12 +25,12 @@ RUN     /etc/init.d/postgresql start && \
         ../venv/bin/python ./manage.py loaddata test_data && \
         /etc/init.d/postgresql stop
 
-ADD     etc/pg_hba.conf /etc/postgresql/9.3/main/pg_hba.conf
-RUN     echo "listen_addresses='*'" >> /etc/postgresql/9.3/main/postgresql.conf
+ADD     etc/pg_hba.conf /etc/postgresql/9.4/main/pg_hba.conf
+RUN     echo "listen_addresses='*'" >> /etc/postgresql/9.4/main/postgresql.conf
 
 # Add VOLUMEs to allow backup of config, logs and databases
 VOLUME  ["/etc/postgresql", "/var/log/postgresql", "/var/lib/postgresql"]
 
 EXPOSE  5432
-CMD ["/usr/lib/postgresql/9.3/bin/postgres", "-D", "/var/lib/postgresql/9.3/main", "-c", "config_file=/etc/postgresql/9.3/main/postgresql.conf"]
+CMD ["/usr/lib/postgresql/9.4/bin/postgres", "-D", "/var/lib/postgresql/9.4/main", "-c", "config_file=/etc/postgresql/9.4/main/postgresql.conf"]
 

--- a/dockerfiles/database/Dockerfile
+++ b/dockerfiles/database/Dockerfile
@@ -1,0 +1,39 @@
+#
+# readthedocs.org - database 
+#
+
+# TODO: It would be nice to not have to install all the python stuff
+# just to run ./manage.py syncdb/migration
+FROM    rtd_webapp
+MAINTAINER  dnephin@gmail.com
+
+RUN     apt-get update && apt-get install -y \
+            postgresql-9.3 \
+            postgresql-contrib-9.3
+
+ADD     local_settings.py /rtd/readthedocs/local_settings.py
+ADD     create_superuser.py /rtd/readthedocs/create_superuser.py
+
+USER    postgres
+
+# See https://github.com/rtfd/readthedocs.org/issues/773
+# for the reason behind `migrate projects 0001` line
+RUN     /etc/init.d/postgresql start && \
+        psql --command "CREATE USER docs WITH SUPERUSER PASSWORD 'password';" && \
+        createdb docs && \
+        ../venv/bin/python ./manage.py syncdb --noinput && \
+        ../venv/bin/python ./manage.py migrate projects 0001 && \
+        ../venv/bin/python ./manage.py migrate && \
+        ../venv/bin/python ./create_superuser.py && \
+        ../venv/bin/python ./manage.py loaddata test_data && \
+        /etc/init.d/postgresql stop
+
+ADD     etc/pg_hba.conf /etc/postgresql/9.3/main/pg_hba.conf
+RUN     echo "listen_addresses='*'" >> /etc/postgresql/9.3/main/postgresql.conf
+
+# Add VOLUMEs to allow backup of config, logs and databases
+VOLUME  ["/etc/postgresql", "/var/log/postgresql", "/var/lib/postgresql"]
+
+EXPOSE  5432
+CMD ["/usr/lib/postgresql/9.3/bin/postgres", "-D", "/var/lib/postgresql/9.3/main", "-c", "config_file=/etc/postgresql/9.3/main/postgresql.conf"]
+

--- a/dockerfiles/database/create_superuser.py
+++ b/dockerfiles/database/create_superuser.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.sqlite")
+    sys.path.append('readthedocs')
+
+    from django.contrib.auth.models import User
+    User.objects.create_superuser('admin', 'admin@example.com', 'password')

--- a/dockerfiles/database/etc/pg_hba.conf
+++ b/dockerfiles/database/etc/pg_hba.conf
@@ -1,0 +1,2 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+host    all             all             0.0.0.0/0               md5

--- a/dockerfiles/database/local_settings.py
+++ b/dockerfiles/database/local_settings.py
@@ -1,0 +1,38 @@
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'docs',
+        'USER': 'docs',
+        'PASSWORD': 'password',
+        'HOST': 'localhost',
+        'PORT': '5432',
+    }
+}
+
+LOG_FORMAT = "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s"
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'standard': {
+            'format': LOG_FORMAT,
+            'datefmt': "%d/%b/%Y %H:%M:%S"
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard'
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        },
+    }
+}
+

--- a/dockerfiles/webapp/Dockerfile
+++ b/dockerfiles/webapp/Dockerfile
@@ -1,0 +1,10 @@
+#
+# readthedocs.org - webapp
+#
+
+FROM    readthedocs/base
+
+
+# TODO: use gunicorn
+EXPOSE  8000
+CMD     ../venv/bin/python ./manage.py runserver 0.0.0.0:8000

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,62 @@
+
+
+#
+# main application
+#
+webapp:
+    build: .
+    environment:
+        DJANGO_SETTINGS_MODULE: 'webapp_settings'
+    volumes_from:
+        - configs
+    volumes:
+        - './user_builds:/rtd/user_builds'
+    ports:
+        - 8080:8000
+    links:
+        - database
+        - redis
+        - search
+
+#
+# data volume container with a dev version of django settings
+#
+configs:
+    build: dockerfiles/configs
+
+#
+# database for the webapp
+#
+database:
+    build: dockerfiles/database
+
+#
+# task queue broker, and cache
+#
+redis:
+    image: redis:latest
+
+#
+# search index for documentation and projects
+#
+search:
+    build: readthedocs/search
+    ports: 
+        - 8081:9200
+
+#
+# task workers for building documentation
+#
+builder:
+    build: dockerfiles/builder
+    environment:
+        DJANGO_SETTINGS_MODULE: 'webapp_settings'
+    volumes_from:
+        - configs
+    volumes:
+        - './user_builds:/rtd/user_builds'
+    links:
+        - redis
+        - webapp
+        - database # see github.com/rtfd/readthedocs.org/issues/987
+

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -302,6 +302,8 @@ def setup_environment(version):
         site_packages = '--system-site-packages'
     else:
         site_packages = '--no-site-packages'
+
+    # TODO: why is this virtualenv-2.7?
     # Here the command has been modified to support different
     # interpreters.
     ret_dict['venv'] = run(

--- a/readthedocs/search/Dockerfile
+++ b/readthedocs/search/Dockerfile
@@ -1,6 +1,6 @@
 
 
-FROM    dockerfile/elasticsearch
+FROM    dockerfile/elasticsearch:latest
 
 RUN     apt-get update && apt-get install -y \
             python-virtualenv \

--- a/readthedocs/search/Dockerfile
+++ b/readthedocs/search/Dockerfile
@@ -1,0 +1,26 @@
+
+
+FROM    dockerfile/elasticsearch
+
+RUN     apt-get update && apt-get install -y \
+            python-virtualenv \
+            python-pip
+
+WORKDIR /search
+RUN     virtualenv .venv && \
+        .venv/bin/pip install elasticsearch==0.4.3
+
+ADD     elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+
+RUN     /elasticsearch/bin/plugin -install \
+            elasticsearch/elasticsearch-analysis-icu/2.3.0 && \
+        /elasticsearch/bin/plugin -install mobz/elasticsearch-head
+
+
+ADD     .   /search
+
+# TODO: sleep could be replaced with more of a polling wait for startup
+RUN     /elasticsearch/bin/elasticsearch & \
+        sleep 8 && \
+        curl -s localhost:9200/_nodes/_all/plugins | python -m json.tool && \
+        .venv/bin/python create_index.py

--- a/readthedocs/search/create_index.py
+++ b/readthedocs/search/create_index.py
@@ -1,0 +1,26 @@
+import logging
+
+from indexes import (
+    Index,
+    PageIndex,
+    ProjectIndex,
+    SectionIndex,
+)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    # Create the index.
+    index = Index()
+    index_name = index.timestamped_index()
+    index.create_index(index_name)
+    index.update_aliases(index_name)
+
+    # Update mapping
+    proj = ProjectIndex()
+    proj.put_mapping()
+    page = PageIndex()
+    page.put_mapping()
+    sec = SectionIndex()
+    sec.put_mapping()

--- a/readthedocs/search/elasticsearch.yml
+++ b/readthedocs/search/elasticsearch.yml
@@ -1,0 +1,8 @@
+
+path:
+    # TODO: /data is being cleared after steps
+    # maybe because of VOLUME # ["/data/"]
+    data: /searchindex
+    logs: /data/logs
+    plugins: /elasticsearch/plugins
+    work: /data/work

--- a/readthedocs/search/indexes.py
+++ b/readthedocs/search/indexes.py
@@ -19,7 +19,12 @@ import datetime
 from elasticsearch import Elasticsearch, exceptions
 from elasticsearch.helpers import bulk_index
 
-from django.conf import settings
+# TODO: fix this, it's here to deal with different execution environments
+# django webapp, vs building fixtures for the search docker container
+try:
+    from django.conf import settings
+except ImportError:
+    import settings
 
 
 class Index(object):
@@ -318,13 +323,14 @@ class SectionIndex(Index):
                 '_boost': {'name': '_boost', 'null_value': 1.0},
                 # Associate a section with a page.
                 '_parent': {'type': self._parent},
-                'suggest': {
-                    "type": "completion",
-                    "index_analyzer": "simple",
-                    "search_analyzer": "simple",
-                    "payloads": True,
-                },
                 'properties': {
+                    # FIXME: this moved to support ES 1.2.x
+                    'suggest': {
+                        "type": "completion",
+                        "index_analyzer": "simple",
+                        "search_analyzer": "simple",
+                        "payloads": True,
+                    },
                     'id': {'type': 'string', 'index': 'not_analyzed'},
                     'project': {'type': 'string', 'index': 'not_analyzed'},
                     'version': {'type': 'string', 'index': 'not_analyzed'},

--- a/readthedocs/search/settings.py
+++ b/readthedocs/search/settings.py
@@ -1,0 +1,6 @@
+
+# Elasticsearch settings.
+ES_HOSTS = ['localhost:9200']
+ES_DEFAULT_NUM_REPLICAS = 1
+ES_DEFAULT_NUM_SHARDS = 1
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,32 @@
+[tox]
+envlist = py27,acceptance
+skipsdist = true
+
+[testenv]
+usedevelop = True
+deps =
+    -rpip_requirements.txt
+    pytest
+    coverage
+commands =
+    ./runtests.sh {posargs}
+
+
+[testenv:acceptance]
+setenv =
+    FIG_PROJECT_NAME = rtd
+deps =
+    fig
+    behave
+    requests
+    pyquery
+commands =
+    # Remove old data volume so we can pickup any changes
+    fig rm --force configs
+    # Build all the images
+    fig build
+    # Start the containers
+    fig up -d
+    # Run the tests
+    behave acceptance
+    fig stop

--- a/tox.ini
+++ b/tox.ini
@@ -13,20 +13,28 @@ commands =
 
 
 [testenv:acceptance]
+whitelist_externals =
+    sleep
 setenv =
-    FIG_PROJECT_NAME = rtd
+    COMPOSE_PROJECT_NAME = rtd
 deps =
-    fig
+    docker-py == 0.6.0
+    websocket-client == 0.11
+    shipwright
+    docker-compose
     behave
     requests
     pyquery
 commands =
     # Remove old data volume so we can pickup any changes
-    fig rm --force configs
+    docker-compose rm --force configs database
     # Build all the images
-    fig build
+    shipwright
     # Start the containers
-    fig up -d
+    docker-compose up -d
+    # Wait for everything to start
+    sleep 5
     # Run the tests
     behave acceptance
-    fig stop
+    # Shutdown
+    docker-compose stop


### PR DESCRIPTION
Adds docker containers and a `docker-compose.yml` (previously known as fig) for acceptance testing and development environments.

I working on this original for [a demo at Docker Global Hack Day](https://www.youtube.com/watch?v=bYfwFkeeUL4#t=190) a few months ago. It was using `fig` and had some issues still with build ordering.  I've updated to use the latest docker compose (the first rc), and to use shipwright for building the images.

There is only one acceptance test right now. There's a lot more that can be done with this setup, but I wanted to include one just as an example.

There are still a few pain points to work out:
- items marked with TODO
- the build for the `builder` container is very slow because of the `apt-get install`. These packages are required to build the pdfs, but they are relatively large, and take a very long time to download. It's quite possible there is a better way to provide these dependencies.

This PR is mostly a preview. If you're interested in this setup, I can see about fixing up some of the pain points.
