### PR TITLE
Only use the current_page if it is available in the MkDocs template

### DIFF
--- a/readthedocs/templates/mkdocs/readthedocs/base.html
+++ b/readthedocs/templates/mkdocs/readthedocs/base.html
@@ -18,10 +18,12 @@
   <link href="{{ path }}" rel="stylesheet">
   {%- endfor %}
 
+  {% if current_page %}
   <script>
     // Current page data
     var mkdocs_page_name = "{{ current_page.input_path.replace('.md', '') }}"
   </script>
+  {% endif %}
 
   <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>


### PR DESCRIPTION
As of the development version of MkDocs, the template is used to build a few extra templates like the 404.html page. While these may not be used on ReadTheDocs, they will still be built.

On these pages, the context is very similar, but there is no current page as that object represents a Markdown file.

I assume this is used by the ReadTheDocs JavaScript, is there something sensible I can set it to for these sorts of pages?