### PR TITLE
Fix main "docs about RTD" link to the current one

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Documentation for RTD
 You will find complete documentation for setting up your project at `the Read
 the Docs site`_.
 
-.. _the Read the Docs site: http://read-the-docs.readthedocs.org
+.. _the Read the Docs site: https://docs.readthedocs.org/
 
 Quickstart for GitHub-Hosted Projects
 -------------------------------------


### PR DESCRIPTION
Existing links points to an outdated subdomain (which maybe should be changed to a redirect to the new one).