### PR TITLE
Fix missing variable in project.tasks.webhook_notification

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -779,6 +779,8 @@ def email_notification(version, build, email):
 
 
 def webhook_notification(version, build, hook_url):
+    project = version.project
+
     data = json.dumps({
         'name': project.name,
         'slug': project.slug,


### PR DESCRIPTION
It seems to be broken since https://github.com/rtfd/readthedocs.org/commit/0f045f35d8105292576d064329a99174c0ff28c8

I haven't run the code myself but it's obviously missing the `project` variable. It's like that since Oct 2014, which makes me think if that feature is still supported?

It was revealed by Pylint :dragon: 