### PR TITLE
Upgrade sphinx ext

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -339,7 +339,7 @@ def setup_environment(version):
         'mkdocs==0.13.3',
         'mock==1.0.1',
         'pillow==2.6.1',
-        'readthedocs-sphinx-ext==0.4.4',
+        'readthedocs-sphinx-ext==0.5.3',
         'sphinx-rtd-theme==0.1.8',
         'recommonmark==0.1.1',
     ])


### PR DESCRIPTION
This fixes applying our theme CSS after user-supplied CSS. We still add our custom embed at the end, but the theme CSS at the front.