### PR TITLE
Add basic maintenance mode page

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -108,6 +108,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'pagination.middleware.PaginationMiddleware',
+    'maintenancemode.middleware.MaintenanceModeMiddleware',
     # Hack
     # 'core.underscore_middleware.UnderscoreMiddleware',
     'core.middleware.SubdomainMiddleware',
@@ -285,6 +286,11 @@ ANONYMOUS_USER_ID = -1
 # Stripe
 STRIPE_SECRET = None
 STRIPE_PUBLISHABLE = None
+
+# Maintenance
+MAINTENANCE_IGNORE_URLS = (
+    r'^/(?:static|media)/',
+)
 
 # RTD Settings
 REPO_LOCK_SECONDS = 30

--- a/readthedocs/templates/503.html
+++ b/readthedocs/templates/503.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}
+  {% trans "We'll be right back" %}
+{% endblock %}
+
+{% block header-wrapper %}
+  {% include "error_header.html" %}
+{% endblock %}
+
+{% block content %}
+<pre style="line-height: 1.25; white-space: pre;">
+              ____
+             ||o o|
+             ||===|
+           .-.`---'-.
+           | | o .o |
+           | | o:.o |
+           | |      |
+           `-".-.-.-'
+           _| | : |_
+          (oo oo)_)_)
+
+    We are busy performing some maintenance, check back shortly.
+
+</pre>
+{% endblock %}

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -52,6 +52,7 @@ simplejson==2.3.0
 stripe==1.20.2
 factory-boy==2.4.1
 django-copyright==1.0.0
+django-maintenancemode==0.10.1
 
 # Docs
 sphinx-http-domain==0.2


### PR DESCRIPTION
Need to perform a quick database operation that will require downtime, but want to get a page up that wasn't a complete failure for now. It might make sense to extend the URLs here, as this is just the base to get static files served in local development.

Going to merge this in ahead of time, I only need this enabled for a few minutes.