### PR TITLE
Fix link from UI to RTD docs

### DIFF
--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -87,7 +87,7 @@
         {% block footer-content %}
         <p>{% blocktrans with "<a href='http://ericholscher.com/'>Eric Holscher</a>" as eric and "<a href='http://charlesleifer.com/'>Charles Leifer<a>" as charles and "<a href='http://bobbygrace.info/'>Bobby Grace</a>" as bobby and "<a href='http://djangodash.com/'>Django Dash</a>" as djangodash %}Copyright 2010-2015. Created by {{ eric }}, {{ charles }}, and {{ bobby }} for the 2010 {{ djangodash }}.{% endblocktrans %}
         </p>
-        <a href="https://github.com/rtfd/readthedocs.org">Github</a> | <a href="http://read-the-docs.readthedocs.org">{%  trans "Docs" %}</a>.
+        <a href="https://github.com/rtfd/readthedocs.org">Github</a> | <a href="http://docs.readthedocs.org">{%  trans "Docs" %}</a>.
 
         {% trans 'Made by <a href="https://github.com/rtfd/readthedocs.org/graphs/contributors">humans</a>. Funded by <a href="https://gratipay.com/readthedocs/">readers like you</a>.' %}
         </p>


### PR DESCRIPTION
read-the-docs.readthedocs.org seems to be a stub with just the index page; docs.readthedocs.org has all the content.