### PR TITLE
Fix slug generation for uppercase branch names

### DIFF
--- a/readthedocs/builds/migrations/0024_fix_slugs_with_leading_placeholders.py
+++ b/readthedocs/builds/migrations/0024_fix_slugs_with_leading_placeholders.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName".
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+
+        Version = orm['builds.Version']
+        slug_field = Version._meta.get_field_by_name('slug')[0]
+
+        bad_slug = Version.objects.exclude(
+            slug__regex=r'^[a-z0-9][-._a-z0-9]+$')
+        for version in bad_slug:
+            version.slug = slug_field.create_slug(version)
+            version.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+        # No backwards operation possible.
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'builds.build': {
+            'Meta': {'ordering': "['-date']", 'object_name': 'Build'},
+            'builder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'commit': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'error': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'exit_code': ('django.db.models.fields.IntegerField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'length': ('django.db.models.fields.IntegerField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'output': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'builds'", 'to': u"orm['projects.Project']"}),
+            'setup': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'setup_error': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'finished'", 'max_length': '55'}),
+            'success': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'html'", 'max_length': '55'}),
+            'version': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'builds'", 'null': 'True', 'to': u"orm['builds.Version']"})
+        },
+        u'builds.version': {
+            'Meta': {'ordering': "['-verbose_name']", 'unique_together': "[('project', 'slug')]", 'object_name': 'Version'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'built': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identifier': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'machine': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'privacy_level': ('django.db.models.fields.CharField', [], {'default': "'public'", 'max_length': '20'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'versions'", 'to': u"orm['projects.Project']"}),
+            'slug': ('builds.version_slug.VersionSlugField', [], {'max_length': '255', 'populate_from': "'verbose_name'", 'db_index': 'True'}),
+            'supported': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'unknown'", 'max_length': '20'}),
+            'uploaded': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'verbose_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'builds.versionalias': {
+            'Meta': {'object_name': 'VersionAlias'},
+            'from_slug': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'largest': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'aliases'", 'to': u"orm['projects.Project']"}),
+            'to_slug': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'projects.project': {
+            'Meta': {'ordering': "('slug',)", 'object_name': 'Project'},
+            'allow_comments': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'analytics_code': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'canonical_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'comment_moderation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'conf_py_file': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
+            'copyright': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'default_branch': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_version': ('django.db.models.fields.CharField', [], {'default': "'latest'", 'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'django_packages_url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'documentation_type': ('django.db.models.fields.CharField', [], {'default': "'auto'", 'max_length': '20'}),
+            'enable_epub_build': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'enable_pdf_build': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '20'}),
+            'main_language_project': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'translations'", 'null': 'True', 'to': u"orm['projects.Project']"}),
+            'mirror': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'num_major': ('django.db.models.fields.IntegerField', [], {'default': '2', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'num_minor': ('django.db.models.fields.IntegerField', [], {'default': '2', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'num_point': ('django.db.models.fields.IntegerField', [], {'default': '2', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'privacy_level': ('django.db.models.fields.CharField', [], {'default': "'public'", 'max_length': '20'}),
+            'programming_language': ('django.db.models.fields.CharField', [], {'default': "'words'", 'max_length': '20', 'blank': 'True'}),
+            'project_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'python_interpreter': ('django.db.models.fields.CharField', [], {'default': "'python'", 'max_length': '20'}),
+            'related_projects': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['projects.Project']", 'null': 'True', 'through': u"orm['projects.ProjectRelationship']", 'blank': 'True'}),
+            'repo': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'repo_type': ('django.db.models.fields.CharField', [], {'default': "'git'", 'max_length': '10'}),
+            'requirements_file': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'single_version': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'skip': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'suffix': ('django.db.models.fields.CharField', [], {'default': "'.rst'", 'max_length': '10'}),
+            'theme': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '20'}),
+            'use_system_packages': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'use_virtualenv': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'projects'", 'symmetrical': 'False', 'to': u"orm['auth.User']"}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'version_privacy_level': ('django.db.models.fields.CharField', [], {'default': "'public'", 'max_length': '20'})
+        },
+        u'projects.projectrelationship': {
+            'Meta': {'object_name': 'ProjectRelationship'},
+            'child': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'superprojects'", 'to': u"orm['projects.Project']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subprojects'", 'to': u"orm['projects.Project']"})
+        }
+    }
+
+    complete_apps = ['builds']
+    symmetrical = True

--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -41,8 +41,10 @@ class VersionSlugField(models.CharField):
     Implementation inspired by ``django_extensions.db.fields.AutoSlugField``.
     """
 
-    allowed_chars = string.lowercase + string.digits + '-._'
+    allowed_punctuation = '-._'
+    allowed_chars = string.lowercase + string.digits + allowed_punctuation
     placeholder = '-'
+    fallback_slug = 'unkown'
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('db_index', True)
@@ -70,6 +72,18 @@ class VersionSlugField(models.CharField):
                 slugified += self.placeholder
             else:
                 slugified += char
+
+        # Do not start and end in punctuation.
+        slug_length = len(slugified)
+        diff = 1
+        while diff > 0:
+            for char in self.allowed_punctuation:
+                slugified = slugified.strip(char)
+            diff = slug_length - len(slugified)
+            slug_length = len(slugified)
+
+        if not slugified:
+            return self.fallback_slug
         return slugified
 
     def uniquifying_suffix(self, iteration):

--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -33,9 +33,6 @@ from django.utils.encoding import force_text
 VERSION_SLUG_REGEX = '(?:[a-z0-9][-._a-z0-9]+?)'
 
 
-version_slug_regex = re.compile(VERSION_SLUG_REGEX)
-
-
 class VersionSlugField(models.CharField):
     """
     Implementation inspired by ``django_extensions.db.fields.AutoSlugField``.
@@ -45,6 +42,7 @@ class VersionSlugField(models.CharField):
     allowed_chars = string.lowercase + string.digits + allowed_punctuation
     placeholder = '-'
     fallback_slug = 'unkown'
+    test_pattern = re.compile('^{pattern}$'.format(pattern=VERSION_SLUG_REGEX))
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('db_index', True)
@@ -154,6 +152,8 @@ class VersionSlugField(models.CharField):
             slug = slug + end
             kwargs[self.attname] = slug
             next += 1
+        assert self.test_pattern.match(slug), (
+            'Invalid generated slug: {slug}'.format(slug=slug))
         return slug
 
     def pre_save(self, model_instance, add):

--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -64,6 +64,7 @@ class VersionSlugField(models.CharField):
         if not content:
             return ''
         slugified = ''
+        content = content.lower()
         for char in content:
             if char not in self.allowed_chars:
                 slugified += self.placeholder

--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -41,7 +41,7 @@ class VersionSlugField(models.CharField):
     allowed_punctuation = '-._'
     allowed_chars = string.lowercase + string.digits + allowed_punctuation
     placeholder = '-'
-    fallback_slug = 'unkown'
+    fallback_slug = 'unknown'
     test_pattern = re.compile('^{pattern}$'.format(pattern=VERSION_SLUG_REGEX))
 
     def __init__(self, *args, **kwargs):

--- a/readthedocs/rtd_tests/tests/test_version_slug.py
+++ b/readthedocs/rtd_tests/tests/test_version_slug.py
@@ -29,6 +29,12 @@ class VersionSlugFieldTests(TestCase):
             project=self.pip)
         self.assertEqual(version.slug, 'releases-1.0')
 
+    def test_uppercase(self):
+        version = Version.objects.create(
+            verbose_name='SomeString-charclass',
+            project=self.pip)
+        self.assertEqual(version.slug, 'somestring-charclass')
+
     def test_uniqueness(self):
         version = Version.objects.create(
             verbose_name='1!0',

--- a/readthedocs/rtd_tests/tests/test_version_slug.py
+++ b/readthedocs/rtd_tests/tests/test_version_slug.py
@@ -35,6 +35,23 @@ class VersionSlugFieldTests(TestCase):
             project=self.pip)
         self.assertEqual(version.slug, 'somestring-charclass')
 
+    def test_placeholder_as_name(self):
+        version = Version.objects.create(
+            verbose_name='-',
+            project=self.pip)
+        self.assertEqual(version.slug, 'unkown')
+
+    def test_multiple_empty_names(self):
+        version = Version.objects.create(
+            verbose_name='-',
+            project=self.pip)
+        self.assertEqual(version.slug, 'unkown')
+
+        version = Version.objects.create(
+            verbose_name='-./.-',
+            project=self.pip)
+        self.assertEqual(version.slug, 'unkown_a')
+
     def test_uniqueness(self):
         version = Version.objects.create(
             verbose_name='1!0',

--- a/readthedocs/rtd_tests/tests/test_version_slug.py
+++ b/readthedocs/rtd_tests/tests/test_version_slug.py
@@ -39,18 +39,18 @@ class VersionSlugFieldTests(TestCase):
         version = Version.objects.create(
             verbose_name='-',
             project=self.pip)
-        self.assertEqual(version.slug, 'unkown')
+        self.assertEqual(version.slug, 'unknown')
 
     def test_multiple_empty_names(self):
         version = Version.objects.create(
             verbose_name='-',
             project=self.pip)
-        self.assertEqual(version.slug, 'unkown')
+        self.assertEqual(version.slug, 'unknown')
 
         version = Version.objects.create(
             verbose_name='-./.-',
             project=self.pip)
-        self.assertEqual(version.slug, 'unkown_a')
+        self.assertEqual(version.slug, 'unknown_a')
 
     def test_uniqueness(self):
         version = Version.objects.create(


### PR DESCRIPTION
There is another issue with slugs that was raised in #1176. The current implementation turns uppercase letters into dashes so that `SomeChar-charclass` as branch name results in `-ome-har-charclass` as slug. However our regex in the URLs don't allow leading dashes.

This PR changes the algorithm to strip punctuation from the generated slug. It includes a migration to fix the currently broken slugs. I tested locally that pypy's version page works after applying it.