### PR TITLE
Default to Sphinx docs

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -104,7 +104,7 @@ class Project(models.Model):
             'Path from the root of your project.'))
     documentation_type = models.CharField(
         _('Documentation type'), max_length=20,
-        choices=constants.DOCUMENTATION_CHOICES, default='auto',
+        choices=constants.DOCUMENTATION_CHOICES, default='sphinx',
         help_text=_('Type of documentation you are building. <a href="http://'
                     'sphinx-doc.org/builders.html#sphinx.builders.html.'
                     'DirectoryHTMLBuilder">More info</a>.'))

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -160,18 +160,9 @@ def update_documentation_type(version):
     Automatically determine the doc type for a user.
     """
 
-    checkout_path = version.project.checkout_path(version.slug)
-    os.chdir(checkout_path)
-    files = run('find .')[1].split('\n')
-    markdown = sphinx = 0
-    for filename in files:
-        if fnmatch.fnmatch(filename, '*.md') or fnmatch.fnmatch(filename, '*.markdown'):
-            markdown += 1
-        elif fnmatch.fnmatch(filename, '*.rst'):
-            sphinx += 1
+    # Keep this here for any 'auto' projects.
+
     ret = 'sphinx'
-    if markdown > sphinx:
-        ret = 'mkdocs'
     project_data = api_v2.project(version.project.pk).get()
     project_data['documentation_type'] = ret
     api_v2.project(version.project.pk).put(project_data)

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -29,7 +29,7 @@ class TestBasicsForm(WizardTestCase):
         self.assertIsNotNone(proj)
         for (key, val) in self.step_data['basics'].items():
             self.assertEqual(getattr(proj, key), val)
-        self.assertEqual(proj.documentation_type, 'auto')
+        self.assertEqual(proj.documentation_type, 'sphinx')
 
     def test_form_missing(self):
         '''Submit form with missing data, expect to get failures'''


### PR DESCRIPTION
This will make it so that we default to using Sphinx, since we now have support for Commonmark in Sphinx. 