### PR TITLE
Bump readthedocs-sphinx-ext version to 0.5.4

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -336,7 +336,7 @@ def setup_environment(version):
         'mkdocs==0.13.3',
         'mock==1.0.1',
         'pillow==2.6.1',
-        'readthedocs-sphinx-ext==0.5.3',
+        'readthedocs-sphinx-ext==0.5.4',
         'sphinx-rtd-theme==0.1.8',
         'recommonmark==0.1.1',
     ])

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -72,7 +72,7 @@ distlib==0.1.2
 
 # Commenting stuff
 django-cors-headers==0.13
-nilsimsa==0.2.0
+nilsimsa==0.3.7
 
 # Pegged git requirements
 git+https://github.com/alex/django-filter.git#egg=django-filter


### PR DESCRIPTION
Requires release of readthedox-sphinx-ext 0.5.4 first:
refs rtfd/readthedocs-sphinx-ext#10
fixes #1337 