### PR TITLE
Upgrade pip to 6.0.8

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -8,7 +8,7 @@
 --allow-unverified lazr.authentication
 
 ## Upgraded packages
-pip==1.5.6
+pip==6.0.8
 virtualenv==1.11.6
 docutils==0.11
 Sphinx==1.2.2


### PR DESCRIPTION
This pull request upgrades RTD to use the latest stable version of [`pip`](https://pypi.python.org/pypi/pip). The older version has trouble installing certain packages. In particular, a useful test case is:
```
pip install -e hg+https://bitbucket.org/espd/sphinx-contrib#egg=sphinxcontrib_aafig&subdirectory=aafig
```
I discovered this when trying to use [aafig](https://pypi.python.org/pypi/sphinxcontrib-aafig/1.0) in my documentation. The version that is currently published on PyPI is broken, but [there is a pull request to fix it](https://bitbucket.org/birkenfeld/sphinx-contrib/pull-request/64), which has not yet been merged. I wasn't able to use this fork in my project dependencies, however, because `pip` 1.5.6 was unable to install it. [Here's an example of a failing build.](https://readthedocs.org/builds/flask-dance/2491148/)