### PR TITLE
feat(project): Make repo URL a clickable URL.

### DIFF
--- a/readthedocs/templates/core/project_detail_right.html
+++ b/readthedocs/templates/core/project_detail_right.html
@@ -6,7 +6,7 @@
 
   {% if project.repo %}
     <h3>{% trans "Repository" %}</h3>
-    <p class="detail-long">{{ project.repo }}</p>
+    <p class="detail-long">{{ project.repo|urlize }}</p>
   {% endif %}
 
   <h3>{% trans "Last Built" %}</h3>


### PR DESCRIPTION
Make the repository URL that appears along the right side of the project
page a clickable URL using Django's urlize filter. This filter will only
make a clickable link if the repository URL is a valid HTTP address.

Closes #379