### PR TITLE
Upgrade MkDocs to 0.14

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -334,7 +334,7 @@ def setup_environment(version):
         'virtualenv==1.10.1',
         'setuptools==1.1',
         'docutils==0.11',
-        'mkdocs==0.13.3',
+        'mkdocs==0.14.0',
         'mock==1.0.1',
         'pillow==2.6.1',
         'readthedocs-sphinx-ext==0.5.4',

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -13,7 +13,7 @@ virtualenv==1.11.6
 docutils==0.11
 Sphinx==1.3.1
 Pygments==2.0.2
-mkdocs==0.13.3
+mkdocs==0.14.0
 
 django==1.6.11
 django-tastypie==0.11.1


### PR DESCRIPTION
This is primarilly a bug fix release. It would have been a 0.13.4 but we
*dropped* two requirements that caused problems and felt that was
sufficient reason to release a 0.14 version.

Fixes #1373