### PR TITLE
Use Django's builtin Form.add_error instead of custom addError

### DIFF
--- a/readthedocs/gold/forms.py
+++ b/readthedocs/gold/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.core.exceptions import NON_FIELD_ERRORS
 
 from .models import LEVEL_CHOICES
 
@@ -22,6 +21,3 @@ class CardForm(forms.Form):
         required=True,
         choices=LEVEL_CHOICES,
     )
-
-    def addError(self, message):
-        self._errors[NON_FIELD_ERRORS] = self.error_class([message])

--- a/readthedocs/gold/views.py
+++ b/readthedocs/gold/views.py
@@ -54,7 +54,7 @@ def register(request):
             try:
                 user.save()
             except IntegrityError:
-                form.addError(user.user.username + ' is already a member')
+                form.add_error(None, user.user.username + ' is already a member')
             else:
                 return HttpResponseRedirect(reverse('gold_thanks'))
 


### PR DESCRIPTION
This method was added in 1.8 and can replace our custom CardForm.addError method.