### PR TITLE
Update virtualenv and setuptools in doc build envs

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -331,8 +331,8 @@ def setup_environment(version):
     requirements = ' '.join([
         'sphinx==1.3.1',
         'Pygments==2.0.2',
-        'virtualenv==1.10.1',
-        'setuptools==1.1',
+        'virtualenv==13.1.0',
+        'setuptools==18.0.1',
         'docutils==0.11',
         'mkdocs==0.14.0',
         'mock==1.0.1',


### PR DESCRIPTION
We updated the virtualenv in requirements/pip.txt for #1426. However that
did only touch the virtualenv of readthedocs, not the ones of the builds. So
updating it with this change.

Fixes #1428.