### PR TITLE
fix(sphinx):adding check for PYTHONHOME

### DIFF
--- a/readthedocs/projects/utils.py
+++ b/readthedocs/projects/utils.py
@@ -69,6 +69,10 @@ def run(*commands, **kwargs):
         del environment['DJANGO_SETTINGS_MODULE']
     if 'PYTHONPATH' in environment:
         del environment['PYTHONPATH']
+    # Remove PYTHONHOME env variable if set, otherwise pip install of requirements
+    # into virtualenv will install incorrectly
+    if 'PYTHONHOME' in environment:
+        del environment['PYTHONHOME']
     cwd = os.getcwd()
     if not commands:
         raise ValueError("run() requires one or more command-line strings")


### PR DESCRIPTION
Closes #1403 

This fixes an issue installing sphinx and setting the virtualenv when the env variable `PYTHONHOME` exists. Currently there is a check for `PYTHONPATH`, but not for `PYTHONHOME`.