### PR TITLE
Updating bzr to 2.6 and removing --allow-unverified flag from requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
  - "2.7"
 install:
  - pip install flake8 stripe
- - pip install --allow-all-external --allow-unverified bzr --allow-unverified launchpadlib --allow-unverified lazr.authentication -r requirements.txt
+ - pip install -r requirements.txt
  - pip install coveralls
 script:
  #- flake8 `find . -iname "*.py" -not -ipath "*migration*"`

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,12 +1,3 @@
-# Hack around bzr hosting
-
---allow-external bzr
---allow-unverified bzr
---allow-external launchpadlib
---allow-unverified launchpadlib
---allow-external lazr.authentication
---allow-unverified lazr.authentication
-
 ## Upgraded packages
 pip==6.1.1
 virtualenv==1.11.6

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -37,7 +37,7 @@ django-celery==3.0.23
 django-allauth==0.16.1
 
 # VCS
-bzr==2.5b4
+bzr==2.6
 mercurial==2.6.3
 github2==0.5.2
 httplib2==0.7.7


### PR DESCRIPTION
As mentioned in #1369 the 2.5b4 version of bzr can make problems as it is not available on PyPI. The 2.6 version however is. I assume it's save to upgrade to the newer version based on this line from the [release notes](http://doc.bazaar.canonical.com/bzr.2.6/en/whats-new/whats-new-in-2.6.html):

> Bazaar 2.6.0 is fully compatible both locally and on the network with 2.0, 2.1, 2.2, 2.3, 2.4 and 2.5, and can read and write repositories generated by all previous versions.

I also removed the `--allow-external` and `--allow-unverified` flags from requirements files as they might introduce security risks. The installation still works as the Travis builds will show.