### PR TITLE
Update version slug to match single characters

### DIFF
--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -30,7 +30,7 @@ from django.utils.encoding import force_text
 #   +? -- allow multiple of those, but be not greedy about the matching
 #   (?: ... ) -- wrap everything so that the pattern cannot escape when used in
 #                regexes.
-VERSION_SLUG_REGEX = '(?:[a-z0-9][-._a-z0-9]+?)'
+VERSION_SLUG_REGEX = '(?:[a-z0-9][-._a-z0-9]*)'
 
 
 class VersionSlugField(models.CharField):

--- a/readthedocs/rtd_tests/tests/test_version_slug.py
+++ b/readthedocs/rtd_tests/tests/test_version_slug.py
@@ -52,6 +52,12 @@ class VersionSlugFieldTests(TestCase):
             project=self.pip)
         self.assertEqual(version.slug, 'unknown_a')
 
+    def test_single_letter(self):
+        version = Version.objects.create(
+            verbose_name='v',
+            project=self.pip)
+        self.assertEqual(version.slug, 'v')
+
     def test_uniqueness(self):
         version = Version.objects.create(
             verbose_name='1!0',


### PR DESCRIPTION
Change pattern to accept single leading letter, followed by any number of valid characters. Adds regression test.

Fixes #1405