### PR TITLE
include the path in the canonical url for sites hosted at subpaths

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -401,9 +401,9 @@ class Project(models.Model):
             return ""
         parsed = urlparse(self.canonical_url)
         if parsed.scheme:
-            scheme, netloc = parsed.scheme, parsed.netloc
+            scheme, netloc = parsed.scheme, parsed.netloc + parsed.path
         elif parsed.netloc:
-            scheme, netloc = "http", parsed.netloc
+            scheme, netloc = "http", parsed.netloc + parsed.path
         else:
             scheme, netloc = "http", parsed.path
         return "%s://%s/" % (scheme, netloc)


### PR DESCRIPTION
The issue is that Pyramid's canonical url is `http://docs.pylonsproject.org/projects/pyramid/` and the `parsed.path` (`/projects/pyramid`) is getting chopped off. This should prevent that from happening and fix the canonical urls.

fixes #1108