### PR TITLE
Added HTTPS git repo

### DIFF
--- a/docs/custom_installs/local_rtd_vm.rst
+++ b/docs/custom_installs/local_rtd_vm.rst
@@ -17,7 +17,11 @@ Assumptions and Prerequisites
 
   $ sudo apt-get install git
   
-* Git repo is ``git.corp.company.com:git/docs/documentation.git``
+* Git repo is 
+
+  * HTTPS: ``https://github.com/rtfd/readthedocs.org.git`` or
+  * SSH: ``git.corp.company.com:git/docs/documentation.git``
+
 * Source documents are in ``../docs/source``
 * Sphinx ::
 


### PR DESCRIPTION
Since this is for a VM install, it's likely that it's a fresh VM without a key registered on GitHub (as the Possible Error section states). The HTTPS url should be readily handy so you can do a quick copy paste and not have to mess with keys, or reformating the text.

The [official installation page](https://docs.readthedocs.org/en/latest/install.html) also uses HTTPS in their documentation.