### PR TITLE
Move dnspython and launchpadlib into requirements/pip.txt

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -2,8 +2,6 @@
 psycopg2==2.4.6
 gunicorn==19.1.0
 pysolr==2.0.13
-dnspython==1.11.0
-launchpadlib==1.10.2
 django-redis-cache==0.9.5
 django-mailgun==0.2.2
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -26,9 +26,11 @@ hiredis==0.1.2
 celery==3.1.18
 django-celery==3.1.16
 django-allauth==0.21.0
+dnspython==1.11.0
 
 # VCS
 bzr==2.6
+launchpadlib==1.10.2
 mercurial==2.6.3
 httplib2==0.7.7
 


### PR DESCRIPTION
They were only in requirements/deploy.txt but were required in a few places
in the codebase. That means that developers can come into a situation were
they end up missing these libraries even when they installed all dependencies
according to the docs.