### PR TITLE
Allow single char version slugs.

### DIFF
--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -27,10 +27,10 @@ from django.utils.encoding import force_text
 # Regex breakdown:
 #   [a-z0-9] -- start with alphanumeric value
 #   [-._a-z0-9] -- allow dash, dot, underscore, digit, lowercase ascii
-#   +? -- allow multiple of those, but be not greedy about the matching
+#   *? -- allow multiple of those, but be not greedy about the matching
 #   (?: ... ) -- wrap everything so that the pattern cannot escape when used in
 #                regexes.
-VERSION_SLUG_REGEX = '(?:[a-z0-9][-._a-z0-9]+?)'
+VERSION_SLUG_REGEX = '(?:[a-z0-9][-._a-z0-9]*?)'
 
 
 class VersionSlugField(models.CharField):

--- a/readthedocs/rtd_tests/tests/test_version_slug.py
+++ b/readthedocs/rtd_tests/tests/test_version_slug.py
@@ -1,8 +1,28 @@
+import re
 from django.test import TestCase
 
 from builds.models import Version
 from builds.version_slug import VersionSlugField
+from builds.version_slug import VERSION_SLUG_REGEX
 from projects.models import Project
+
+
+class VersionSlugPatternTests(TestCase):
+    pattern = re.compile('^{pattern}$'.format(pattern=VERSION_SLUG_REGEX))
+
+    def test_single_char(self):
+        self.assertTrue(self.pattern.match('v'))
+        self.assertFalse(self.pattern.match('.'))
+
+    def test_trailing_punctuation(self):
+        self.assertTrue(self.pattern.match('with_'))
+        self.assertTrue(self.pattern.match('with.'))
+        self.assertTrue(self.pattern.match('with-'))
+        self.assertFalse(self.pattern.match('with!'))
+
+    def test_multiple_words(self):
+        self.assertTrue(self.pattern.match('release-1.0'))
+        self.assertTrue(self.pattern.match('fix_this-and-that.'))
 
 
 class VersionSlugFieldTests(TestCase):


### PR DESCRIPTION
The version slug regex was previously not allowing single char slugs. This PR fixes that and is adding appropriate tests.

Closes #1405.