### PR TITLE
Mocking os.path.exists in test_builds.BuildTests.test_build

### DIFF
--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from django.test import TestCase
@@ -50,16 +51,25 @@ class BuildTests(TestCase):
 
         mock_apiv2_downloads.get.return_value = {'downloads': "no_url_here"}
 
+        original_exists = os.path.exists
+        conf_path = os.path.join(project.checkout_path(version.slug), project.conf_py_file)
+
+        def patched_exists(path):
+            if path == conf_path:
+                return True
+            return original_exists(path)
+
         with mock.patch('codecs.open', mock.mock_open(), create=True):
-            built_docs = build_docs(version,
-                                    False,
-                                    False,
-                                    False,
-                                    False,
-                                    False,
-                                    False,
-                                    False,
-                                    )
+            with mock.patch.object(os.path, 'exists', patched_exists):
+                built_docs = build_docs(version,
+                                        False,
+                                        False,
+                                        False,
+                                        False,
+                                        False,
+                                        False,
+                                        False,
+                                        )
 
         builder = project.doc_builder()(version)
         self.assertIn(builder.sphinx_builder,


### PR DESCRIPTION
Mocking `os.path.exists´ in `rtd_tests.test_builds.BuildTests.test_build` in order to simulate a successfull project checkout including the conf.py file defined in the Project model.

That should fix the currently broken build, see https://travis-ci.org/rtfd/readthedocs.org/builds/62574036

I'm not sure if that is the way to go as it more or less silences the issue that the `Project` model touches the filesystem. The filesystem access should be encapsulated somehow so that it can easily be switched out. But that might be a bigger task. Better to fix the mocks now to get the builds back to green :) 