### PR TITLE
Update sphinx to 1.3

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -11,7 +11,7 @@
 pip==1.5.6
 virtualenv==1.11.6
 docutils==0.11
-Sphinx==1.2.2
+Sphinx==1.3
 mkdocs==0.11.1
 
 django==1.6.10

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -329,7 +329,7 @@ def setup_environment(version):
     ret_dict['doc_builder'] = run(
         (
             '{cmd} install --use-wheel --find-links={wheeldir} -U {ignore_option} '
-            'sphinx==1.2.2 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 mkdocs==0.11.1 mock==1.0.1 pillow==2.6.1'
+            'sphinx==1.3 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 mkdocs==0.11.1 mock==1.0.1 pillow==2.6.1'
             ' readthedocs-sphinx-ext==0.4.4 sphinx-rtd-theme==0.1.6 '
         ).format(
             cmd=project.venv_bin(version=version.slug, bin='pip'),


### PR DESCRIPTION
With rtd's sphinx 1.2.2, I get this build error when building my docs
generated with sphinx 1.3's quickstart:

    File "/home/nnyby/src/django-pagetree/ve/local/lib/python2.7/site-packages/sphinx/util/__init__.py", line 94, in get_matching_docs
      suffixpattern = '*' + suffix
      TypeError: cannot concatenate 'str' and 'list' objects