### PR TITLE
Fixed #1353 -- Removing broken (Help) link from versions page.

### DIFF
--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -30,10 +30,6 @@ Versions
 
   <div class="project-version-list">
 
-        <div id="help_container">
-          <a href="#" class="quiet readthedocs-help-embed">(Help)</a>
-        </div>
-
     <div class="module project-versions-active">
       <div class="module-wrapper">
         <h1>{% trans "Active Versions" %}</h1>


### PR DESCRIPTION
Ya. It's all in the heading and fixes #1353