### PR TITLE
Update mkdocs version due to bug in 0.11.1.

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -331,7 +331,7 @@ def setup_environment(version):
     ret_dict['doc_builder'] = run(
         (
             '{cmd} install --use-wheel --find-links={wheeldir} -U {ignore_option} '
-            'sphinx==1.2.2 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 mkdocs==0.11.1 mock==1.0.1 pillow==2.6.1'
+            'sphinx==1.2.2 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 mkdocs==0.12.1 mock==1.0.1 pillow==2.6.1'
             ' readthedocs-sphinx-ext==0.4.4 sphinx-rtd-theme==0.1.6 '
         ).format(
             cmd=project.venv_bin(version=version.slug, bin='pip'),

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,7 +12,7 @@ pip==6.1.1
 virtualenv==1.11.6
 docutils==0.11
 Sphinx==1.2.2
-mkdocs==0.11.1
+mkdocs==0.12.1
 
 django==1.6.11
 django-tastypie==0.11.1


### PR DESCRIPTION
Mkdocs, version 0.11.1, contains a bug concerning trailing slashes when
you navigate down the page tree. 0.12.1 fixes that issue and resolves #1229