### PR TITLE
Strip trailing '.html' from paths before searching

### DIFF
--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -56,6 +56,7 @@ def parse_path_from_file(documentation_type, file_path):
     page_json = json.loads(content)
     path = page_json['url']
     path = re.sub('/$', '/index', path)
+    path = re.sub('\.html$', '', path)
     path = re.sub('^/', '', path)
 
     return path

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -55,6 +55,12 @@ def parse_path_from_file(documentation_type, file_path):
 
     page_json = json.loads(content)
     path = page_json['url']
+
+    # The URLs here should be of the form "path/index". So we need to
+    # convert:
+    #   "path/" => "path/index"
+    #   "path/index.html" => "path/index"
+    #   "/path/index" => "path/index"
     path = re.sub('/$', '/index', path)
     path = re.sub('\.html$', '', path)
     path = re.sub('^/', '', path)


### PR DESCRIPTION
I've got a Markdown ReadTheDocs site, with 'use_directory_urls' set to false (as a workaround for https://github.com/rtfd/readthedocs.org/issues/1101). This breaks the search - the results go to a path like Configuring_an_Application_Server/**index.html.html** (see https://readthedocs.org/elasticsearch/?q=example&check_keywords=yes&area=default&project=clearwater&version=latest&type=file).

This patch should fix that. I've done some very basic testing - I have a local copy of readthedocs running, and I confirmed that before this change I got a log like:

`[07/Feb/2015 12:19:36] INFO [projects.tasks:663] (Search Index) Sending Data: cw-rtd [index.html Clearwater_Elastic_Scaling/index.html All_in_one_Images/index.html ...`

and afterwards like:

`[07/Feb/2015 12:23:43] INFO [projects.tasks:663] (Search Index) Sending Data: cw-rtd [index Clearwater_Elastic_Scaling/index All_in_one_Images/index ...`

(The search page on my local copy wasn't returning any actual results either before or after this change, which is why I've had to rely on the logs.)