### PR TITLE
fix(migration): Use valid column type for MariaDB.

### DIFF
--- a/readthedocs/builds/migrations/0008_fix_aliases.py
+++ b/readthedocs/builds/migrations/0008_fix_aliases.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
 
         # Changing field 'VersionAlias.slug'
-        db.alter_column('builds_versionalias', 'slug', self.gf('django.db.models.fields.TextField')(max_length=255))
+        db.alter_column('builds_versionalias', 'slug', self.gf('django.db.models.fields.CharField')(max_length=255))
 
     def backwards(self, orm):
 


### PR DESCRIPTION
When running database migrations using a MariaDB backend, the migration
fails due to an issue related to
(https://code.djangoproject.com/ticket/2495).

Closes #1398 