### PR TITLE
Use python -m to create virtualenvs

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -315,7 +315,7 @@ def setup_environment(version):
     # interpreters.
     ret_dict['venv'] = run(
         '{cmd} {site_packages} {path}'.format(
-            cmd='virtualenv-2.7 -p {interpreter}'.format(
+            cmd='{interpreter} -m virtualenv'.format(
                 interpreter=project.python_interpreter),
             site_packages=site_packages,
             path=project.venv_path(version=version.slug)


### PR DESCRIPTION
Fixes gh-1263, failure to create Python 3 virtualenvs (I hope)

The problem appears to be that `virtualenv -p python3` re-executes its own file in site-packages as a script under Python 3. Because the directory containing a script is prepended to `sys.path`, the contents of Python 2 site-packages are then on sys.path for Python 3. [python-future](http://python-future.org/) is installed in Python 2, providing certain standard library modules under their Python 3 names. So when it tries to import copyreg, it finds the compatibility module for Python 2 instead of the standard Python 3 module, making future fail with the error:

ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.

As suggested by @dstufft, this invokes `python3 -m virtualenv` instead, which will cause Python 3 to run its own copy of virtualenv, and should avoid this issue. This requires virtualenv to be installed in Python 3 as well; I don't know if it already is, but it should be easy to arrange if not.