### PR TITLE
Add tox setting to disregard local_settings.py

### DIFF
--- a/readthedocs/settings/onebox.py
+++ b/readthedocs/settings/onebox.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import *  # noqa
 
 DATABASES = {
@@ -52,7 +54,8 @@ DONT_HIT_DB = False
 #USE_SUBDOMAIN = True
 
 
-try:
-    from local_settings import *  # noqa
-except ImportError:
-    pass
+if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
+    try:
+        from local_settings import *  # noqa
+    except ImportError:
+        pass

--- a/readthedocs/settings/postgres.py
+++ b/readthedocs/settings/postgres.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import *  # noqa
 
 
@@ -67,7 +69,8 @@ SOCIALACCOUNT_PROVIDERS = {
     'github': {'SCOPE': ['user:email', 'read:org', 'admin:repo_hook', 'repo:status']}
 }
 
-try:
-    from local_settings import *  # noqa
-except ImportError:
-    pass
+if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
+    try:
+        from local_settings import *  # noqa
+    except ImportError:
+        pass

--- a/readthedocs/settings/sqlite.py
+++ b/readthedocs/settings/sqlite.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 
 from .base import *  # noqa
 
@@ -52,7 +52,8 @@ CORS_ORIGIN_WHITELIST = (
     'test:8000',
 )
 
-try:
-    from local_settings import *  # noqa
-except ImportError:
-    pass
+if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
+    try:
+        from local_settings import *  # noqa
+    except ImportError:
+        pass

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 
 from .sqlite import *  # noqa
 
@@ -9,7 +9,9 @@ SLUMBER_API_HOST = 'http://localhost:8000'
 PRODUCTION_DOMAIN = 'readthedocs.org'
 GROK_API_HOST = 'http://localhost:8888'
 
-try:
-    from local_settings import *  # noqa
-except ImportError:
-    pass
+
+if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
+    try:
+        from local_settings import *  # noqa
+    except ImportError:
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ setenv =
     PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
     DJANGO_SETTINGS_MODULE=settings.test
     LANG=C
+    DJANGO_SETTINGS_SKIP_LOCAL=True
 deps = -r{toxinidir}/requirements/pip.txt
 changedir = {toxinidir}/readthedocs
 commands =


### PR DESCRIPTION
If you use local_settings.py for development, tox will currently try to use
those settings. This disregards local_settings inside settings.test and friends
so that there is no chance for overlap.