### PR TITLE
Upgrade haystack to work with Django 1.8

### DIFF
--- a/readthedocs/projects/search_indexes.py
+++ b/readthedocs/projects/search_indexes.py
@@ -26,7 +26,7 @@ class ProjectIndex(indexes.SearchIndex, indexes.Indexable):
     absolute_url = CharField()
 
     def prepare_author(self, obj):
-        return obj.users.all()[0]
+        return str(obj.users.first())
 
     def prepare_absolute_url(self, obj):
         return obj.get_absolute_url()
@@ -49,7 +49,7 @@ class ImportedFileIndex(indexes.SearchIndex, indexes.Indexable):
     absolute_url = CharField()
 
     def prepare_author(self, obj):
-        return obj.project.users.all()[0]
+        return str(obj.project.users.first())
 
     def prepare_title(self, obj):
         return obj.name.replace('.html', '').replace('_', ' ').title()
@@ -76,11 +76,14 @@ class ImportedFileIndex(indexes.SearchIndex, indexes.Indexable):
         log.debug('(Search Index) Indexing %s:%s' % (obj.project, obj.path))
         DOCUMENT_PYQUERY_PATH = getattr(settings, 'DOCUMENT_PYQUERY_PATH',
                                         'div.document')
-        try:
-            to_index = strip_tags(PyQuery(content)(
-                DOCUMENT_PYQUERY_PATH).html()).replace(u'¶', '')
-        except ValueError:
-            #Pyquery returns ValueError if div.document doesn't exist.
+        if html_to_index:
+            to_index = strip_tags(html_to_index).replace(u'¶', '')
+        else:
+            # Pyquery returns None if it didn't find the query in the document
+	    log.info('(Search Index) Unable to index file: %s:%s, no matching'
+                      ' pyquery for %s' % (obj.project,
+                                           file_path,
+                                           DOCUMENT_PYQUERY_PATH))
             return
         if not to_index:
             log.info('(Search Index) Unable to index file: %s:%s, empty file' % (obj.project,

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,8 +9,8 @@ mkdocs==0.14.0
 django==1.8.3
 
 git+https://github.com/django-tastypie/django-tastypie.git@1e1aff3dd4dcd21669e9c68bd7681253b286b856#egg=django-tastypie
-django-haystack==2.1.0
-celery-haystack==0.7.2
+django-haystack==2.4.0
+celery-haystack==0.9
 django-guardian==1.3.0
 django-extensions==1.3.8
 djangorestframework==3.0.4


### PR DESCRIPTION
Also fix pyquery part as it no longer raises an exception
on not finding it's query in the document.

This should fix some issues I've found when deploying RTD myself.