### PR TITLE
Remove outdated comment

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -10,5 +10,4 @@ django-mailgun==0.2.2
 #For resizing images
 pillow
 
-#Uncomment this if you want to index things in solr.
 cssselect==0.7.1


### PR DESCRIPTION
This comment was targeted at pyquery which was removed removed from this
file in d8b5adc. It's now in requirements/pip.txt.