### PR TITLE
Forcing tests to be run with LANG=C

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -13,5 +13,6 @@
     cd readthedocs
     rm -rf rtd_tests/builds/
 
+    LANG=C \
     coverage run -m pytest $*
 )


### PR DESCRIPTION
Forcing tests to be run with LANG=C. Otherwise the tests might fail if a non english locale is active.

The problem is that system messages change. And it seems that the tests rely on those messages to be english. If I'm using `LANG=de_DE.UTF-8`, the test suite fails with:

```
(readthedocs.org) gregor@layka ~/projects/readthedocs.org (git)-[master] % ./runtests.sh 
================================================================= test session starts ==================================================================
platform linux2 -- Python 2.7.9 -- py-1.4.27 -- pytest-2.7.1
rootdir: /home/gregor/projects/readthedocs.org, inifile: 
plugins: django
collected 210 items 

rtd_tests/tests/test_404.py .......
rtd_tests/tests/test_api.py ........
rtd_tests/tests/test_backend.py ......
rtd_tests/tests/test_betterversion.py .....
rtd_tests/tests/test_bookmarks.py ..........
rtd_tests/tests/test_builds.py ...
rtd_tests/tests/test_canonical.py .
rtd_tests/tests/test_celery.py ....
rtd_tests/tests/test_comments.py ..........x.............
rtd_tests/tests/test_core_management.py ...
rtd_tests/tests/test_core_tags.py ......................
rtd_tests/tests/test_doc_building.py ....F....
rtd_tests/tests/test_footer.py .
rtd_tests/tests/test_hacks.py .
rtd_tests/tests/test_middleware.py .....
rtd_tests/tests/test_oauth.py .....
rtd_tests/tests/test_post_commit_hooks.py ...
rtd_tests/tests/test_privacy.py .............
rtd_tests/tests/test_project.py ....
rtd_tests/tests/test_project_symlinks.py ...
rtd_tests/tests/test_project_views.py ..........
rtd_tests/tests/test_redirects.py ..........................
rtd_tests/tests/test_redirects_utils.py .....
rtd_tests/tests/test_repo_parsing.py ..
rtd_tests/tests/test_search_json_parsing.py .
rtd_tests/tests/test_single_version.py .......
rtd_tests/tests/test_supported.py ...
rtd_tests/tests/test_sync_versions.py ....
rtd_tests/tests/test_urls.py ..............
rtd_tests/tests/test_views.py .

======================================================================= FAILURES =======================================================================
________________________________________________________ TestBuildCommand.test_missing_command _________________________________________________________

self = <readthedocs.rtd_tests.tests.test_doc_building.TestBuildCommand testMethod=test_missing_command>

    def test_missing_command(self):
        '''Test missing command'''
        path = os.path.join('non-existant', str(uuid.uuid4()))
        self.assertFalse(os.path.exists(path))
        cmd = BuildCommand('/non-existant/foobar')
        with cmd:
            cmd.run()
        missing_re = re.compile(r'(?:No such file or directory|not found)')
>       self.assertRegexpMatches(cmd.error, missing_re)
E       AssertionError: Regexp didn't match: '(?:No such file or directory|not found)' not found in '/bin/sh: /non-existant/foobar: Datei oder Verzeichnis nicht gefunden\n'

rtd_tests/tests/test_doc_building.py:87: AssertionError
----------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------
[21/May/2015 08:37:59] INFO [doc_builder.environments:209] Running: '/non-existant/foobar' [/home/gregor/projects/readthedocs.org/readthedocs]
=================================================== 1 failed, 208 passed, 1 xfailed in 82.86 seconds ===================================================
```

**Note:** The build for this PR will fail because it is based on a master which is current red. Once #1282 is merged, I can rebase this PR on the new master which will also fix the builds for this PR.