### PR TITLE
pdf glob matching: Serve the newest file

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -272,7 +272,7 @@ class PdfBuilder(BaseSphinx):
         else:
             from_globs = glob(os.path.join(self.old_artifact_path, "*.pdf"))
             if from_globs:
-                from_file = from_globs[0]
+                from_file = max(from_globs, key=os.path.getmtime)
             else:
                 from_file = None
         if from_file:


### PR DESCRIPTION
...instead of the alphabetically first.

There may be lots of pdf files lying around in the build directory
(embedded graphics in pdf format). Just serving the alphabetically
first will almost-always choose the wrong file.

The final compiled pdf depends on the other ones, hence it is
always the newest.