### PR TITLE
Un-disable the mkdocs searchbox

### DIFF
--- a/readthedocs/templates/mkdocs/readthedocs/searchbox.html
+++ b/readthedocs/templates/mkdocs/readthedocs/searchbox.html
@@ -1,0 +1,7 @@
+<div role="search">
+  <form id ="rtd-search-form" class="wy-form" action="" method="get">
+    <input type="text" name="q" placeholder="Search docs" />
+    <input type="hidden" name="check_keywords" value="yes" />
+    <input type="hidden" name="area" value="default" />
+  </form>
+</div>


### PR DESCRIPTION
MkDocs 0.11 [disabled the searchbox](https://github.com/tomchristie/mkdocs/commit/349515f98a0aad1a13c76f6435503776fcf5b2bf), pending implementation of client-side search in mkdocs. This makes ReadTheDocs search a bit less usable.

This commit adds a searchbox.html to the custom theme, which is identical to the upstream version before it was commented out. I've tested on a local readthedocs copy.

Fixes https://github.com/rtfd/readthedocs.org/issues/1074.