### PR TITLE
Set ACCOUNT_DEFAULT_HTTP_PROTOCOL to 'http' in production

### DIFF
--- a/readthedocs/settings/postgres.py
+++ b/readthedocs/settings/postgres.py
@@ -69,6 +69,9 @@ SOCIALACCOUNT_PROVIDERS = {
     'github': {'SCOPE': ['user:email', 'read:org', 'admin:repo_hook', 'repo:status']}
 }
 
+# allauth settings
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
+
 if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
     try:
         from local_settings import *  # noqa


### PR DESCRIPTION
allauth redirects to GitHub for the social login using a HTTP URL by default.
However the GitHub app is setup to expect a HTTPS URL. So we need to instruct
allauth to use one as well.

Fixes #1520.
