### PR TITLE
Elasticsearch 1.5.0 Upgrade, including:

### DIFF
--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -42,6 +42,6 @@ class Command(BaseCommand):
                 commit = None
             try:
                 page_list = parse_json.process_all_json_files(version, build_dir=False)
-                index_search_request(version=version, page_list=page_list, commit=commit, project_scale=0, page_scale=0, section=False)
+                index_search_request(version=version, page_list=page_list, commit=commit, project_scale=0, page_scale=0, section=False, delete=False)
             except Exception:
                 log.error('Build failed for %s' % version, exc_info=True)

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -42,6 +42,6 @@ class Command(BaseCommand):
                 commit = None
             try:
                 page_list = parse_json.process_all_json_files(version, build_dir=False)
-                index_search_request(version=version, page_list=page_list, commit=commit, project_scale=0, page_scale=0)
+                index_search_request(version=version, page_list=page_list, commit=commit, project_scale=0, page_scale=0, section=False)
             except Exception:
                 log.error('Build failed for %s' % version, exc_info=True)

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -42,6 +42,6 @@ class Command(BaseCommand):
                 commit = None
             try:
                 page_list = parse_json.process_all_json_files(version, build_dir=False)
-                index_search_request(version=version, page_list=page_list, commit=commit)
+                index_search_request(version=version, page_list=page_list, commit=commit, project_scale=0, page_scale=0)
             except Exception:
                 log.error('Build failed for %s' % version, exc_info=True)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -686,7 +686,7 @@ def update_search(version_pk, commit):
 
     log_msg = ' '.join([page['path'] for page in page_list])
     log.info("(Search Index) Sending Data: %s [%s]" % (version.project.slug, log_msg))
-    index_search_request(version=version, page_list=page_list, commit=commit)
+    index_search_request(version=version, page_list=page_list, commit=commit, project_scale=0, page_scale=0)
 
 
 @task(queue='web')

--- a/readthedocs/restapi/utils.py
+++ b/readthedocs/restapi/utils.py
@@ -86,13 +86,13 @@ def delete_versions(project, version_data):
         return set()
 
 
-def index_search_request(version, page_list, commit):
+def index_search_request(version, page_list, commit, project_scale, page_scale):
     log_msg = ' '.join([page['path'] for page in page_list])
     log.info("(Server Search) Indexing Pages: %s [%s]" % (
         version.project.slug, log_msg))
     project = version.project
     page_obj = PageIndex()
-    project_scale = 1
+    section_obj = SectionIndex()
 
     #tags = [tag.name for tag in project.tags.all()]
 
@@ -106,13 +106,13 @@ def index_search_request(version, page_list, commit):
         'author': [user.username for user in project.users.all()],
         'url': project.get_absolute_url(),
         'tags': None,
-        '_boost': project_scale,
+        'weight': project_scale,
     })
 
     index_list = []
+    section_index_list = []
     for page in page_list:
         log.debug("(API Index) %s:%s" % (project.slug, page['path']))
-        page_scale = 1
         page_id = hashlib.md5('%s-%s-%s' % (project.slug, version.slug, page['path'])).hexdigest()
         index_list.append({
             'id': page_id,
@@ -124,27 +124,38 @@ def index_search_request(version, page_list, commit):
             'content': page['content'],
             'taxonomy': None,
             'commit': commit,
-            '_boost': page_scale + project_scale,
+            'weight': page_scale + project_scale,
         })
+        for section in page['sections']:
+            section_index_list.append({
+                'id': hashlib.md5('%s-%s-%s-%s' % (project.slug, version.slug, page['path'], section['id'])).hexdigest(),
+                'project': project.slug,
+                'version': version.slug,
+                'path': page['path'],
+                'page_id': section['id'],
+                'title': section['title'],
+                'content': section['content'],
+                'weight': page_scale,
+            })
+        section_obj.bulk_index(section_index_list, parent=page_id, routing=project.slug)
 
     page_obj.bulk_index(index_list, parent=project.slug)
 
     log.info("(Server Search) Deleting files not in commit: %s" % commit)
-    # Figure this out later
+    # TODO: AK Make sure this works
     delete_query = {
-        # ES .90 doesn't wrap this 
-        #"query": {
-        "bool": {
-            "must": [
-                {"term": {"project": project.slug, }},
-                {"term": {"version": version.slug, }},
-            ],
-            "must_not": {
-                "term": {
-                    "commit": commit
+        "query": {
+            "bool": {
+                "must": [
+                    {"term": {"project": project.slug, }},
+                    {"term": {"version": version.slug, }},
+                ],
+                "must_not": {
+                    "term": {
+                        "commit": commit
+                    }
                 }
             }
         }
-        #}
     }
     page_obj.delete_document(body=delete_query)

--- a/readthedocs/restapi/utils.py
+++ b/readthedocs/restapi/utils.py
@@ -86,7 +86,7 @@ def delete_versions(project, version_data):
         return set()
 
 
-def index_search_request(version, page_list, commit, project_scale, page_scale):
+def index_search_request(version, page_list, commit, project_scale, page_scale, section=True):
     log_msg = ' '.join([page['path'] for page in page_list])
     log.info("(Server Search) Indexing Pages: %s [%s]" % (
         version.project.slug, log_msg))
@@ -126,18 +126,19 @@ def index_search_request(version, page_list, commit, project_scale, page_scale):
             'commit': commit,
             'weight': page_scale + project_scale,
         })
-        for section in page['sections']:
-            section_index_list.append({
-                'id': hashlib.md5('%s-%s-%s-%s' % (project.slug, version.slug, page['path'], section['id'])).hexdigest(),
-                'project': project.slug,
-                'version': version.slug,
-                'path': page['path'],
-                'page_id': section['id'],
-                'title': section['title'],
-                'content': section['content'],
-                'weight': page_scale,
-            })
-        section_obj.bulk_index(section_index_list, parent=page_id, routing=project.slug)
+        if section:
+            for section in page['sections']:
+                section_index_list.append({
+                    'id': hashlib.md5('%s-%s-%s-%s' % (project.slug, version.slug, page['path'], section['id'])).hexdigest(),
+                    'project': project.slug,
+                    'version': version.slug,
+                    'path': page['path'],
+                    'page_id': section['id'],
+                    'title': section['title'],
+                    'content': section['content'],
+                    'weight': page_scale,
+                })
+            section_obj.bulk_index(section_index_list, parent=page_id, routing=project.slug)
 
     page_obj.bulk_index(index_list, parent=project.slug)
 

--- a/readthedocs/restapi/utils.py
+++ b/readthedocs/restapi/utils.py
@@ -86,7 +86,7 @@ def delete_versions(project, version_data):
         return set()
 
 
-def index_search_request(version, page_list, commit, project_scale, page_scale, section=True):
+def index_search_request(version, page_list, commit, project_scale, page_scale, section=True, delete=True):
     log_msg = ' '.join([page['path'] for page in page_list])
     log.info("(Server Search) Indexing Pages: %s [%s]" % (
         version.project.slug, log_msg))
@@ -142,21 +142,22 @@ def index_search_request(version, page_list, commit, project_scale, page_scale, 
 
     page_obj.bulk_index(index_list, parent=project.slug)
 
-    log.info("(Server Search) Deleting files not in commit: %s" % commit)
-    # TODO: AK Make sure this works
-    delete_query = {
-        "query": {
-            "bool": {
-                "must": [
-                    {"term": {"project": project.slug, }},
-                    {"term": {"version": version.slug, }},
-                ],
-                "must_not": {
-                    "term": {
-                        "commit": commit
+    if delete:
+        log.info("(Server Search) Deleting files not in commit: %s" % commit)
+        # TODO: AK Make sure this works
+        delete_query = {
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"project": project.slug, }},
+                        {"term": {"version": version.slug, }},
+                    ],
+                    "must_not": {
+                        "term": {
+                            "commit": commit
+                        }
                     }
                 }
             }
         }
-    }
-    page_obj.delete_document(body=delete_query)
+        page_obj.delete_document(body=delete_query)

--- a/readthedocs/restapi/views/search_views.py
+++ b/readthedocs/restapi/views/search_views.py
@@ -1,6 +1,6 @@
 import logging
 
-from rest_framework import decorators, permissions, viewsets, status
+from rest_framework import decorators, permissions, status
 from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
 from rest_framework.response import Response
 import requests
@@ -11,7 +11,9 @@ from search.indexes import PageIndex, ProjectIndex, SectionIndex
 from projects.models import Project
 from restapi import utils
 
+
 log = logging.getLogger(__name__)
+
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
@@ -43,7 +45,14 @@ def index_search(request):
     commit = data.get('commit')
     project = Project.objects.get(pk=project_pk)
     version = Version.objects.get(pk=version_pk)
-    utils.index_search_request(version=version, page_list=data['page_list'], commit=commit)
+
+    resp = requests.get('https://api.grokthedocs.com/api/v1/index/1/heatmap/', params={'project': project.slug, 'compare': True})
+    ret_json = resp.json()
+    project_scale = ret_json.get('scaled_project', {}).get(project.slug)
+    page_scale = ret_json.get('scaled_page', {}).get(page['path'], 1)
+
+    utils.index_search_request(version=version, page_list=data['page_list'], commit=commit, project_scale=project_scale, page_scale=page_scale)
+
     return Response({'indexed': True})
 
 
@@ -59,12 +68,17 @@ def search(request):
     kwargs = {}
     body = {
         "query": {
-            "bool": {
-                "should": [
-                    {"match": {"title": {"query": query, "boost": 10}}},
-                    {"match": {"headers": {"query": query, "boost": 5}}},
-                    {"match": {"content": {"query": query}}},
-                ]
+            "function_score": {
+                "field_value_factor": {"field": "weight"},
+                "query": {
+                    "bool": {
+                        "should": [
+                            {"match": {"title": {"query": query, "boost": 10}}},
+                            {"match": {"headers": {"query": query, "boost": 5}}},
+                            {"match": {"content": {"query": query}}},
+                        ]
+                    }
+                }
             }
         },
         "highlight": {
@@ -102,18 +116,24 @@ def project_search(request):
     log.debug("(API Project Search) %s" % (query))
     body = {
         "query": {
-            "bool": {
-                "should": [
-                    {"match": {"name": {"query": query, "boost": 10}}},
-                    {"match": {"description": {"query": query}}},
-                ]
-            },
+            "function_score": {
+                "field_value_factor": {"field": "weight"},
+                "query": {
+                    "bool": {
+                        "should": [
+                            {"match": {"name": {"query": query, "boost": 10}}},
+                            {"match": {"description": {"query": query}}},
+                        ]
+                    }
+                }
+            }
         },
         "fields": ["name", "slug", "description", "lang"]
     }
     results = ProjectIndex().search(body)
 
     return Response({'results': results})
+
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
@@ -165,11 +185,16 @@ def section_search(request):
     kwargs = {}
     body = {
         "query": {
-            "bool": {
-                "should": [
-                    {"match": {"title": {"query": query, "boost": 10}}},
-                    {"match": {"content": {"query": query}}},
-                ]
+            "function_score": {
+                "field_value_factor": {"field": "weight"},
+                "query": {
+                    "bool": {
+                        "should": [
+                            {"match": {"title": {"query": query, "boost": 10}}},
+                            {"match": {"content": {"query": query}}},
+                        ]
+                    }
+                }
             }
         },
         "facets": {
@@ -177,7 +202,7 @@ def section_search(request):
                 "terms": {"field": "project"},
                 "facet_filter": {
                     "term": {"version": version_slug},
-                } 
+                }
             },
         },
         "highlight": {
@@ -197,11 +222,11 @@ def section_search(request):
                 {"term": {"version": version_slug}},
             ]
         }
-        body["facets"]['path'] = {
+        body['facets']['path'] = {
             "terms": {"field": "path"},
             "facet_filter": {
                 "term": {"project": project_slug},
-            } 
+            }
         },
         # Add routing to optimize search by hitting the right shard.
         kwargs['routing'] = project_slug
@@ -212,13 +237,12 @@ def section_search(request):
                 {"term": {"path": path_slug}},
             ]
         }
-        
+
     if path_slug and not project_slug:
         # Show facets when we only have a path
-        body["facets"]['path'] = {
+        body['facets']['path'] = {
             "terms": {"field": "path"}
         }
-
 
     results = SectionIndex().search(body, **kwargs)
 

--- a/readthedocs/search/indexes.py
+++ b/readthedocs/search/indexes.py
@@ -317,12 +317,13 @@ class SectionIndex(Index):
                 '_all': {'enabled': False},
                 # Associate a section with a page.
                 '_parent': {'type': self._parent},
-                'suggest': {
-                    "type": "completion",
-                    "index_analyzer": "simple",
-                    "search_analyzer": "simple",
-                    "payloads": True,
-                },
+                # Commenting this out until we need it.
+                # 'suggest': {
+                #     "type": "completion",
+                #     "index_analyzer": "simple",
+                #     "search_analyzer": "simple",
+                #     "payloads": True,
+                # },
                 'properties': {
                     'id': {'type': 'string', 'index': 'not_analyzed'},
                     'project': {'type': 'string', 'index': 'not_analyzed'},

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -43,7 +43,7 @@ github2==0.5.2
 httplib2==0.7.7
 
 # Search
-elasticsearch==0.4.3
+elasticsearch==1.5.0
 pyelasticsearch==0.7.1
 pyquery==1.2.2
 


### PR DESCRIPTION
- Many thanks to @robhudson, who wrote the original 0.90 -> 1.0+ ElasticSearch query code.
- Updating pip elasticsearch requirement to 1.5.0 for the new server.
- Refactor argument order to match new API.
- Updated to boost relevance in a Elasticsearch >= 1.0 way
- Removing score script and adding in field_value_factor per @robhudson's insight.
- Adding default project_scale and page_scale values.
- Found the source of the 400 error on _bulk, and noted.
