### PR TITLE
Fix reference to path to manage.py in documentation

### DIFF
--- a/docs/custom_installs/local_rtd_vm.rst
+++ b/docs/custom_installs/local_rtd_vm.rst
@@ -55,7 +55,6 @@ Possible Error and Resolution
 
 1. Run the following commands. ::
 
-    $ cd readthedocs
     $ ./manage.py migrate
 
 2. This will prompt you to create a superuser account for Django. Enter appropriate details. For example: ::
@@ -67,7 +66,7 @@ Possible Error and Resolution
 3. RTD Server Administration.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Navigate to the ``../checkouts/readthedocs.org/readthedocs`` folder in your VM and run the following command. :: 
+Navigate to the ``../checkouts/readthedocs.org`` folder in your VM and run the following command. ::
 
     $ ./manage.py runserver [VM IP ADDRESS]:8000
     $ curl -i http://[VM IP ADDRESS]:8000

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -250,7 +250,7 @@ Updating Localization Files
 
 To update the translation source files (eg if you changed or added translatable
 strings in the templates or Python code) you should run ``python manage.py
-makemessages -l <language>`` in the ``readthedocs/`` directory (substitute
+makemessages -l <language>`` in the project's root directory (substitute
 ``<language>`` with a valid language code).
 
 The updated files can now be localized in a `PO editor


### PR DESCRIPTION
The location of the manage.py file changed with #1496. Accommodate that in the
docs as well.