### PR TITLE
Fix install developer docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -74,9 +74,11 @@ database::
 
     ./manage.py migrate
 
-This will prompt you to create a superuser account for Django. Do that.
+Then please create a superuser account for Django::
 
-Then go ahead and load in a couple users and a test projects::
+    ./manage.py createsuperuser
+
+By now, it is the right time to load in a couple users and a test projects::
 
     ./manage.py loaddata test_data
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -72,7 +72,6 @@ Next, install the dependencies using ``pip`` (included with virtualenv_)::
 This may take a while, so go grab a beverage. When it's done, build your
 database::
 
-    cd readthedocs
     ./manage.py migrate
 
 This will prompt you to create a superuser account for Django. Do that.


### PR DESCRIPTION
The `./manage.py migrate` was instructed to be run in a wrong directory. And it stated that it will prompt you to create a superuser. However since Django 1.7, it doesn't so the docs now also contain instructions to add a superuser `createsuperuser`.

Fixes #1566.