### PR TITLE
Make source_parsers['.md'] configurable in conf.py

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -20,7 +20,8 @@ if version_info[0] == 1 and version_info[1] > 2:
         source_suffix = ['.rst', '.md']
 
     if 'source_parsers' in globals():
-        source_parsers['.md'] = CommonMarkParser
+        if '.md' not in source_parsers:
+            source_parsers['.md'] = CommonMarkParser
     else:
         source_parsers = {
             '.md': CommonMarkParser,


### PR DESCRIPTION
Currently the conf.py.tmpl will overwrite the `source_parsers['.md']` setting if
it is set. Check if it already set and leave it alone if so.

Fixes #1527.