### PR TITLE
update name and URL from gittip to gratipay

### DIFF
--- a/docs/sponsors.rst
+++ b/docs/sponsors.rst
@@ -26,7 +26,7 @@ Past sponsors
 * `Django Software Foundation`_
 * Lab305_
 
-.. _Gittip: https://www.gittip.com/readthedocs/
+.. _Gittip: https://gratipay.com/readthedocs/
 .. _Revsys: http://www.revsys.com/
 .. _Python Software Foundation: http://python.org/psf/
 .. _Mozilla Web Dev: http://blog.mozilla.com/webdev/

--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -137,7 +137,7 @@
 
 
       <hr/>
-      Free document hosting provided by <a href="https://readthedocs.org">Read the Docs</a>. Support us on <a href="https://www.gittip.com/readthedocs/">Gittip</a>.
+      Free document hosting provided by <a href="https://readthedocs.org">Read the Docs</a>. Support us on <a href="https://www.gratipay.com/readthedocs/">Gratipay</a>.
 
       {% if not new_theme %}
     </div>


### PR DESCRIPTION
- update name and URL from gittip to gratipay
- On sponsors.rst, update only URL and not the Sphinx reference. I am not certain how to update all of the .po files that use the reference, whether in this repo or via Transifex. Please advise. See https://github.com/rtfd/readthedocs.org/search?l=pot&p=1&q=gittip&utf8=%E2%9C%93