### PR TITLE
Use new travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
  - "2.7"
+sudo: false
 install:
  - pip install flake8 stripe
  - pip install -r requirements.txt


### PR DESCRIPTION
Setting `sudo: false` will use the new docker based infrastructure of
TravisCI. See these docs for more information:
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade

I was playing around with this out of interest. As it is not breaking the builds and is recommended by TravisCI, we should switch over.