### PR TITLE
[trivial] vcs_support: organize imports

### DIFF
--- a/readthedocs/vcs_support/backends/github.py
+++ b/readthedocs/vcs_support/backends/github.py
@@ -1,11 +1,13 @@
 import logging
-from django.conf import settings
-from github2.client import Github
-from vcs_support.base import BaseContributionBackend
 import base64
 import os
 import urllib
 import urllib2
+
+from django.conf import settings
+from github2.client import Github
+
+from vcs_support.base import BaseContributionBackend
 
 log = logging.getLogger(__name__)
 

--- a/readthedocs/vcs_support/backends/launchpad.py
+++ b/readthedocs/vcs_support/backends/launchpad.py
@@ -1,4 +1,5 @@
 from launchpadlib.launchpad import Launchpad
+
 from vcs_support.base import VCSVersion
 from vcs_support.backends import bzr
 

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -1,9 +1,9 @@
 import logging
-from collections import namedtuple
 import os
-from os.path import basename
 import shutil
 import subprocess
+from collections import namedtuple
+from os.path import basename
 
 from django.template.defaultfilters import slugify
 
@@ -131,7 +131,7 @@ class BaseVCS(BaseCLI):
         """
         raise NotImplementedError
 
-    
+
     @property
     def commit(self):
         """

--- a/readthedocs/vcs_support/test.py
+++ b/readthedocs/vcs_support/test.py
@@ -1,7 +1,8 @@
-import mock
 import os
 import shutil
 import unittest
+
+import mock
 
 from django.conf import settings
 


### PR DESCRIPTION
placing standard libraries first. stdlibs, third party libs, django libs, rtd libs.