### PR TITLE
Use ATOMIC_REQUESTS=True to wrap every django request in a database transaction

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -92,6 +92,8 @@ SECRET_KEY = 'replace-this-please'
 ACCOUNT_ACTIVATION_DAYS = 7
 
 
+ATOMIC_REQUESTS = True
+
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',


### PR DESCRIPTION
I think it is a good practice to wrap every request in a transaction. I think we already have lots of places in the codebase that do not explicitly run in a transaction which makes it possible that a requests aborts in the middle (for example in case of an exception) and leaves the DB in an inconsistent state as we might have already processed some, but not all incoming data.

The [django documentation states](https://docs.djangoproject.com/en/1.7/topics/db/transactions/#tying-transactions-to-http-requests) that this might impact performance a bit depending on the used database.

So I'm not sure if that really is the perfect option for readthedocs, but I think we make everything a little more predictable that way :)