### PR TITLE
Version handling improvements

### DIFF
--- a/readthedocs/api/base.py
+++ b/readthedocs/api/base.py
@@ -12,6 +12,7 @@ from tastypie.resources import ModelResource
 from tastypie.http import HttpCreated, HttpApplicationError
 from tastypie.utils import dict_strip_unicode_keys, trailing_slash
 
+from builds.constants import LATEST
 from builds.models import Build, Version
 from core.utils import trigger_build
 from projects.models import Project, ImportedFile
@@ -150,7 +151,7 @@ class VersionResource(ModelResource):
         if highest[0]:
             ret_val['url'] = highest[0].get_absolute_url()
             ret_val['slug'] = highest[0].slug,
-        if base and base != 'latest':
+        if base and base != LATEST:
             try:
                 ver_obj = project.versions.get(slug=base)
                 base_ver = mkversion(ver_obj)
@@ -167,7 +168,7 @@ class VersionResource(ModelResource):
 
     def build_version(self, request, **kwargs):
         project = get_object_or_404(Project, slug=kwargs['project_slug'])
-        version = kwargs.get('version_slug', 'latest')
+        version = kwargs.get('version_slug', LATEST)
         version_obj = project.versions.get(slug=version)
         trigger_build(project=project, version=version_obj)
         return self.create_response(request, {'building': True})

--- a/readthedocs/betterversion/better.py
+++ b/readthedocs/betterversion/better.py
@@ -1,7 +1,14 @@
 from distlib.version import AdaptiveVersion
 from collections import defaultdict
 
-class BetterVersion(AdaptiveVersion):
+
+class VersionIdentifier(AdaptiveVersion):
+    """
+    An extended variant of ``distlib.version.AdaptiveVersion``. The constructor
+    takes a version string like ``0.7.3`` and the class then provides a nice
+    interface to access the different major/minor version numbers etc.
+    """
+
     @property
     def major_version(self):
         return self._parts[0][0]
@@ -14,8 +21,8 @@ class BetterVersion(AdaptiveVersion):
         except IndexError, e:
             return 0
 
-class VersionManager(object):
 
+class VersionManager(object):
     def __init__(self):
         self._state = defaultdict(lambda: defaultdict(list))
 
@@ -50,13 +57,18 @@ class VersionManager(object):
                     # Raise these for now.
                     raise
 
+
 def version_windows(versions, major=1, minor=1, point=1, flat=False):
+    # TODO: This needs some documentation on how VersionManager etc works and
+    # some examples what the expected outcome is.
+
     major_version_window = major
     minor_version_window = minor
     point_version_window = point
 
     manager = VersionManager()
-    [ manager.add(v) for v in versions]
+    for v in versions:
+        manager.add(v)
     manager.prune_major(major_version_window)
     manager.prune_minor(minor_version_window)
     manager.prune_point(point_version_window)

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -24,3 +24,6 @@ VERSION_TYPES = (
     ('tag', _('Tag')),
     ('unknown', _('Unknown')),
 )
+
+STABLE = 'stable'
+STABLE_VERBOSE_NAME = 'stable'

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -25,5 +25,8 @@ VERSION_TYPES = (
     ('unknown', _('Unknown')),
 )
 
+LATEST = 'latest'
+LATEST_VERBOSE_NAME = 'latest'
+
 STABLE = 'stable'
 STABLE_VERBOSE_NAME = 'stable'

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _, ugettext
 from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
+from builds.constants import LATEST
 from privacy.loader import VersionManager, RelatedProjectManager
 from projects.models import Project
 from projects import constants
@@ -79,7 +80,7 @@ class Version(models.Model):
 
     @property
     def remote_slug(self):
-        if self.slug == 'latest':
+        if self.slug == LATEST:
             if self.project.default_branch:
                 return self.project.default_branch
             else:

--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -2,6 +2,9 @@ import re
 import logging
 from shutil import rmtree
 
+from builds.constants import LATEST
+
+
 log = logging.getLogger(__name__)
 
 
@@ -42,7 +45,7 @@ def get_bitbucket_username_repo(version, repo_url=None):
 
 def get_vcs_version_slug(version):
     slug = None
-    if version.slug == 'latest':
+    if version.slug == LATEST:
         if version.project.default_branch:
             slug = version.project.default_branch
         else:

--- a/readthedocs/core/djangome_urls.py
+++ b/readthedocs/core/djangome_urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import patterns, url
+from builds.constants import LATEST
+
 
 urlpatterns = patterns(
     '',  # base view, flake8 complains if it is on the previous line.
     url('^$',
         'djangome.views.redirect_home',
-        {'version': 'latest'}),
+        {'version': LATEST}),
 )

--- a/readthedocs/core/management/commands/build_files.py
+++ b/readthedocs/core/management/commands/build_files.py
@@ -5,6 +5,7 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 
 from projects import tasks
+from builds.constants import LATEST
 from builds.models import Version
 
 log = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ class Command(BaseCommand):
             queryset = Version.objects.public(project__slug=project)
             log.info("Building all versions for %s" % project)
         elif getattr(settings, 'INDEX_ONLY_LATEST', True):
-            queryset = Version.objects.filter(slug='latest')
+            queryset = Version.objects.filter(slug=LATEST)
         else:
             queryset = Version.objects.public()
         for v in queryset:

--- a/readthedocs/core/management/commands/import_intersphinx.py
+++ b/readthedocs/core/management/commands/import_intersphinx.py
@@ -1,10 +1,11 @@
 from django.core.management.base import BaseCommand
 
+from builds.constants import LATEST
 from builds.models import Version
 from projects.tasks import update_intersphinx
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        for version in Version.objects.filter(slug="latest"):
+        for version in Version.objects.filter(slug=LATEST):
             update_intersphinx(version.pk)

--- a/readthedocs/core/management/commands/pull.py
+++ b/readthedocs/core/management/commands/pull.py
@@ -3,6 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
+from builds.constants import LATEST
 from projects import tasks, utils
 
 import redis
@@ -14,5 +15,5 @@ class Command(BaseCommand):
         if len(args):
             for slug in args:
                 tasks.update_imported_docs(
-                    utils.version_from_slug(slug, 'latest').pk
+                    utils.version_from_slug(slug, LATEST).pk
                 )

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -4,6 +4,7 @@ from optparse import make_option
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
+from builds.constants import LATEST
 from builds.models import Version
 from search import parse_json
 from restapi.utils import index_search_request
@@ -30,7 +31,7 @@ class Command(BaseCommand):
             queryset = Version.objects.public(project__slug=project)
             log.info("Building all versions for %s" % project)
         elif getattr(settings, 'INDEX_ONLY_LATEST', True):
-            queryset = Version.objects.public().filter(slug='latest')
+            queryset = Version.objects.public().filter(slug=LATEST)
         else:
             queryset = Version.objects.public()
         for version in queryset:

--- a/readthedocs/core/utils.py
+++ b/readthedocs/core/utils.py
@@ -9,6 +9,8 @@ from django.core.mail import EmailMultiAlternatives
 from django.template.loader import get_template
 from django.template import Context
 
+from builds.constants import LATEST
+from builds.constants import LATEST_VERBOSE_NAME
 from builds.models import Build
 
 log = logging.getLogger(__name__)
@@ -44,10 +46,10 @@ def make_latest(project):
     branch = project.default_branch or project.vcs_repo().fallback_branch
     version_data, created = Version.objects.get_or_create(
         project=project,
-        slug='latest',
+        slug=LATEST,
         type='branch',
         active=True,
-        verbose_name='latest',
+        verbose_name=LATEST_VERBOSE_NAME,
         identifier=branch,
     )
 
@@ -82,7 +84,7 @@ def trigger_build(project, version=None, record=True, force=False, basic=False):
         return None
 
     if not version:
-        version = project.versions.get(slug='latest')
+        version = project.versions.get(slug=LATEST)
 
     if record:
         build = Build.objects.create(

--- a/readthedocs/core/views.py
+++ b/readthedocs/core/views.py
@@ -24,6 +24,7 @@ from builds.models import Version
 from core.forms import FacetedSearchForm
 from core.utils import trigger_build
 from donate.mixins import DonateProgressMixin
+from builds.constants import LATEST
 from projects import constants
 from projects.models import Project, ImportedFile, ProjectRelationship
 from projects.tasks import remove_dir, update_imported_docs
@@ -152,7 +153,7 @@ def _build_version(project, slug, already_built=()):
         # short circuit versions that are default
         # these will build at "latest", and thus won't be
         # active
-        latest_version = project.versions.get(slug='latest')
+        latest_version = project.versions.get(slug=LATEST)
         trigger_build(project=project, version=latest_version, force=True)
         pc_log.info(("(Version build) Building %s:%s"
                      % (project.slug, latest_version.slug)))
@@ -162,7 +163,7 @@ def _build_version(project, slug, already_built=()):
             trigger_build(project=project, version=slug_version, force=True)
             pc_log.info(("(Version build) Building %s:%s"
                          % (project.slug, slug_version.slug)))
-        return "latest"
+        return LATEST
     elif project.versions.exclude(active=True).filter(slug=slug).exists():
         pc_log.info(("(Version build) Not Building %s" % slug))
         return None
@@ -201,7 +202,7 @@ def _build_url(url, branches):
         for project in projects:
             (to_build, not_building) = _build_branches(project, branches)
             if not to_build:
-                update_imported_docs.delay(project.versions.get(slug='latest').pk)
+                update_imported_docs.delay(project.versions.get(slug=LATEST).pk)
                 msg = '(URL Build) Syncing versions for %s' % project.slug
                 pc_log.info(msg)
         if to_build:
@@ -293,7 +294,7 @@ def generic_build(request, pk=None):
             _build_version(project, slug)
         else:
             pc_log.info(
-                "(Incoming Generic Build) %s [%s]" % (project.slug, 'latest'))
+                "(Incoming Generic Build) %s [%s]" % (project.slug, LATEST))
             trigger_build(project=project, force=True)
     else:
         return HttpResponse("You must POST to this resource.")

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -3,6 +3,8 @@ from django.db import models
 
 from guardian.shortcuts import get_objects_for_user
 
+from builds.constants import LATEST
+from builds.constants import LATEST_VERBOSE_NAME
 from builds.constants import STABLE
 from builds.constants import STABLE_VERBOSE_NAME
 from projects import constants
@@ -125,7 +127,19 @@ class VersionManager(RelatedProjectManager):
             'type': 'branch',
         }
         defaults.update(kwargs)
-        return self.create(**kwargs)
+        return self.create(**defaults)
+
+    def create_latest(self, **kwargs):
+        defaults = {
+            'slug': LATEST,
+            'verbose_name': LATEST_VERBOSE_NAME,
+            'machine': True,
+            'active': True,
+            'identifier': LATEST,
+            'type': 'branch',
+        }
+        defaults.update(kwargs)
+        return self.create(**defaults)
 
 
 class AdminPermission(object):

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -3,6 +3,8 @@ from django.db import models
 
 from guardian.shortcuts import get_objects_for_user
 
+from builds.constants import STABLE
+from builds.constants import STABLE_VERBOSE_NAME
 from projects import constants
 
 
@@ -112,6 +114,18 @@ class VersionManager(RelatedProjectManager):
 
     def api(self, user=None, *args, **kwargs):
         return self.public(user, only_active=False)
+
+    def create_stable(self, **kwargs):
+        defaults = {
+            'slug': STABLE,
+            'verbose_name': STABLE_VERBOSE_NAME,
+            'machine': True,
+            'active': True,
+            'identifier': STABLE,
+            'type': 'branch',
+        }
+        defaults.update(kwargs)
+        return self.create(**kwargs)
 
 
 class AdminPermission(object):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from guardian.shortcuts import assign
 
-from betterversion.better import version_windows, BetterVersion
+from betterversion.better import version_windows, VersionIdentifier
 from builds.constants import LATEST
 from builds.constants import LATEST_VERBOSE_NAME
 from oauth import utils as oauth_utils
@@ -716,15 +716,15 @@ class Project(models.Model):
         """
         if not self.num_major or not self.num_minor or not self.num_point:
             return None
-        versions = []
-        for ver in self.versions.all():
+        version_identifiers = []
+        for version in self.versions.all():
             try:
-                versions.append(BetterVersion(ver.verbose_name))
+                version_identifiers.append(VersionIdentifier(version.verbose_name))
             except UnsupportedVersionError:
                 # Probably a branch
                 pass
         active_versions = version_windows(
-            versions,
+            version_identifiers,
             major=self.num_major,
             minor=self.num_minor,
             point=self.num_point,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -292,8 +292,8 @@ class Project(models.Model):
             if not self.versions.filter(slug='latest').exists():
                 self.versions.create(
                     slug='latest', verbose_name='latest', machine=True, type='branch', active=True, identifier=branch)
-            # if not self.versions.filter(slug='stable').exists():
-            #     self.versions.create(slug='stable', verbose_name='stable', type='branch', active=True, identifier=branch)
+            # if not self.versions.filter(slug=STABLE).exists():
+            #     self.versions.create_stable(type='branch', identifier=branch)
         except Exception:
             log.error('Error creating default branches', exc_info=True)
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -16,6 +16,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from slumber.exceptions import HttpClientError
 
+from builds.constants import LATEST
 from builds.models import Build, Version
 from core.utils import send_email, run_on_app_servers
 from doc_builder.loader import get_builder_class
@@ -156,7 +157,7 @@ def ensure_version(api, project, version_pk):
     if version_pk:
         version_data = api.version(version_pk).get()
     else:
-        version_data = api.version(project.slug).get(slug='latest')['objects'][0]
+        version_data = api.version(project.slug).get(slug=LATEST)['objects'][0]
     version = make_api_version(version_data)
     return version
 
@@ -261,7 +262,7 @@ def update_imported_docs(version_pk, api=None):
             # Does this ever get called?
             log.info(LOG_TEMPLATE.format(
                 project=project.slug, version=version.slug, msg='Updating to latest revision'))
-            version_slug = 'latest'
+            version_slug = LATEST
             version_repo = project.vcs_repo(version_slug)
             ret_dict['checkout'] = version_repo.update()
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -25,6 +25,7 @@ from projects.exceptions import ProjectImportError
 from projects.models import ImportedFile, Project
 from projects.utils import run, make_api_version, make_api_project
 from projects.constants import LOG_TEMPLATE
+from builds.constants import STABLE
 from projects import symlinks
 from privacy.loader import Syncer
 from tastyapi import api, apiv2
@@ -650,7 +651,7 @@ def finish_build(version_pk, build_pk, hostname=None, html=False,
     update_static_metadata.delay(version.project.pk)
     fileify.delay(version.pk, commit=build.commit)
     update_search.delay(version.pk, commit=build.commit)
-    if not html and version.slug != 'stable' and build.exit_code != 423:
+    if not html and version.slug != STABLE and build.exit_code != 423:
         send_notifications.delay(version.pk, build_pk=build.pk)
 
 

--- a/readthedocs/projects/templatetags/projects_tags.py
+++ b/readthedocs/projects/templatetags/projects_tags.py
@@ -2,6 +2,7 @@ from django import template
 
 from distutils2.version import NormalizedVersion
 from projects.utils import mkversion
+from builds.constants import STABLE
 
 register = template.Library()
 
@@ -11,7 +12,7 @@ def make_version(version):
     if not ver:
         if version.slug == 'latest':
             return NormalizedVersion('99999.0', error_on_huge_major_num=False)
-        elif version.slug == 'stable':
+        elif version.slug == STABLE:
             return NormalizedVersion('9999.0', error_on_huge_major_num=False)
         else:
             return NormalizedVersion('999.0', error_on_huge_major_num=False)

--- a/readthedocs/projects/templatetags/projects_tags.py
+++ b/readthedocs/projects/templatetags/projects_tags.py
@@ -2,6 +2,7 @@ from django import template
 
 from distutils2.version import NormalizedVersion
 from projects.utils import mkversion
+from builds.constants import LATEST
 from builds.constants import STABLE
 
 register = template.Library()
@@ -10,7 +11,7 @@ register = template.Library()
 def make_version(version):
     ver = mkversion(version)
     if not ver:
-        if version.slug == 'latest':
+        if version.slug == LATEST:
             return NormalizedVersion('99999.0', error_on_huge_major_num=False)
         elif version.slug == STABLE:
             return NormalizedVersion('9999.0', error_on_huge_major_num=False)

--- a/readthedocs/projects/utils.py
+++ b/readthedocs/projects/utils.py
@@ -12,6 +12,8 @@ from django.conf import settings
 from distutils2.version import NormalizedVersion, suggest_normalized_version
 import redis
 
+from builds.constants import LATEST
+
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +28,7 @@ def version_from_slug(slug, version):
         v = Version.objects.get(project__slug=slug, slug=version)
     return v
 
-def symlink(project, version='latest'):
+def symlink(project, version=LATEST):
     from projects import symlinks
     v = version_from_slug(project, version)
     log.info("Symlinking %s" % v)

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -22,6 +22,7 @@ from taggit.models import Tag
 import requests
 
 from .base import ProjectOnboardMixin
+from builds.constants import LATEST
 from builds.filters import VersionSlugFilter
 from builds.models import Version
 from projects.models import Project, ImportedFile
@@ -118,7 +119,7 @@ def project_badge(request, project_slug, redirect=False):
     """
     Return a sweet badge for the project
     """
-    version_slug = request.GET.get('version', 'latest')
+    version_slug = request.GET.get('version', LATEST)
     style = request.GET.get('style', 'flat')
     try:
         version = Version.objects.public(request.user).get(project__slug=project_slug, slug=version_slug)
@@ -296,7 +297,7 @@ def elastic_project_search(request, project_slug):
     """
     queryset = Project.objects.protected(request.user)
     project = get_object_or_404(queryset, slug=project_slug)
-    version_slug = request.GET.get('version', 'latest')
+    version_slug = request.GET.get('version', LATEST)
     query = request.GET.get('q', None)
     if query:
         user = ''
@@ -449,7 +450,7 @@ def project_embed(request, project_slug):
     """
     project = get_object_or_404(Project.objects.protected(request.user),
                                 slug=project_slug)
-    version = project.versions.get(slug='latest')
+    version = project.versions.get(slug=LATEST)
     files = version.imported_files.order_by('path')
 
     return render_to_response(

--- a/readthedocs/restapi/utils.py
+++ b/readthedocs/restapi/utils.py
@@ -3,6 +3,7 @@ import logging
 
 import requests
 
+from builds.constants import LATEST
 from builds.models import Version
 from projects.utils import slugify_uniquely
 from search.indexes import PageIndex, ProjectIndex, SectionIndex
@@ -75,7 +76,7 @@ def delete_versions(project, version_data):
         identifier__in=current_versions).exclude(
         uploaded=True).exclude(
         active=True).exclude(
-        slug='latest')
+        slug=LATEST)
 
     if to_delete_qs.count():
         ret_val = {obj.slug for obj in to_delete_qs}

--- a/readthedocs/restapi/utils.py
+++ b/readthedocs/restapi/utils.py
@@ -8,8 +8,6 @@ from builds.models import Version
 from projects.utils import slugify_uniquely
 from search.indexes import PageIndex, ProjectIndex, SectionIndex
 
-from betterversion.better import version_windows, BetterVersion
-
 log = logging.getLogger(__name__)
 
 

--- a/readthedocs/restapi/views/core_views.py
+++ b/readthedocs/restapi/views/core_views.py
@@ -10,6 +10,7 @@ from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 
 from core.utils import clean_url, cname_to_slug
+from builds.constants import LATEST
 from builds.models import Version
 from projects.models import Project
 from core.templatetags.core_tags import make_document_url
@@ -54,7 +55,7 @@ def docurl(request):
 
     """
     project = request.GET.get('project')
-    version = request.GET.get('version', 'latest')
+    version = request.GET.get('version', LATEST)
     doc = request.GET.get('doc', 'index')
 
     project = get_object_or_404(Project, slug=project)
@@ -87,7 +88,7 @@ def embed(request):
     # Current Request
     """
     project = request.GET.get('project')
-    version = request.GET.get('version', 'latest')
+    version = request.GET.get('version', LATEST)
     doc = request.GET.get('doc')
     section = request.GET.get('section')
 

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -11,6 +11,7 @@ from builds.filters import VersionFilter
 from builds.models import Build, Version
 from core.utils import trigger_build
 from oauth import utils as oauth_utils
+from builds.constants import STABLE
 from projects.filters import ProjectFilter
 from projects.models import Project, EmailHook
 from restapi.permissions import APIPermission
@@ -111,7 +112,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
                 new_stable = project.versions.get(verbose_name=new_stable_slug)
 
                 # Update stable version
-                stable = project.versions.filter(slug='stable').first()
+                stable = project.versions.filter(slug=STABLE).first()
                 if stable:
                     if (new_stable.identifier != stable.identifier) and (stable.machine is True):
                         stable.identifier = new_stable.identifier
@@ -120,7 +121,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
                         trigger_build(project=project, version=stable)
                 else:
                     log.info("Creating new stable version: {project}:{version}".format(project=project.slug, version=new_stable.identifier))
-                    version = project.versions.create(slug='stable', verbose_name='stable', machine=True, type=new_stable.type, active=True, identifier=new_stable.identifier)
+                    version = project.versions.create(slug=STABLE, verbose_name=STABLE_VERBOSE_NAME, machine=True, type=new_stable.type, active=True, identifier=new_stable.identifier)
                     trigger_build(project=project, version=version)
 
                 # Build new tag if enabled

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -121,7 +121,8 @@ class ProjectViewSet(viewsets.ModelViewSet):
                         trigger_build(project=project, version=stable)
                 else:
                     log.info("Creating new stable version: {project}:{version}".format(project=project.slug, version=new_stable.identifier))
-                    version = project.versions.create(slug=STABLE, verbose_name=STABLE_VERBOSE_NAME, machine=True, type=new_stable.type, active=True, identifier=new_stable.identifier)
+                    version = project.versions.create_stable(
+                        type=new_stable.type, identifier=new_stable.identifier)
                     trigger_build(project=project, version=version)
 
                 # Build new tag if enabled

--- a/readthedocs/restapi/views/search_views.py
+++ b/readthedocs/restapi/views/search_views.py
@@ -5,6 +5,7 @@ from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRe
 from rest_framework.response import Response
 import requests
 
+from builds.constants import LATEST
 from builds.models import Version
 from djangome import views as djangome
 from search.indexes import PageIndex, ProjectIndex, SectionIndex
@@ -20,7 +21,7 @@ log = logging.getLogger(__name__)
 @decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
 def quick_search(request):
     project_slug = request.GET.get('project', None)
-    version_slug = request.GET.get('version', 'latest')
+    version_slug = request.GET.get('version', LATEST)
     query = request.GET.get('q', None)
     redis_data = djangome.r.keys('redirects:v4:en:%s:%s:*%s*' % (version_slug, project_slug, query))
     ret_dict = {}
@@ -61,7 +62,7 @@ def index_search(request):
 @decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
 def search(request):
     project_slug = request.GET.get('project', None)
-    version_slug = request.GET.get('version', 'latest')
+    version_slug = request.GET.get('version', LATEST)
     query = request.GET.get('q', None)
     log.debug("(API Search) %s" % query)
 
@@ -177,7 +178,7 @@ def section_search(request):
         return Response({'error': 'Search term required. Use the "q" GET arg to search. '}, status=status.HTTP_400_BAD_REQUEST)
 
     project_slug = request.GET.get('project', None)
-    version_slug = request.GET.get('version', 'latest')
+    version_slug = request.GET.get('version', LATEST)
     path_slug = request.GET.get('path', None)
 
     log.debug("(API Section Search) [%s:%s] %s" % (project_slug, version_slug, query))

--- a/readthedocs/rtd_tests/tests/test_404.py
+++ b/readthedocs/rtd_tests/tests/test_404.py
@@ -2,9 +2,6 @@ import lxml.html
 
 from django.test import TestCase
 
-from builds.constants import LATEST
-from builds.constants import LATEST_VERBOSE_NAME
-from builds.models import Version
 from projects.models import Project
 
 
@@ -14,9 +11,7 @@ class Testmaker(TestCase):
     def setUp(self):
         self.client.login(username='eric', password='test')
         self.pip = Project.objects.get(slug='pip')
-        self.latest = Version.objects.create(project=self.pip, identifier=LATEST,
-                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
-                               active=True)
+        self.latest = self.pip.versions.create_latest()
         self.pip_es = Project.objects.create(name="PIP-ES", slug='pip-es', language='es', main_language_project=self.pip)
 
     def test_project_does_not_exist(self):

--- a/readthedocs/rtd_tests/tests/test_404.py
+++ b/readthedocs/rtd_tests/tests/test_404.py
@@ -2,6 +2,8 @@ import lxml.html
 
 from django.test import TestCase
 
+from builds.constants import LATEST
+from builds.constants import LATEST_VERBOSE_NAME
 from builds.models import Version
 from projects.models import Project
 
@@ -12,8 +14,8 @@ class Testmaker(TestCase):
     def setUp(self):
         self.client.login(username='eric', password='test')
         self.pip = Project.objects.get(slug='pip')
-        self.latest = Version.objects.create(project=self.pip, identifier='latest',
-                               verbose_name='latest', slug='latest',
+        self.latest = Version.objects.create(project=self.pip, identifier=LATEST,
+                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
                                active=True)
         self.pip_es = Project.objects.create(name="PIP-ES", slug='pip-es', language='es', main_language_project=self.pip)
 

--- a/readthedocs/rtd_tests/tests/test_betterversion.py
+++ b/readthedocs/rtd_tests/tests/test_betterversion.py
@@ -1,25 +1,25 @@
 import unittest
 
-from betterversion.better import version_windows, BetterVersion
+from betterversion.better import version_windows, VersionIdentifier
+
 
 class TestSequenceFunctions(unittest.TestCase):
-
     def setUp(self):
         self.versions = [
-            BetterVersion("0.1.0"),
-            BetterVersion("0.2.0"),
-            BetterVersion("0.2.1"),
-            BetterVersion("0.3.0"),
-            BetterVersion("0.3.1"),
-            BetterVersion("1.1.0"),
-            BetterVersion("1.2.0"),
-            BetterVersion("1.3.0"),
-            BetterVersion("2.1.0"),
-            BetterVersion("2.2.0"),
-            BetterVersion("2.3.0"),
-            BetterVersion("2.3.1"),
-            BetterVersion("2.3.2"),
-            BetterVersion("2.3.3"),
+            VersionIdentifier("0.1.0"),
+            VersionIdentifier("0.2.0"),
+            VersionIdentifier("0.2.1"),
+            VersionIdentifier("0.3.0"),
+            VersionIdentifier("0.3.1"),
+            VersionIdentifier("1.1.0"),
+            VersionIdentifier("1.2.0"),
+            VersionIdentifier("1.3.0"),
+            VersionIdentifier("2.1.0"),
+            VersionIdentifier("2.2.0"),
+            VersionIdentifier("2.3.0"),
+            VersionIdentifier("2.3.1"),
+            VersionIdentifier("2.3.2"),
+            VersionIdentifier("2.3.3"),
         ]
 
     def test_major(self):
@@ -65,40 +65,59 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEqual(len(point_versions[2][3]), 4)
 
     def test_sort(self):
-        final_versions = version_windows(self.versions, major=2, minor=2, point=1)
-        self.assertTrue(final_versions[1][2][0] == BetterVersion('1.2.0'))
-        self.assertTrue(final_versions[1][3][0] == BetterVersion('1.3.0'))
-        self.assertTrue(final_versions[2][3][0] == BetterVersion('2.3.3'))
-        self.assertTrue(final_versions[2][3][0] != BetterVersion('2.3.0'))
+        final_versions = version_windows(self.versions,
+                                         major=2, minor=2, point=1)
+        self.assertTrue(final_versions[1][2][0] == VersionIdentifier('1.2.0'))
+        self.assertTrue(final_versions[1][3][0] == VersionIdentifier('1.3.0'))
+        self.assertTrue(final_versions[2][3][0] == VersionIdentifier('2.3.3'))
+        self.assertTrue(final_versions[2][3][0] != VersionIdentifier('2.3.0'))
 
-        final_versions = version_windows(self.versions, major=1, minor=2, point=2)
+        final_versions = version_windows(self.versions,
+                                         major=1, minor=2, point=2)
         # 1 major version
         self.assertEqual(final_versions[1], {})
         # 2 minor versions
         self.assertEqual(len(final_versions[2]), 2)
         # 2 point versions
         self.assertEqual(len(final_versions[2][3]), 2)
-        final_versions = version_windows(self.versions, major=1, minor=2, point=3)
+        final_versions = version_windows(self.versions,
+                                         major=1, minor=2, point=3)
         # 2 point versions
         self.assertEqual(len(final_versions[2][3]), 3)
 
     def test_flat(self):
-        final_versions = version_windows(self.versions, major=2, minor=2, point=1, flat=True)
+        final_versions = version_windows(self.versions,
+                                         major=2, minor=2, point=1, flat=True)
         self.assertEqual(len(final_versions), 4)
         self.assertEqual(
             final_versions,
-            [BetterVersion('1.2.0'), BetterVersion('1.3.0'), BetterVersion('2.2.0'), BetterVersion('2.3.3')]
+            [
+                VersionIdentifier('1.2.0'),
+                VersionIdentifier('1.3.0'),
+                VersionIdentifier('2.2.0'),
+                VersionIdentifier('2.3.3')
+            ]
         )
 
-        final_versions = version_windows(self.versions, major=3, minor=2, point=1, flat=True)
+        final_versions = version_windows(self.versions,
+                                         major=3, minor=2, point=1, flat=True)
         self.assertEqual(len(final_versions), 6)
         self.assertEqual(
             final_versions,
-            [BetterVersion('0.2.1'), BetterVersion('0.3.1'), BetterVersion('1.2.0'), BetterVersion('1.3.0'), BetterVersion('2.2.0'), BetterVersion('2.3.3')]
+            [
+                VersionIdentifier('0.2.1'),
+                VersionIdentifier('0.3.1'),
+                VersionIdentifier('1.2.0'),
+                VersionIdentifier('1.3.0'),
+                VersionIdentifier('2.2.0'),
+                VersionIdentifier('2.3.3')
+            ]
         )
 
-        final_versions = version_windows(self.versions, major=3, minor=2, point=2, flat=True)
+        final_versions = version_windows(self.versions,
+                                         major=3, minor=2, point=2, flat=True)
         self.assertEqual(len(final_versions), 9)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/readthedocs/rtd_tests/tests/test_bookmarks.py
+++ b/readthedocs/rtd_tests/tests/test_bookmarks.py
@@ -3,6 +3,7 @@ from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 import json
 
+from builds.constants import LATEST
 from projects.models import Project
 from bookmarks.models import Bookmark
 
@@ -19,7 +20,7 @@ class TestBookmarks(TestCase):
     def __add_bookmark(self):
         post_data = {
             "project": self.project.slug,
-            "version": 'latest',
+            "version": LATEST,
             "page": "",
             "url": "",
         }

--- a/readthedocs/rtd_tests/tests/test_bookmarks.py
+++ b/readthedocs/rtd_tests/tests/test_bookmarks.py
@@ -81,7 +81,7 @@ class TestBookmarks(TestCase):
 
         post_data = {
             "project": self.project.slug,
-            "version": 'latest',
+            "version": LATEST,
             "page": "",
             "url": "",
         }

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from projects.models import Project
+from builds.constants import LATEST
 from builds.models import Version
 from core.templatetags import core_tags
 
@@ -152,24 +153,24 @@ class CoreTagsTests(TestCase):
     def test_mkdocs(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
-        url = core_tags.make_document_url(proj, 'latest', 'document')
+        url = core_tags.make_document_url(proj, LATEST, 'document')
         self.assertEqual(url, '/docs/pip/en/latest/document.html')
 
     def test_mkdocs_no_directory_urls(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
-        url = core_tags.make_document_url(proj, 'latest', 'document.html')
+        url = core_tags.make_document_url(proj, LATEST, 'document.html')
         self.assertEqual(url, '/docs/pip/en/latest/document.html')
 
     def test_mkdocs_index(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
-        url = core_tags.make_document_url(proj, 'latest', 'index')
+        url = core_tags.make_document_url(proj, LATEST, 'index')
         self.assertEqual(url, '/docs/pip/en/latest/')
 
     def test_mkdocs_index_no_directory_urls(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
-        url = core_tags.make_document_url(proj, 'latest', 'index.html')
+        url = core_tags.make_document_url(proj, LATEST, 'index.html')
         self.assertEqual(url, '/docs/pip/en/latest/')
 

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -2,9 +2,6 @@ import json
 
 from django.test import TestCase
 
-from builds.constants import LATEST
-from builds.constants import LATEST_VERBOSE_NAME
-from builds.models import Version
 from projects.models import Project
 
 
@@ -14,9 +11,7 @@ class Testmaker(TestCase):
     def setUp(self):
         self.client.login(username='eric', password='test')
         self.pip = Project.objects.get(slug='pip')
-        self.latest = Version.objects.create(project=self.pip, identifier=LATEST,
-                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
-                               active=True)
+        self.latest = self.pip.versions.create_latest()
 
     def test_footer(self):
         r = self.client.get('/api/v2/footer_html/?project=pip&version=latest&page=index', {})

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -2,6 +2,8 @@ import json
 
 from django.test import TestCase
 
+from builds.constants import LATEST
+from builds.constants import LATEST_VERBOSE_NAME
 from builds.models import Version
 from projects.models import Project
 
@@ -12,8 +14,8 @@ class Testmaker(TestCase):
     def setUp(self):
         self.client.login(username='eric', password='test')
         self.pip = Project.objects.get(slug='pip')
-        self.latest = Version.objects.create(project=self.pip, identifier='latest',
-                               verbose_name='latest', slug='latest',
+        self.latest = Version.objects.create(project=self.pip, identifier=LATEST,
+                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
                                active=True)
 
     def test_footer(self):

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.contrib.auth.models import User
 
+from builds.constants import LATEST
 from builds.models import Version
 from projects.models import Project
 from projects.forms import UpdateProjectForm
@@ -40,7 +41,7 @@ class PrivacyTests(TestCase):
                   'language': 'en',
                   'default_branch': '',
                   'project_url': 'http://django-kong.rtfd.org',
-                  'default_version': 'latest',
+                  'default_version': LATEST,
                   'python_interpreter': 'python',
                   'description': 'OOHHH AH AH AH KONG SMASH',
                   'documentation_type': 'sphinx'},

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -2,8 +2,6 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from builds.constants import LATEST
-from builds.constants import LATEST_VERBOSE_NAME
-from builds.models import Version
 from projects.models import Project
 from redirects.models import Redirect
 
@@ -29,9 +27,7 @@ class RedirectTests(TestCase):
              'description': 'wat',
              'documentation_type': 'sphinx'})
         pip = Project.objects.get(slug='pip')
-        Version.objects.create(project=pip, identifier=LATEST,
-                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
-                               active=True)
+        pip.versions.create_latest()
 
     def test_proper_url_no_slash(self):
         r = self.client.get('/docs/pip')
@@ -198,9 +194,7 @@ class RedirectAppTests(TestCase):
              'description': 'wat',
              'documentation_type': 'sphinx'})
         self.pip = Project.objects.get(slug='pip')
-        Version.objects.create(project=self.pip, identifier=LATEST,
-                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
-                               active=True)
+        self.pip.versions.create_latest()
 
     @override_settings(USE_SUBDOMAIN=True)
     def test_redirect_root(self):

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from builds.constants import LATEST
+from builds.constants import LATEST_VERBOSE_NAME
 from builds.models import Version
 from projects.models import Project
 from redirects.models import Redirect
@@ -21,14 +23,14 @@ class RedirectTests(TestCase):
              'project_url': 'http://pip.rtfd.org',
              'repo': 'https://github.com/fail/sauce',
              'csrfmiddlewaretoken': '34af7c8a5ba84b84564403a280d9a9be',
-             'default_version': 'latest',
+             'default_version': LATEST,
              'privacy_level': 'public',
              'version_privacy_level': 'public',
              'description': 'wat',
              'documentation_type': 'sphinx'})
         pip = Project.objects.get(slug='pip')
-        Version.objects.create(project=pip, identifier='latest',
-                               verbose_name='latest', slug='latest',
+        Version.objects.create(project=pip, identifier=LATEST,
+                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
                                active=True)
 
     def test_proper_url_no_slash(self):
@@ -190,14 +192,14 @@ class RedirectAppTests(TestCase):
              'project_url': 'http://pip.rtfd.org',
              'repo': 'https://github.com/fail/sauce',
              'csrfmiddlewaretoken': '34af7c8a5ba84b84564403a280d9a9be',
-             'default_version': 'latest',
+             'default_version': LATEST,
              'privacy_level': 'public',
              'version_privacy_level': 'public',
              'description': 'wat',
              'documentation_type': 'sphinx'})
         self.pip = Project.objects.get(slug='pip')
-        Version.objects.create(project=self.pip, identifier='latest',
-                               verbose_name='latest', slug='latest',
+        Version.objects.create(project=self.pip, identifier=LATEST,
+                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
                                active=True)
 
     @override_settings(USE_SUBDOMAIN=True)

--- a/readthedocs/rtd_tests/tests/test_repo_parsing.py
+++ b/readthedocs/rtd_tests/tests/test_repo_parsing.py
@@ -2,6 +2,8 @@ import json
 
 from django.test import TestCase
 
+from builds.constants import LATEST
+from builds.constants import LATEST_VERBOSE_NAME
 from builds.models import Version
 from projects.models import Project
 
@@ -12,8 +14,8 @@ class TestRepoParsing(TestCase):
     def setUp(self):
         self.client.login(username='eric', password='test')
         self.pip = Project.objects.get(slug='pip')
-        self.version = Version.objects.create(project=self.pip, identifier='latest',
-                               verbose_name='latest', slug='latest',
+        self.version = Version.objects.create(project=self.pip, identifier=LATEST,
+                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
                                active=True)
 
     def test_github(self):

--- a/readthedocs/rtd_tests/tests/test_repo_parsing.py
+++ b/readthedocs/rtd_tests/tests/test_repo_parsing.py
@@ -2,9 +2,6 @@ import json
 
 from django.test import TestCase
 
-from builds.constants import LATEST
-from builds.constants import LATEST_VERBOSE_NAME
-from builds.models import Version
 from projects.models import Project
 
 
@@ -14,9 +11,7 @@ class TestRepoParsing(TestCase):
     def setUp(self):
         self.client.login(username='eric', password='test')
         self.pip = Project.objects.get(slug='pip')
-        self.version = Version.objects.create(project=self.pip, identifier=LATEST,
-                               verbose_name=LATEST_VERBOSE_NAME, slug=LATEST,
-                               active=True)
+        self.version = self.pip.versions.create_latest()
 
     def test_github(self):
         self.pip.repo = 'https://github.com/user/repo'

--- a/readthedocs/rtd_tests/tests/test_single_version.py
+++ b/readthedocs/rtd_tests/tests/test_single_version.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from builds.constants import LATEST
 from builds.models import Version
 from projects.models import Project
 
@@ -16,7 +17,7 @@ class RedirectSingleVersionTests(TestCase):
         self.assertTrue(Project.objects.get(name='Pip').single_version)
 
     def test_test_case_version_exists(self):
-        self.assertTrue(Version.objects.filter(project__name__exact='Pip').get(slug='latest'))
+        self.assertTrue(Version.objects.filter(project__name__exact='Pip').get(slug=LATEST))
 
     def test_proper_single_version_url_full_with_filename(self):
         r = self.client.get('/docs/pip/usage.html')

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -81,6 +81,116 @@ class TestSyncVersions(TestCase):
         self.assertTrue(version_stable.active)
         self.assertEqual(version_stable.identifier, '0.9')
 
+    def test_update_stable_version(self):
+        version_post_data = {
+            'branches': [
+                {
+                    'identifier': 'origin/master',
+                    'verbose_name': 'master',
+                },
+            ],
+            'tags': [
+                {
+                    'identifier': '0.9',
+                    'verbose_name': '0.9',
+                },
+                {
+                    'identifier': '0.8',
+                    'verbose_name': '0.8',
+                },
+            ]
+        }
+
+        self.client.post(
+            '/api/v2/project/%s/sync_versions/' % self.pip.pk,
+            data=json.dumps(version_post_data),
+            content_type='application/json',
+        )
+
+        version_stable = Version.objects.get(slug=STABLE)
+        self.assertTrue(version_stable.active)
+        self.assertEqual(version_stable.identifier, '0.9')
+
+        version_post_data = {
+            'tags': [
+                {
+                    'identifier': '1.0.0',
+                    'verbose_name': '1.0.0',
+                },
+            ]
+        }
+
+        self.client.post(
+            '/api/v2/project/%s/sync_versions/' % self.pip.pk,
+            data=json.dumps(version_post_data),
+            content_type='application/json',
+        )
+
+        version_stable = Version.objects.get(slug=STABLE)
+        self.assertTrue(version_stable.active)
+        self.assertEqual(version_stable.identifier, '1.0.0')
+
+        version_post_data = {
+            'tags': [
+                {
+                    'identifier': '0.7',
+                    'verbose_name': '0.7',
+                },
+            ]
+        }
+
+        self.client.post(
+            '/api/v2/project/%s/sync_versions/' % self.pip.pk,
+            data=json.dumps(version_post_data),
+            content_type='application/json',
+        )
+
+        version_stable = Version.objects.get(slug=STABLE)
+        self.assertTrue(version_stable.active)
+        self.assertEqual(version_stable.identifier, '1.0.0')
+
+    def test_update_inactive_stable_version(self):
+        version_post_data = {
+            'branches': [
+                {
+                    'identifier': 'origin/master',
+                    'verbose_name': 'master',
+                },
+            ],
+            'tags': [
+                {
+                    'identifier': '0.9',
+                    'verbose_name': '0.9',
+                },
+            ]
+        }
+
+        self.client.post(
+            '/api/v2/project/%s/sync_versions/' % self.pip.pk,
+            data=json.dumps(version_post_data),
+            content_type='application/json',
+        )
+
+        version_stable = Version.objects.get(slug=STABLE)
+        self.assertEqual(version_stable.identifier, '0.9')
+        version_stable.active = False
+        version_stable.save()
+
+        version_post_data['tags'].append({
+            'identifier': '1.0.0',
+            'verbose_name': '1.0.0',
+        })
+
+        self.client.post(
+            '/api/v2/project/%s/sync_versions/' % self.pip.pk,
+            data=json.dumps(version_post_data),
+            content_type='application/json',
+        )
+
+        version_stable = Version.objects.get(slug=STABLE)
+        self.assertFalse(version_stable.active)
+        self.assertEqual(version_stable.identifier, '1.0.0')
+
     def test_new_tag_update_active(self):
 
         Version.objects.create(project=self.pip, identifier='0.8.3',

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -3,6 +3,7 @@ import json
 from django.test import TestCase
 
 from builds.models import Version
+from builds.constants import STABLE
 from projects.models import Project
 
 
@@ -69,14 +70,14 @@ class TestSyncVersions(TestCase):
         self.assertRaises(
             Version.DoesNotExist,
             Version.objects.get,
-            slug='stable'
+            slug=STABLE
         )
         self.client.post(
             '/api/v2/project/%s/sync_versions/' % self.pip.pk,
             data=json.dumps(version_post_data),
             content_type='application/json',
         )
-        version_stable = Version.objects.get(slug='stable')
+        version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
         self.assertEqual(version_stable.identifier, '0.9')
 

--- a/readthedocs/rtd_tests/tests/test_urls.py
+++ b/readthedocs/rtd_tests/tests/test_urls.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 from django.core.urlresolvers import NoReverseMatch
 from django.test import TestCase
 
+from builds.constants import LATEST
 import core.views
 
 class SubdomainUrlTests(TestCase):
@@ -13,7 +14,7 @@ class SubdomainUrlTests(TestCase):
 
     def test_sub_lang_version(self):
         url = reverse('docs_detail', urlconf='core.subdomain_urls',
-            kwargs={'lang_slug': 'en', 'version_slug': 'latest'})
+            kwargs={'lang_slug': 'en', 'version_slug': LATEST})
         self.assertEqual(url, '/en/latest/')
 
     def test_sub_lang_version_filename(self):
@@ -25,7 +26,7 @@ class SubdomainUrlTests(TestCase):
         url = reverse('subproject_docs_detail',
             urlconf='core.subdomain_urls',
             kwargs={'project_slug':'pyramid', 'lang_slug': 'en',
-                    'version_slug':'latest', 'filename': 'index.html'})
+                    'version_slug': LATEST, 'filename': 'index.html'})
         self.assertEqual(url, '/projects/pyramid/en/latest/index.html')
 
     def test_sub_project_slug_only(self):

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 
+from builds.constants import LATEST
 from projects.models import Project
 from projects.forms import UpdateProjectForm
 
@@ -24,7 +25,7 @@ class Testmaker(TestCase):
             'language': 'en',
             'default_branch': '',
             'project_url': 'http://django-kong.rtfd.org',
-            'default_version': 'latest',
+            'default_version': LATEST,
             'privacy_level': 'public',
             'version_privacy_level': 'public',
             'python_interpreter': 'python',

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -1,3 +1,4 @@
+from builds.constants import LATEST
 from .indexes import ProjectIndex, PageIndex
 
 # Hack around django requiring a specific import path for signals >:x
@@ -42,7 +43,7 @@ def search_project(request, query, language):
     return ProjectIndex().search(body)
 
 
-def search_file(request, query, project=None, version='latest', taxonomy=None):
+def search_file(request, query, project=None, version=LATEST, taxonomy=None):
 
     kwargs = {}
     body = {

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -19,6 +19,7 @@ from django.views.static import serve
 from taggit.models import Tag
 import requests
 
+from builds.constants import LATEST
 from builds.filters import VersionSlugFilter
 from builds.models import Version
 from projects.models import Project, ImportedFile
@@ -38,7 +39,7 @@ def elastic_search(request):
     type = request.GET.get('type', 'project')
     # File Facets
     project = request.GET.get('project')
-    version = request.GET.get('version', 'latest')
+    version = request.GET.get('version', LATEST)
     taxonomy = request.GET.get('taxonomy')
     language = request.GET.get('language')
     results = ""


### PR DESCRIPTION
Here are some improvements that I made while investigating #1052.
The breakdown is:

* Remove magic constants like `'stable'` and `'latest'` and use a defined constant instead.
* Add `create_stable` / `create_latest` manager methods for easier creation of versions.
* `BetterVersion` is a terrible name IMO :) It should more say about what it actually is. I renamed it to `VersionIdentifier`.
* Added tests that should provide more insight for #1052. Unfortunatelly they didn't. The tests might still be useful to have in the suite.