### PR TITLE
Call python scripts as argument to virtualenv python command

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -141,7 +141,7 @@ class BaseMkdocs(BaseBuilder):
         cmd_ret = self.run(
             *build_command,
             cwd=checkout_path,
-            bin_path=self.project.venv_bin(version=self.version.slug, bin=None)
+            bin_path=self.project.venv_bin(version=self.version.slug)
         )
         return cmd_ret.successful
 

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -130,6 +130,7 @@ class BaseMkdocs(BaseBuilder):
     def build(self, **kwargs):
         checkout_path = self.project.checkout_path(self.version.slug)
         build_command = [
+            'python',
             self.project.venv_bin(version=self.version.slug, bin='mkdocs'),
             self.builder,
             '--clean',
@@ -137,7 +138,11 @@ class BaseMkdocs(BaseBuilder):
         ]
         if self.use_theme:
             build_command.extend(['--theme', 'readthedocs'])
-        cmd_ret = self.run(*build_command, cwd=checkout_path)
+        cmd_ret = self.run(
+            *build_command,
+            cwd=checkout_path,
+            bin_path=self.project.venv_bin(version=self.version.slug, bin=None)
+        )
         return cmd_ret.successful
 
 

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -126,6 +126,7 @@ class BaseSphinx(BaseBuilder):
         self.clean()
         project = self.project
         build_command = [
+            'python',
             project.venv_bin(version=self.version.slug, bin='sphinx-build'),
             '-T'
         ]
@@ -138,8 +139,11 @@ class BaseSphinx(BaseBuilder):
             '.',
             self.sphinx_build_dir
         ])
-        cmd_ret = self.run(*build_command,
-                           cwd=project.conf_dir(self.version.slug))
+        cmd_ret = self.run(
+            *build_command,
+            cwd=project.conf_dir(self.version.slug),
+            bin_path=project.venv_bin(version=self.version.slug, bin=None)
+        )
         return cmd_ret.successful
 
 
@@ -232,13 +236,15 @@ class PdfBuilder(BaseSphinx):
 
         # Default to this so we can return it always.
         self.run(
+            'python',
             self.project.venv_bin(version=self.version.slug, bin='sphinx-build'),
             '-b', 'latex',
             '-D', 'language={lang}'.format(lang=self.project.language),
             '-d', '_build/doctrees',
             '.',
             '_build/latex',
-            cwd=cwd
+            cwd=cwd,
+            bin_path=self.project.venv_bin(version=self.version.slug, bin=None)
         )
         latex_cwd = os.path.join(cwd, '_build', 'latex')
         tex_files = glob(os.path.join(latex_cwd, '*.tex'))

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -142,7 +142,7 @@ class BaseSphinx(BaseBuilder):
         cmd_ret = self.run(
             *build_command,
             cwd=project.conf_dir(self.version.slug),
-            bin_path=project.venv_bin(version=self.version.slug, bin=None)
+            bin_path=project.venv_bin(version=self.version.slug)
         )
         return cmd_ret.successful
 
@@ -244,7 +244,7 @@ class PdfBuilder(BaseSphinx):
             '.',
             '_build/latex',
             cwd=cwd,
-            bin_path=self.project.venv_bin(version=self.version.slug, bin=None)
+            bin_path=self.project.venv_bin(version=self.version.slug)
         )
         latex_cwd = os.path.join(cwd, '_build', 'latex')
         tex_files = glob(os.path.join(latex_cwd, '*.tex'))

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -44,7 +44,8 @@ class BuildCommand(object):
 
     # TODO add short name here for reporting
     def __init__(self, command, cwd=None, shell=False, environment=None,
-                 combine_output=True, input_data=None, build_env=None):
+                 combine_output=True, input_data=None, build_env=None,
+                 bin_path=None):
         self.command = command
         self.shell = shell
         if cwd is None:
@@ -55,6 +56,7 @@ class BuildCommand(object):
             self.environment.update(environment)
         self.combine_output = combine_output
         self.build_env = build_env
+        self.bin_path = bin_path
         self.status = None
         self.input_data = input_data
         self.output = None
@@ -91,6 +93,10 @@ class BuildCommand(object):
             del environment['DJANGO_SETTINGS_MODULE']
         if 'PYTHONPATH' in environment:
             del environment['PYTHONPATH']
+        if self.bin_path is not None:
+            env_paths = environment.get('PATH', '').split(':')
+            env_paths.insert(0, self.bin_path)
+            environment['PATH'] = ':'.join(env_paths)
 
         try:
             proc = subprocess.Popen(

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -484,16 +484,17 @@ class Project(models.Model):
     # End symlink paths
     #
 
-    def venv_bin(self, version=LATEST, bin='python'):
+    def venv_bin(self, version=LATEST, bin=None):
         """Return path to the virtualenv bin path, or a specific binary
 
-        By default, return the path to the ``python`` binary in the virtual
-        environment path. If ``bin`` is :py:data:`None`, then return the path to
-        the virtual env path.
+        If ``bin`` is :py:data:`None`, then return the path to the virtual env
+        path, otherwise, return the path to the executable ``bin`` in the
+        virtual env ``bin`` path
         """
-        if bin is None:
-            bin = ''
-        return os.path.join(self.venv_path(version), 'bin', bin)
+        parts = [self.venv_path(version), 'bin']
+        if bin is not None:
+            parts.append(bin)
+        return os.path.join(*parts)
 
     def full_doc_path(self, version=LATEST):
         """

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -485,6 +485,14 @@ class Project(models.Model):
     #
 
     def venv_bin(self, version=LATEST, bin='python'):
+        """Return path to the virtualenv bin path, or a specific binary
+
+        By default, return the path to the ``python`` binary in the virtual
+        environment path. If ``bin`` is :py:data:`None`, then return the path to
+        the virtual env path.
+        """
+        if bin is None:
+            bin = ''
         return os.path.join(self.venv_path(version), 'bin', bin)
 
     def full_doc_path(self, version=LATEST):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -267,6 +267,7 @@ class UpdateDocsTask(Task):
         ]
 
         cmd = [
+            'python',
             self.project.venv_bin(version=self.version.slug, bin='pip'),
             'install',
             '--use-wheel',
@@ -280,7 +281,10 @@ class UpdateDocsTask(Task):
             # --system-site-packages is used)
             cmd.append('-I')
         cmd.extend(requirements)
-        self.build_env.run(*cmd)
+        self.build_env.run(
+            *cmd,
+            bin_path=self.project.venv_bin(version=self.version.slug, bin=None)
+        )
 
         # Handle requirements
         requirements_file_path = self.project.requirements_file
@@ -298,11 +302,14 @@ class UpdateDocsTask(Task):
 
         if requirements_file_path:
             self.build_env.run(
+                'python',
                 self.project.venv_bin(version=self.version.slug, bin='pip'),
                 'install',
                 '--exists-action=w',
                 '-r{0}'.format(requirements_file_path),
-                cwd=checkout_path
+                cwd=checkout_path,
+                bin_path=self.project.venv_bin(version=self.version.slug,
+                                               bin=None)
             )
 
         # Handle setup.py
@@ -311,21 +318,24 @@ class UpdateDocsTask(Task):
         if os.path.isfile(setup_path):
             if getattr(settings, 'USE_PIP_INSTALL', False):
                 self.build_env.run(
-                    self.project.venv_bin(version=self.version.slug,
-                                          bin='pip'),
+                    'python',
+                    self.project.venv_bin(version=self.version.slug, bin='pip'),
                     'install',
                     '--ignore-installed',
                     '.',
-                    cwd=checkout_path
+                    cwd=checkout_path,
+                    bin_path=self.project.venv_bin(version=self.version.slug,
+                                                   bin=None)
                 )
             else:
                 self.build_env.run(
-                    self.project.venv_bin(version=self.version.slug,
-                                          bin='python'),
+                    'python',
                     'setup.py',
                     'install',
                     '--force',
-                    cwd=checkout_path
+                    cwd=checkout_path,
+                    bin_path=self.project.venv_bin(version=self.version.slug,
+                                                   bin=None)
                 )
 
     def build_docs(self):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -283,7 +283,7 @@ class UpdateDocsTask(Task):
         cmd.extend(requirements)
         self.build_env.run(
             *cmd,
-            bin_path=self.project.venv_bin(version=self.version.slug, bin=None)
+            bin_path=self.project.venv_bin(version=self.version.slug)
         )
 
         # Handle requirements
@@ -308,8 +308,7 @@ class UpdateDocsTask(Task):
                 '--exists-action=w',
                 '-r{0}'.format(requirements_file_path),
                 cwd=checkout_path,
-                bin_path=self.project.venv_bin(version=self.version.slug,
-                                               bin=None)
+                bin_path=self.project.venv_bin(version=self.version.slug)
             )
 
         # Handle setup.py
@@ -324,8 +323,7 @@ class UpdateDocsTask(Task):
                     '--ignore-installed',
                     '.',
                     cwd=checkout_path,
-                    bin_path=self.project.venv_bin(version=self.version.slug,
-                                                   bin=None)
+                    bin_path=self.project.venv_bin(version=self.version.slug)
                 )
             else:
                 self.build_env.run(
@@ -334,8 +332,7 @@ class UpdateDocsTask(Task):
                     'install',
                     '--force',
                     cwd=checkout_path,
-                    bin_path=self.project.venv_bin(version=self.version.slug,
-                                                   bin=None)
+                    bin_path=self.project.venv_bin(version=self.version.slug)
                 )
 
     def build_docs(self):

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -46,7 +46,8 @@ class BuildEnvironmentTests(TestCase):
         # Get command and check first part of command list is a call to sphinx
         self.assertEqual(self.mocks.popen.call_count, 1)
         cmd = self.mocks.popen.call_args_list[0][0]
-        self.assertRegexpMatches(cmd[0][0], r'sphinx-build')
+        self.assertRegexpMatches(cmd[0][0], r'python')
+        self.assertRegexpMatches(cmd[0][1], r'sphinx-build')
 
     def test_build_respects_pdf_flag(self):
         '''Build output format control'''


### PR DESCRIPTION
This fixes #994, where the 127 character limit on shebang line lengths was
triggering failures of commands inside virtualenvs that had long names or
long branch names. This PR adds some path environment variable handling to
allow for shorter commands, and makes all python script call wrapped by a
call to the virtual env symlinked python binary.

This depends on the pending pull request #1524, for adding docker
containerization and should be rebased after that PR is merged.