### PR TITLE
More stripping of '.html. suffix on URLs

### DIFF
--- a/readthedocs/core/templatetags/core_tags.py
+++ b/readthedocs/core/templatetags/core_tags.py
@@ -35,11 +35,13 @@ def make_document_url(project, version=None, page=None):
         base_url = project.get_translation_url(version)
     else:
         base_url = project.get_docs_url(version)
-    if page and page != "index":
+    if page and (page != "index") and (page != "index.html"):
         if project.documentation_type == "sphinx_htmldir":
             path = page + "/"
         elif project.documentation_type == "sphinx_singlehtml":
             path = "index.html#document-" + page
+        elif page.endswith(".html"):
+            path = page
         else:
             path = page + ".html"
     else:

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -149,3 +149,27 @@ class CoreTagsTests(TestCase):
         url = core_tags.make_document_url(proj, 'abc', 'index')
         self.assertEqual(url, '/docs/pip/fr/abc/')
 
+    def test_mkdocs(self):
+        proj = Project.objects.get(slug='pip')
+        proj.documentation_type = 'mkdocs'
+        url = core_tags.make_document_url(proj, 'latest', 'document')
+        self.assertEqual(url, '/docs/pip/en/latest/document.html')
+
+    def test_mkdocs_no_directory_urls(self):
+        proj = Project.objects.get(slug='pip')
+        proj.documentation_type = 'mkdocs'
+        url = core_tags.make_document_url(proj, 'latest', 'document.html')
+        self.assertEqual(url, '/docs/pip/en/latest/document.html')
+
+    def test_mkdocs_index(self):
+        proj = Project.objects.get(slug='pip')
+        proj.documentation_type = 'mkdocs'
+        url = core_tags.make_document_url(proj, 'latest', 'index')
+        self.assertEqual(url, '/docs/pip/en/latest/')
+
+    def test_mkdocs_index_no_directory_urls(self):
+        proj = Project.objects.get(slug='pip')
+        proj.documentation_type = 'mkdocs'
+        url = core_tags.make_document_url(proj, 'latest', 'index.html')
+        self.assertEqual(url, '/docs/pip/en/latest/')
+


### PR DESCRIPTION
Even after #1147 was merged, and even after a rebuild of my docs, I'm still seeing the problem where search links come up as "page.html.html" (e.g. https://readthedocs.org/elasticsearch/?q=example&check_keywords=yes&area=default&project=clearwater&version=latest&type=file).

I've done a bit more digging, and found another likely culprit - this PR prevents the `doc_url` tag (used in the elastic_search.html template) from adding an extra trailing .html as well.