### PR TITLE
Removing unused core.utils.make_latest

### DIFF
--- a/readthedocs/core/utils.py
+++ b/readthedocs/core/utils.py
@@ -35,25 +35,6 @@ def run_on_app_servers(command):
         return ret
 
 
-def make_latest(project):
-    """
-    Useful for correcting versions with no latest, using the database.
-
-    >>> no_latest = Project.objects.exclude(versions__slug__in=['latest'])
-    >>> for project in no_latest:
-    >>>     make_latest(project)
-    """
-    branch = project.default_branch or project.vcs_repo().fallback_branch
-    version_data, created = Version.objects.get_or_create(
-        project=project,
-        slug=LATEST,
-        type='branch',
-        active=True,
-        verbose_name=LATEST_VERBOSE_NAME,
-        identifier=branch,
-    )
-
-
 def clean_url(url):
     parsed = urlparse(url)
     if parsed.scheme:


### PR DESCRIPTION
It was in there but was actually never used anywhere in the history of the project:

```
(readthedocs.org) gregor@layka ~/projects/readthedocs.org (git)-[master] % git log -Smake_latest -p
commit b7ac78737f73f7d998d1234e3eb9e5fdd8539276
Author: Eric Holscher <eric@ericholscher.com>
Date:   Tue May 13 18:00:35 2014 -0700

    Add basic make_latest util

diff --git a/readthedocs/core/utils.py b/readthedocs/core/utils.py
index 3aa81c6..4bba334 100644
--- a/readthedocs/core/utils.py
+++ b/readthedocs/core/utils.py
@@ -105,3 +105,21 @@ def run_on_app_servers(command):
     else:
         ret = os.system(command)
         return ret
+
+def make_latest(project):
+    """
+    Useful for correcting versions with no latest, using the database.
+
+    >>> no_latest = Project.objects.exclude(versions__slug__in=['latest'])
+    >>> for project in no_latest:
+    >>>     make_latest(project)
+    """
+    branch = project.default_branch or project.vcs_repo().fallback_branch
+    version_data, created = Version.objects.get_or_create(
+        project=project,
+        slug='latest',
+        type='branch',
+        active=True,
+        verbose_name='latest',
+        identifier=branch,
+    )
```

 We already have the `Version.objects.create_latest`.