### PR TITLE
Linting and starting to use Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: python
 python:
- - "2.7"
+ - 2.7
 sudo: false
+env:
+ - TOX_ENV=py27
+ - TOX_ENV=docs
+ - TOX_ENV=lint
 install:
- - pip install flake8 stripe
- - pip install -r requirements.txt
+ - pip install tox
  - pip install coveralls
 script:
- #- flake8 `find . -iname "*.py" -not -ipath "*migration*"`
- - ./runtests.sh
+ - tox -e $TOX_ENV
 after_success:
  - coveralls
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 env:
  - TOX_ENV=py27
  - TOX_ENV=docs
- - TOX_ENV=lint
+ #- TOX_ENV=lint
 install:
  - pip install tox
  - pip install coveralls

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -1,14 +1,44 @@
-Running tests
-=============
+Testing
+=======
 
-Read the Docs ships with a test suite that tests the application. You should run these tests when you are doing development before committing code.
+Before contributing to Read the Docs, make sure your patch passes our test suite
+and your code style passes our code linting suite.
 
-They can be run easily::
+Read the Docs uses `Tox`_ to execute testing and linting procedures. Tox is the
+only dependency you need to run linting or our test suite, the remainder of our
+requirements will be installed by Tox into environment specific virtualenv
+paths. Before testing, make sure you have Tox installed::
 
-    pip install coverage 
-    ./runtests.sh
+    pip install tox
 
-This should print out a bunch of information and pass with 0 errors.
+To run the full test and lint suite against your changes, simply run Tox. Tox
+should return without any errors. You can run Tox against all of our
+environments by running::
+
+    tox
+
+To target a specific environment::
+
+    tox -e py27
+
+The ``tox`` configuration has the following environments configured. You can
+target a single environment to limit the test suite::
+
+    py27
+        Run our test suite using Python 2.7
+
+    lint
+        Run code linting using `Prospector`_. This currently runs `pylint`_,
+        `pyflakes`_, `pep8`_ and other linting tools.
+
+    docs
+        Test documentation compilation with Sphinx.
+
+.. _`Tox`: http://tox.readthedocs.org/en/latest/index.html
+.. _`Prospector`: http://prospector.readthedocs.org/en/master/
+.. _`pylint`: http://docs.pylint.org/
+.. _`pyflakes`: https://github.com/pyflakes/pyflakes
+.. _`pep8`: http://pep8.readthedocs.org/en/latest/index.html
 
 Continuous Integration
 ----------------------

--- a/prospector.yml
+++ b/prospector.yml
@@ -1,0 +1,30 @@
+strictness: low
+
+test-warnings: false
+doc-warnings: true
+
+uses:
+  - django
+  - celery
+
+ignore-paths:
+  - projects
+  - builds
+  - docs
+
+ignore-patterns:
+  - /migrations/
+
+pep8:
+    full: true
+    options:
+        max-line-length: 100
+
+pylint:
+  max-line-length: 100
+
+mccabe:
+  run: false
+
+pep257:
+  run: false

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -58,10 +58,12 @@ class TestSymlinkTranslations(TestCase):
             'ln -nsf {translation}/rtd-builds {project}/translations/de',
             'ln -nsf {builds} {project}/translations/en',
         ]
-        for (i, command) in enumerate(commands):
-            self.assertEqual(self.commands[i], command.format(**self.args),
-                             msg=('Command {0} mismatch, expecting {1}'
-                                  .format(i, self.commands[i])))
+
+        for command in commands:
+            self.assertIsNotNone(
+                self.commands.pop(
+                    self.commands.index(command.format(**self.args))
+                ))
 
     @patched
     def test_symlink_non_english(self):
@@ -80,10 +82,12 @@ class TestSymlinkTranslations(TestCase):
             'ln -nsf {project}/rtd-builds {project}/translations/de',
             'ln -nsf {translation}/rtd-builds {project}/translations/en',
         ]
-        for (i, command) in enumerate(commands):
-            self.assertEqual(self.commands[i], command.format(**self.args),
-                             msg=('Command {0} mismatch, expecting {1}'
-                                  .format(i, self.commands[i])))
+
+        for command in commands:
+            self.assertIsNotNone(
+                self.commands.pop(
+                    self.commands.index(command.format(**self.args))
+                ))
 
     @patched
     def test_symlink_no_english(self):
@@ -107,7 +111,9 @@ class TestSymlinkTranslations(TestCase):
             'ln -nsf {project}/rtd-builds {project}/translations/de',
             'ln -nsf {project}/rtd-builds {project}/translations/en',
         ]
-        for (i, command) in enumerate(commands):
-            self.assertEqual(self.commands[i], command.format(**self.args),
-                             msg=('Command {0} mismatch, expecting {1}'
-                                  .format(i, self.commands[i])))
+
+        for command in commands:
+            self.assertIsNotNone(
+                self.commands.pop(
+                    self.commands.index(command.format(**self.args))
+                ))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,lint,docs
+envlist = py27,lint,docs
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = py26,py27,lint,docs
+skipsdist = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
+    DJANGO_SETTINGS_MODULE=settings.test
+deps = -r{toxinidir}/requirements/pip.txt
+changedir = {toxinidir}/readthedocs
+commands =
+    py.test
+    /bin/sh -c 'cd {toxinidir}/docs; sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html'
+
+[testenv:lint]
+deps =
+    -r{toxinidir}/requirements/pip.txt
+    prospector
+    pylint-django
+commands =
+    prospector \
+    --profile-path={toxinidir} \
+    --profile=prospector \
+    --die-on-tool-error

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,16 @@ setenv =
 deps = -r{toxinidir}/requirements/pip.txt
 changedir = {toxinidir}/readthedocs
 commands =
-    py.test
-    /bin/sh -c 'cd {toxinidir}/docs; sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html'
+    py.test {posargs}
+
+[testenv:docs]
+changedir = {toxinidir}/docs
+commands =
+    sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
 [testenv:lint]
 deps =
-    -r{toxinidir}/requirements/pip.txt
+    {[testenv]deps}
     prospector
     pylint-django
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skipsdist = True
 setenv =
     PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
     DJANGO_SETTINGS_MODULE=settings.test
+    LANG=C
 deps = -r{toxinidir}/requirements/pip.txt
 changedir = {toxinidir}/readthedocs
 commands =


### PR DESCRIPTION
This is a example of some improved linting and testing configuration, thoughts are welcome.

This is an example of linting using [Prospector][prospector], which is a wrapper around a number of tools -- including flake8 and pylint. It includes a configuration that will set a low bar to getting back to linting code, and is configurable by strictness profile -- which is something we can increase when we start to clean things up more.

Output of a run here:
https://travis-ci.org/rtfd/readthedocs.org/builds/71619840

This also starts to use tox, as suggested by @destroyerofbuilds, which seems like an easy way to at least combine our testing, linting, and doc creation test commands into one tool, instead of one-off shell scripts. It makes for more reproducible tests as well, handling virtualenv creation.

This also fixes a bug on dict ordering in a test case.

[prospector]: https://github.com/landscapeio/prospector