### PR TITLE
Lint project code

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -8,23 +8,22 @@ uses:
   - celery
 
 ignore-paths:
-  - projects
   - docs
 
 ignore-patterns:
   - /migrations/
 
 pep8:
-    full: true
-    options:
-        max-line-length: 100
-    disable:
-        - N806
+  full: true
+  options:
+    max-line-length: 100
 
 pylint:
-  max-line-length: 100
+  options:
+    dummy-variables-rgx: '_$|__$|dummy'
+    max-line-length: 100
   disable:
-      - logging-format-interpolation
+    - logging-format-interpolation
 
 mccabe:
   run: false

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -15,7 +15,9 @@ from readthedocs.privacy.loader import (VersionManager, RelatedProjectManager,
                                         RelatedBuildManager)
 from readthedocs.projects.models import Project
 from readthedocs.projects.constants import (PRIVACY_CHOICES, REPO_TYPE_GIT,
-                                            REPO_TYPE_HG)
+                                            REPO_TYPE_HG, GITHUB_URL,
+                                            GITHUB_REGEXS, BITBUCKET_URL,
+                                            BITBUCKET_REGEXS)
 
 from .constants import (BUILD_STATE, BUILD_TYPES, VERSION_TYPES,
                         LATEST, NON_REPOSITORY_VERSIONS, STABLE,
@@ -228,14 +230,6 @@ class Version(models.Model):
         return slug
 
     def get_github_url(self, docroot, filename, source_suffix='.rst', action='view'):
-        GITHUB_REGEXS = [
-            re.compile('github.com/(.+)/(.+)(?:\.git){1}'),
-            re.compile('github.com/(.+)/(.+)'),
-            re.compile('github.com:(.+)/(.+).git'),
-        ]
-        GITHUB_URL = ('https://github.com/{user}/{repo}/'
-                      '{action}/{version}{docroot}{path}{source_suffix}')
-
         repo_url = self.project.repo
         if 'github' not in repo_url:
             return ''
@@ -273,20 +267,13 @@ class Version(models.Model):
         )
 
     def get_bitbucket_url(self, docroot, filename, source_suffix='.rst'):
-        BB_REGEXS = [
-            re.compile('bitbucket.org/(.+)/(.+).git'),
-            re.compile('bitbucket.org/(.+)/(.+)/'),
-            re.compile('bitbucket.org/(.+)/(.+)'),
-        ]
-        BB_URL = 'https://bitbucket.org/{user}/{repo}/src/{version}{docroot}{path}{source_suffix}'
-
         repo_url = self.project.repo
         if 'bitbucket' not in repo_url:
             return ''
         if not docroot:
             return ''
 
-        for regex in BB_REGEXS:
+        for regex in BITBUCKET_REGEXS:
             match = regex.search(repo_url)
             if match:
                 user, repo = match.groups()
@@ -295,7 +282,7 @@ class Version(models.Model):
             return ''
         repo = repo.rstrip('/')
 
-        return BB_URL.format(
+        return BITBUCKET_URL.format(
             user=user,
             repo=repo,
             version=self.remote_slug,

--- a/readthedocs/comments/views.py
+++ b/readthedocs/comments/views.py
@@ -187,7 +187,7 @@ class CommentViewSet(ModelViewSet):
         project = Project.objects.get(slug=request.data['project'])
         comment = project.add_comment(version_slug=request.data['version'],
                                       page=request.data['document_page'],
-                                      hash=request.data['node'],
+                                      content_hash=request.data['node'],
                                       commit=request.data['commit'],
                                       user=request.user,
                                       text=request.data['text'])

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -143,7 +143,7 @@ class BaseMkdocs(BaseBuilder):
         checkout_path = self.project.checkout_path(self.version.slug)
         build_command = [
             'python',
-            self.project.venv_bin(version=self.version.slug, bin='mkdocs'),
+            self.project.venv_bin(version=self.version.slug, filename='mkdocs'),
             self.builder,
             '--clean',
             '--site-dir', self.build_dir,

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -128,7 +128,7 @@ class BaseSphinx(BaseBuilder):
         project = self.project
         build_command = [
             'python',
-            project.venv_bin(version=self.version.slug, bin='sphinx-build'),
+            project.venv_bin(version=self.version.slug, filename='sphinx-build'),
             '-T'
         ]
         if self._force:
@@ -249,7 +249,8 @@ class PdfBuilder(BaseSphinx):
         # Default to this so we can return it always.
         self.run(
             'python',
-            self.project.venv_bin(version=self.version.slug, bin='sphinx-build'),
+            self.project.venv_bin(version=self.version.slug,
+                                  filename='sphinx-build'),
             '-b', 'latex',
             '-D', 'language={lang}'.format(lang=self.project.language),
             '-d', '_build/doctrees',

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -36,7 +36,7 @@ class BaseBuilder(object):
         self._force = force
         self.target = self.project.artifact_path(
             version=self.version.slug,
-            type=self.type
+            type_=self.type
         )
 
     def force(self, **kwargs):

--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -1,32 +1,45 @@
-"""Django administration interface for `~projects.models.Project`
-and related models.
-"""
+"""Django administration interface for `projects.models`"""
 
 from readthedocs.builds.models import Version
 from django.contrib import admin
 from readthedocs.redirects.models import Redirect
-from readthedocs.projects.models import (Project, ImportedFile, ProjectRelationship, EmailHook, WebHook)
+from readthedocs.projects.models import (Project, ImportedFile,
+                                         ProjectRelationship, EmailHook,
+                                         WebHook)
 from guardian.admin import GuardedModelAdmin
 
 
 class ProjectRelationshipInline(admin.TabularInline):
+
+    """Project inline relationship view for :py:cls:`ProjectAdmin`"""
+
     model = ProjectRelationship
     fk_name = 'parent'
     raw_id_fields = ('child',)
 
 
 class VersionInline(admin.TabularInline):
+
+    """Version inline relationship view for :py:cls:`ProjectAdmin`"""
+
     model = Version
 
 
 class RedirectInline(admin.TabularInline):
+
+    """Redirect inline relationship view for :py:cls:`ProjectAdmin`"""
+
     model = Redirect
 
 
 class ProjectAdmin(GuardedModelAdmin):
+
+    """Project model admin view"""
+
     prepopulated_fields = {'slug': ('name',)}
     list_display = ('name', 'repo', 'repo_type', 'allow_comments', 'featured', 'theme')
-    list_filter = ('repo_type', 'allow_comments', 'featured', 'privacy_level', 'documentation_type', 'programming_language')
+    list_filter = ('repo_type', 'allow_comments', 'featured', 'privacy_level',
+                   'documentation_type', 'programming_language')
     list_editable = ('featured',)
     search_fields = ('slug', 'repo')
     inlines = [ProjectRelationshipInline, RedirectInline, VersionInline]
@@ -34,6 +47,9 @@ class ProjectAdmin(GuardedModelAdmin):
 
 
 class ImportedFileAdmin(admin.ModelAdmin):
+
+    """Admin view for :py:cls:`ImportedFile`"""
+
     list_display = ('path', 'name', 'version')
 
 

--- a/readthedocs/projects/backends/views.py
+++ b/readthedocs/projects/backends/views.py
@@ -1,9 +1,9 @@
-'''
+"""
 Project views loaded by configuration settings
 
 Use these views instead of calling the views directly, in order to allow for
 settings override of the view class.
-'''
+"""
 
 from django.utils.module_loading import import_by_path
 from django.conf import settings

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -1,5 +1,7 @@
-"""Default values and other various configuration for projects,
-including available theme names and repository types.
+"""Project constants
+
+Default values and other various configuration for projects, including available
+theme names and repository types.
 """
 
 import re
@@ -20,8 +22,8 @@ DOCUMENTATION_CHOICES = (
     ('mkdocs', _('Mkdocs (Markdown)')),
     ('sphinx_htmldir', _('Sphinx HtmlDir')),
     ('sphinx_singlehtml', _('Sphinx Single Page HTML')),
-    #('sphinx_websupport2', _('Sphinx Websupport')),
-    #('rdoc', 'Rdoc'),
+    # ('sphinx_websupport2', _('Sphinx Websupport')),
+    # ('rdoc', 'Rdoc'),
 )
 
 DEFAULT_THEME_CHOICES = (
@@ -29,8 +31,8 @@ DEFAULT_THEME_CHOICES = (
     (THEME_DEFAULT, _('Default')),
     # Translators: This is a name of a Sphinx theme.
     (THEME_SPHINX, _('Sphinx Docs')),
-    #(THEME_SCROLLS, 'Scrolls'),
-    #(THEME_AGOGO, 'Agogo'),
+    # (THEME_SCROLLS, 'Scrolls'),
+    # (THEME_AGOGO, 'Agogo'),
     # Translators: This is a name of a Sphinx theme.
     (THEME_TRADITIONAL, _('Traditional')),
     # Translators: This is a name of a Sphinx theme.
@@ -277,3 +279,18 @@ LOG_TEMPLATE = u"(Build) [{project}:{version}] {msg}"
 
 PROJECT_PK_REGEX = '(?:[-\w]+)'
 PROJECT_SLUG_REGEX = '(?:[-\w]+)'
+
+GITHUB_REGEXS = [
+    re.compile('github.com/(.+)/(.+)(?:\.git){1}'),
+    re.compile('github.com/(.+)/(.+)'),
+    re.compile('github.com:(.+)/(.+).git'),
+]
+BITBUCKET_REGEXS = [
+    re.compile('bitbucket.org/(.+)/(.+).git'),
+    re.compile('bitbucket.org/(.+)/(.+)/'),
+    re.compile('bitbucket.org/(.+)/(.+)'),
+]
+GITHUB_URL = ('https://github.com/{user}/{repo}/'
+              '{action}/{version}{docroot}{path}{source_suffix}')
+BITBUCKET_URL = ('https://bitbucket.org/{user}/{repo}/'
+                 'src/{version}{docroot}{path}{source_suffix}')

--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -1,3 +1,8 @@
+"""Project exceptions"""
+
+
 class ProjectImportError (Exception):
+
     """Failure to import a project from a repository."""
+
     pass

--- a/readthedocs/projects/feeds.py
+++ b/readthedocs/projects/feeds.py
@@ -1,9 +1,14 @@
+"""Project RSS feeds"""
+
 from django.contrib.syndication.views import Feed
 
 from readthedocs.projects.models import Project
 
 
 class LatestProjectsFeed(Feed):
+
+    """RSS feed for projects that were recently updated"""
+
     title = "Recently updated documentation"
     link = "http://readthedocs.org"
     description = "Recently updated documentation on Read the Docs"
@@ -19,6 +24,9 @@ class LatestProjectsFeed(Feed):
 
 
 class NewProjectsFeed(Feed):
+
+    """RSS feed for newly created projects"""
+
     title = "Newest documentation"
     link = "http://readthedocs.org"
     description = "Recently created documentation on Read the Docs"

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -1,3 +1,5 @@
+"""Project forms"""
+
 from random import choice
 
 from django import forms
@@ -18,6 +20,12 @@ from readthedocs.privacy.loader import AdminPermission
 
 
 class ProjectForm(forms.ModelForm):
+
+    """Project form
+
+    :param user: If provided, add this user as a project user on save
+    """
+
     required_css_class = "required"
 
     def __init__(self, *args, **kwargs):
@@ -33,14 +41,15 @@ class ProjectForm(forms.ModelForm):
 
 
 class ProjectTriggerBuildMixin(object):
-    '''Mixin to trigger build on form save
+
+    """Mixin to trigger build on form save
 
     This should be replaced with signals instead of calling trigger_build
     explicitly.
-    '''
+    """
 
     def save(self, commit=True):
-        '''Trigger build on commit save'''
+        """Trigger build on commit save"""
         project = super(ProjectTriggerBuildMixin, self).save(commit)
         if commit:
             trigger_build(project=project)
@@ -48,12 +57,15 @@ class ProjectTriggerBuildMixin(object):
 
 
 class ProjectBackendForm(forms.Form):
-    '''Get the import backend'''
+
+    """Get the import backend"""
+
     backend = forms.CharField()
 
 
 class ProjectBasicsForm(ProjectForm):
-    '''Form for basic project fields'''
+
+    """Form for basic project fields"""
 
     class Meta:
         model = Project
@@ -104,6 +116,8 @@ class ProjectBasicsForm(ProjectForm):
 
 class ProjectExtraForm(ProjectForm):
 
+    """Additional project information form"""
+
     class Meta:
         model = Project
         fields = (
@@ -127,6 +141,9 @@ class ProjectExtraForm(ProjectForm):
 
 
 class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
+
+    """Advanced project option form"""
+
     python_interpreter = forms.ChoiceField(
         choices=constants.PYTHON_CHOICES, initial='python',
         help_text=_("(Beta) The Python interpreter used to create the virtual "
@@ -157,12 +174,12 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
         )
 
     def clean_conf_py_file(self):
-        file = self.cleaned_data.get('conf_py_file', '').strip()
-        if file and not 'conf.py' in file:
+        filename = self.cleaned_data.get('conf_py_file', '').strip()
+        if filename and 'conf.py' not in filename:
             raise forms.ValidationError(
                 _('Your configuration file is invalid, make sure it contains '
                   'conf.py in it.'))
-        return file
+        return filename
 
 
 class UpdateProjectForm(ProjectTriggerBuildMixin, ProjectBasicsForm,
@@ -174,8 +191,8 @@ class UpdateProjectForm(ProjectTriggerBuildMixin, ProjectBasicsForm,
             # Basics
             'name', 'repo', 'repo_type',
             # Extra
-            #'allow_comments',
-            #'comment_moderation',
+            # 'allow_comments',
+            # 'comment_moderation',
             'description',
             'documentation_type',
             'language', 'programming_language',
@@ -186,6 +203,8 @@ class UpdateProjectForm(ProjectTriggerBuildMixin, ProjectBasicsForm,
 
 
 class DualCheckboxWidget(forms.CheckboxInput):
+
+    """Checkbox with link to the version's built documentation"""
 
     def __init__(self, version, attrs=None, check_test=bool):
         super(DualCheckboxWidget, self).__init__(attrs, check_test)
@@ -208,6 +227,8 @@ class DualCheckboxWidget(forms.CheckboxInput):
 
 class BaseVersionsForm(forms.Form):
 
+    """Form for versions page"""
+
     def save(self):
         versions = self.project.versions.all()
         for version in versions:
@@ -218,12 +239,13 @@ class BaseVersionsForm(forms.Form):
             self.project.save()
 
     def save_version(self, version):
+        """Save version if there has been a change, trigger a rebuild"""
         new_value = self.cleaned_data.get('version-%s' % version.slug, None)
         privacy_level = self.cleaned_data.get('privacy-%s' % version.slug,
                                               None)
         if ((new_value is None or
-             new_value == version.active)
-            and (privacy_level is None or
+             new_value == version.active) and (
+                 privacy_level is None or
                  privacy_level == version.privacy_level)):
             return
         version.active = new_value
@@ -234,10 +256,11 @@ class BaseVersionsForm(forms.Form):
 
 
 def build_versions_form(project):
+    """Versions form with a list of versions and version privacy levels"""
     attrs = {
         'project': project,
     }
-    versions_qs = project.versions.all() # Admin page, so show all versions
+    versions_qs = project.versions.all()  # Admin page, so show all versions
     active = versions_qs.filter(active=True)
     if active.exists():
         choices = [(version.slug, version.verbose_name) for version in active]
@@ -279,19 +302,20 @@ class BaseUploadHTMLForm(forms.Form):
 
     def clean(self):
         version_slug = self.cleaned_data['version']
-        file = self.request.FILES['content']
+        filename = self.request.FILES['content']
         version = self.project.versions.get(slug=version_slug)
 
         # Validation
         if version.active and not self.cleaned_data.get('overwrite', False):
             raise forms.ValidationError(_("That version is already active!"))
-        if not file.name.endswith('zip'):
+        if not filename.name.endswith('zip'):
             raise forms.ValidationError(_("Must upload a zip file."))
 
         return self.cleaned_data
 
 
 def build_upload_html_form(project):
+    """Upload HTML form with list of versions to upload HTML for"""
     attrs = {
         'project': project,
     }
@@ -307,6 +331,9 @@ def build_upload_html_form(project):
 
 
 class SubprojectForm(forms.Form):
+
+    """Project subproject form"""
+
     subproject = forms.CharField()
 
     def __init__(self, *args, **kwargs):
@@ -315,6 +342,11 @@ class SubprojectForm(forms.Form):
         super(SubprojectForm, self).__init__(*args, **kwargs)
 
     def clean_subproject(self):
+        """Normalize subproject field
+
+        Does lookup on against :py:cls:`Project` to ensure matching project
+        exists. Return the :py:cls:`Project` object instead.
+        """
         subproject_name = self.cleaned_data['subproject']
         subproject_qs = Project.objects.filter(slug=subproject_name)
         if not subproject_qs.exists():
@@ -334,6 +366,9 @@ class SubprojectForm(forms.Form):
 
 
 class UserForm(forms.Form):
+
+    """Project user association form"""
+
     user = forms.CharField()
 
     def __init__(self, *args, **kwargs):
@@ -357,6 +392,9 @@ class UserForm(forms.Form):
 
 
 class EmailHookForm(forms.Form):
+
+    """Project email notification form"""
+
     email = forms.EmailField()
 
     def __init__(self, *args, **kwargs):
@@ -374,6 +412,9 @@ class EmailHookForm(forms.Form):
 
 
 class WebHookForm(forms.Form):
+
+    """Project webhook form"""
+
     url = forms.URLField()
 
     def __init__(self, *args, **kwargs):
@@ -389,7 +430,11 @@ class WebHookForm(forms.Form):
         self.project.webhook_notifications.add(self.webhook)
         return self.project
 
+
 class TranslationForm(forms.Form):
+
+    """Project translation form"""
+
     project = forms.CharField()
 
     def __init__(self, *args, **kwargs):
@@ -412,6 +457,8 @@ class TranslationForm(forms.Form):
 
 class RedirectForm(forms.ModelForm):
 
+    """Form for project redirects"""
+
     class Meta:
         model = Redirect
         fields = ['redirect_type', 'from_url', 'to_url']
@@ -420,7 +467,7 @@ class RedirectForm(forms.ModelForm):
         self.project = kwargs.pop('project', None)
         super(RedirectForm, self).__init__(*args, **kwargs)
 
-    def save(self, *args, **kwargs):
+    def save(self, **_):
         redirect = Redirect.objects.create(
             project=self.project,
             redirect_type=self.cleaned_data['redirect_type'],
@@ -428,4 +475,3 @@ class RedirectForm(forms.ModelForm):
             to_url=self.cleaned_data['to_url'],
         )
         return redirect
-

--- a/readthedocs/projects/management/commands/import_project_from_live.py
+++ b/readthedocs/projects/management/commands/import_project_from_live.py
@@ -1,8 +1,4 @@
-"""
-This is a helper to debug issues with projects on the server more easily
-locally. It allows you to import projects based on the data that the public API
-provides.
-"""
+"""Import project command"""
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
@@ -14,6 +10,15 @@ from ...models import Project
 
 
 class Command(BaseCommand):
+
+    """
+    Import project from production API
+
+    This is a helper to debug issues with projects on the server more easily
+    locally. It allows you to import projects based on the data that the public
+    API provides.
+    """
+
     help = (
         "Retrieves the data of a project from readthedocs.org's API and puts "
         "it into the local database. This is mostly useful for debugging "

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1,3 +1,5 @@
+"""Project models"""
+
 import fnmatch
 import logging
 import os
@@ -15,12 +17,12 @@ from guardian.shortcuts import assign
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import LATEST_VERBOSE_NAME
 from readthedocs.builds.constants import STABLE
-from readthedocs.oauth import utils as oauth_utils
 from readthedocs.privacy.loader import RelatedProjectManager, ProjectManager
 from readthedocs.projects import constants
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
-from readthedocs.projects.utils import make_api_version, symlink, update_static_metadata
+from readthedocs.projects.utils import (make_api_version, symlink,
+                                        update_static_metadata)
 from readthedocs.projects.version_handling import determine_stable_version
 from readthedocs.projects.version_handling import version_windows
 from taggit.managers import TaggableManager
@@ -35,6 +37,12 @@ log = logging.getLogger(__name__)
 
 
 class ProjectRelationship(models.Model):
+
+    """Project to project relationship
+
+    This is used for subprojects
+    """
+
     parent = models.ForeignKey('Project', verbose_name=_('Parent'),
                                related_name='subprojects')
     child = models.ForeignKey('Project', verbose_name=_('Child'),
@@ -50,6 +58,9 @@ class ProjectRelationship(models.Model):
 
 
 class Project(models.Model):
+
+    """Project model"""
+
     # Auto fields
     pub_date = models.DateTimeField(_('Publication date'), auto_now_add=True)
     modified_date = models.DateTimeField(_('Modified date'), auto_now=True)
@@ -84,7 +95,10 @@ class Project(models.Model):
                               default='.rst')
     single_version = models.BooleanField(
         _('Single version'), default=False,
-        help_text=_('A single version site has no translations and only your "latest" version, served at the root of the domain. Use this with caution, only turn it on if you will <b>never</b> have multiple versions of your docs.'))
+        help_text=_('A single version site has no translations and only your '
+                    '"latest" version, served at the root of the domain. Use '
+                    'this with caution, only turn it on if you will <b>never</b>'
+                    'have multiple versions of your docs.'))
     default_version = models.CharField(
         _('Default version'), max_length=255, default=LATEST,
         help_text=_('The version of your project that / redirects to'))
@@ -189,10 +203,12 @@ class Project(models.Model):
                                             "Note: this affects your project's URL."),
                                 choices=constants.LANGUAGES)
 
-    programming_language = models.CharField(_('Programming Language'), max_length=20, default='words',
-                                            help_text=_(
-                                                "The primary programming language the project is written in."),
-                                            choices=constants.PROGRAMMING_LANGUAGES, blank=True)
+    programming_language = models.CharField(
+        _('Programming Language'),
+        max_length=20,
+        default='words',
+        help_text=_("The primary programming language the project is written in."),
+        choices=constants.PROGRAMMING_LANGUAGES, blank=True)
     # A subproject pointed at it's main language, so it can be tracked
     main_language_project = models.ForeignKey('self',
                                               related_name='translations',
@@ -300,9 +316,9 @@ class Project(models.Model):
         return reverse('projects_detail', args=[self.slug])
 
     def get_docs_url(self, version_slug=None, lang_slug=None):
-        """
-        Return a url for the docs. Always use http for now,
-        to avoid content warnings.
+        """Return a url for the docs
+
+        Always use http for now, to avoid content warnings.
         """
         protocol = "http"
         version = version_slug or self.get_default_version()
@@ -366,29 +382,33 @@ class Project(models.Model):
             'project_slug': self.slug,
         })
 
-    def get_production_media_path(self, type, version_slug, include_file=True):
-        """
-        Get file path for media files in production.
+    def get_production_media_path(self, type_, version_slug, include_file=True):
+        """Get file path for media files in production
+
         This is used to see if these files exist so we can offer them for download.
+
+        :param type_: Media content type, ie - 'pdf', 'zip'
+        :param version_slug: Project version slug for lookup
+        :param include_file: Include file name in return
+        :type include_file: bool
+        :returns: Full path to media file or path
         """
         if getattr(settings, 'DEFAULT_PRIVACY_LEVEL', 'public') == 'public':
             path = os.path.join(
-                settings.MEDIA_ROOT, type, self.slug, version_slug)
+                settings.MEDIA_ROOT, type_, self.slug, version_slug)
         else:
             path = os.path.join(
-                settings.PRODUCTION_MEDIA_ARTIFACTS, type, self.slug, version_slug)
+                settings.PRODUCTION_MEDIA_ARTIFACTS, type_, self.slug, version_slug)
         if include_file:
             path = os.path.join(
-                path, '%s.%s' % (self.slug, type.replace('htmlzip', 'zip')))
+                path, '%s.%s' % (self.slug, type_.replace('htmlzip', 'zip')))
         return path
 
-    def get_production_media_url(self, type, version_slug, full_path=True):
-        """
-        Get the URL for downloading a specific media file.
-        """
+    def get_production_media_url(self, type_, version_slug, full_path=True):
+        """Get the URL for downloading a specific media file."""
         path = reverse('project_download_media', kwargs={
             'project_slug': self.slug,
-            'type': type,
+            'type_': type_,
             'version_slug': version_slug,
         })
         if full_path:
@@ -413,6 +433,7 @@ class Project(models.Model):
 
     @property
     def clean_canonical_url(self):
+        """Normalize canonical URL field"""
         if not self.canonical_url:
             return ""
         parsed = urlparse(self.canonical_url)
@@ -461,45 +482,37 @@ class Project(models.Model):
         return os.path.join(settings.CNAME_ROOT, domain)
 
     def translations_symlink_path(self, language=None):
-        """
-        Path in the doc_path that we symlink translations
-        """
+        """Path in the doc_path that we symlink translations"""
         if not language:
             language = self.language
         return os.path.join(self.doc_path, 'translations', language)
 
     def subprojects_symlink_path(self, project):
-        """
-        Path in the doc_path that we symlink subprojects
-        """
+        """Path in the doc_path that we symlink subprojects"""
         return os.path.join(self.doc_path, 'subprojects', project)
 
     def single_version_symlink_path(self):
-        """
-        Path in the doc_path for the single_version symlink.
-        """
+        """Path in the doc_path for the single_version symlink"""
         return os.path.join(self.doc_path, 'single_version')
 
     #
     # End symlink paths
     #
 
-    def venv_bin(self, version=LATEST, bin=None):
+    def venv_bin(self, version=LATEST, filename=None):
         """Return path to the virtualenv bin path, or a specific binary
 
-        If ``bin`` is :py:data:`None`, then return the path to the virtual env
-        path, otherwise, return the path to the executable ``bin`` in the
-        virtual env ``bin`` path
+        :param version: Version slug to use in path name
+        :param filename: If specified, add this filename to the path return
+        :returns: Path to virtualenv bin or filename in virtualenv bin
         """
         parts = [self.venv_path(version), 'bin']
-        if bin is not None:
-            parts.append(bin)
+        if filename is not None:
+            parts.append(filename)
         return os.path.join(*parts)
 
     def full_doc_path(self, version=LATEST):
-        """
-        The path to the documentation root in the project.
-        """
+        """The path to the documentation root in the project"""
         doc_base = self.checkout_path(version)
         for possible_path in ['docs', 'doc', 'Doc']:
             if os.path.exists(os.path.join(doc_base, '%s' % possible_path)):
@@ -507,28 +520,20 @@ class Project(models.Model):
         # No docs directory, docs are at top-level.
         return doc_base
 
-    def artifact_path(self, type, version=LATEST):
-        """
-        The path to the build html docs in the project.
-        """
-        return os.path.join(self.doc_path, "artifacts", version, type)
+    def artifact_path(self, type_, version=LATEST):
+        """The path to the build html docs in the project"""
+        return os.path.join(self.doc_path, "artifacts", version, type_)
 
     def full_build_path(self, version=LATEST):
-        """
-        The path to the build html docs in the project.
-        """
+        """The path to the build html docs in the project"""
         return os.path.join(self.conf_dir(version), "_build", "html")
 
     def full_latex_path(self, version=LATEST):
-        """
-        The path to the build LaTeX docs in the project.
-        """
+        """The path to the build LaTeX docs in the project"""
         return os.path.join(self.conf_dir(version), "_build", "latex")
 
     def full_epub_path(self, version=LATEST):
-        """
-        The path to the build epub docs in the project.
-        """
+        """The path to the build epub docs in the project"""
         return os.path.join(self.conf_dir(version), "_build", "epub")
 
     # There is currently no support for building man/dash formats, but we keep
@@ -536,45 +541,34 @@ class Project(models.Model):
     # legacy builds.
 
     def full_man_path(self, version=LATEST):
-        """
-        The path to the build man docs in the project.
-        """
+        """The path to the build man docs in the project"""
         return os.path.join(self.conf_dir(version), "_build", "man")
 
     def full_dash_path(self, version=LATEST):
-        """
-        The path to the build dash docs in the project.
-        """
+        """The path to the build dash docs in the project"""
         return os.path.join(self.conf_dir(version), "_build", "dash")
 
     def full_json_path(self, version=LATEST):
-        """
-        The path to the build json docs in the project.
-        """
+        """The path to the build json docs in the project"""
         if 'sphinx' in self.documentation_type:
             return os.path.join(self.conf_dir(version), "_build", "json")
         elif 'mkdocs' in self.documentation_type:
             return os.path.join(self.checkout_path(version), "_build", "json")
 
     def full_singlehtml_path(self, version=LATEST):
-        """
-        The path to the build singlehtml docs in the project.
-        """
+        """The path to the build singlehtml docs in the project"""
         return os.path.join(self.conf_dir(version), "_build", "singlehtml")
 
     def rtd_build_path(self, version=LATEST):
-        """
-        The destination path where the built docs are copied.
-        """
+        """The destination path where the built docs are copied"""
         return os.path.join(self.doc_path, 'rtd-builds', version)
 
     def static_metadata_path(self):
-        """
-        The path to the static metadata JSON settings file
-        """
+        """The path to the static metadata JSON settings file"""
         return os.path.join(self.doc_path, 'metadata.json')
 
     def conf_file(self, version=LATEST):
+        """Find a ``conf.py`` file in the project checkout"""
         if self.conf_py_file:
             conf_path = os.path.join(self.checkout_path(version), self.conf_py_file)
             if os.path.exists(conf_path):
@@ -587,9 +581,9 @@ class Project(models.Model):
             files = self.full_find('conf.py', version)
         if len(files) == 1:
             return files[0]
-        for file in files:
-            if file.find('doc', 70) != -1:
-                return file
+        for filename in files:
+            if filename.find('doc', 70) != -1:
+                return filename
         # Having this be translatable causes this odd error:
         # ProjectImportError(<django.utils.functional.__proxy__ object at
         # 0x1090cded0>,)
@@ -603,12 +597,12 @@ class Project(models.Model):
 
     @property
     def is_type_sphinx(self):
-        '''Is project type Sphinx'''
+        """Is project type Sphinx"""
         return 'sphinx' in self.documentation_type
 
     @property
     def is_type_mkdocs(self):
-        '''Is project type Mkdocs'''
+        """Is project type Mkdocs"""
         return 'mkdocs' in self.documentation_type
 
     @property
@@ -630,15 +624,18 @@ class Project(models.Model):
     def has_pdf(self, version_slug=LATEST):
         if not self.enable_pdf_build:
             return False
-        return os.path.exists(self.get_production_media_path(type='pdf', version_slug=version_slug))
+        return os.path.exists(self.get_production_media_path(
+            type_='pdf', version_slug=version_slug))
 
     def has_epub(self, version_slug=LATEST):
         if not self.enable_epub_build:
             return False
-        return os.path.exists(self.get_production_media_path(type='epub', version_slug=version_slug))
+        return os.path.exists(self.get_production_media_path(
+            type_='epub', version_slug=version_slug))
 
     def has_htmlzip(self, version_slug=LATEST):
-        return os.path.exists(self.get_production_media_path(type='htmlzip', version_slug=version_slug))
+        return os.path.exists(self.get_production_media_path(
+            type_='htmlzip', version_slug=version_slug))
 
     @property
     def sponsored(self):
@@ -660,23 +657,27 @@ class Project(models.Model):
     def repo_lock(self, version, timeout=5, polling_interval=5):
         return Lock(self, version, timeout, polling_interval)
 
-    def find(self, file, version):
-        """
-        A balla API to find files inside of a projects dir.
+    def find(self, filename, version):
+        """Find files inside the project's ``doc`` path
+
+        :param filename: Filename to search for in project checkout
+        :param version: Version instance to set version checkout path
         """
         matches = []
-        for root, dirnames, filenames in os.walk(self.full_doc_path(version)):
-            for filename in fnmatch.filter(filenames, file):
+        for root, __, filenames in os.walk(self.full_doc_path(version)):
+            for filename in fnmatch.filter(filenames, filename):
                 matches.append(os.path.join(root, filename))
         return matches
 
-    def full_find(self, file, version):
-        """
-        A balla API to find files inside of a projects dir.
+    def full_find(self, filename, version):
+        """Find files inside a project's checkout path
+
+        :param filename: Filename to search for in project checkout
+        :param version: Version instance to set version checkout path
         """
         matches = []
-        for root, dirnames, filenames in os.walk(self.checkout_path(version)):
-            for filename in fnmatch.filter(filenames, file):
+        for root, __, filenames in os.walk(self.checkout_path(version)):
+            for filename in fnmatch.filter(filenames, filename):
                 matches.append(os.path.join(root, filename))
         return matches
 
@@ -712,16 +713,20 @@ class Project(models.Model):
         return sort_version_aware(versions)
 
     def all_active_versions(self):
-        """A temporary workaround for active_versions filtering out things
-        that were active, but failed to build
+        """Get queryset with all active versions
 
+        .. note::
+            This is a temporary workaround for activate_versions filtering out
+            things that were active, but failed to build
+
+        :returns: :py:cls:`Version` queryset
         """
         return self.versions.filter(active=True)
 
     def supported_versions(self):
-        """
-        Get the list of supported versions.
-        Returns a list of version strings.
+        """Get the list of supported versions
+
+        :returns: List of version strings.
         """
         if not self.num_major or not self.num_minor or not self.num_point:
             return []
@@ -737,10 +742,10 @@ class Project(models.Model):
         return self.versions.filter(slug=STABLE).first()
 
     def update_stable_version(self):
-        """
-        Returns the version that was promoited to be the new stable version.
-        It will return ``None`` if no update was mode or if there is no
-        version on the project that can be considered stable.
+        """Returns the version that was promoted to be the new stable version
+
+        Return ``None`` if no update was mode or if there is no version on the
+        project that can be considered stable.
         """
         versions = self.versions.all()
         new_stable = determine_stable_version(versions)
@@ -800,16 +805,14 @@ class Project(models.Model):
         return LATEST
 
     def get_default_branch(self):
-        """
-        Get the version representing "latest"
-        """
+        """Get the version representing 'latest'"""
         if self.default_branch:
             return self.default_branch
         else:
             return self.vcs_repo().fallback_branch
 
     def add_subproject(self, child):
-        subproject, created = ProjectRelationship.objects.get_or_create(
+        subproject, __ = ProjectRelationship.objects.get_or_create(
             parent=self, child=child,
         )
         return subproject
@@ -829,16 +832,27 @@ class Project(models.Model):
 
         return queue
 
-    def add_node(self, node_hash, page, version, commit):
+    def add_node(self, content_hash, page, version, commit):
+        """Add comment node
+
+        :param content_hash: Hash of node content
+        :param page: Doc page for node
+        :param version: Slug for project version to apply node to
+        :type version: str
+        :param commit: Commit that node was updated in
+        :type commit: str
+        """
         from readthedocs.comments.models import NodeSnapshot, DocumentNode
         project_obj = Project.objects.get(slug=self.slug)
         version_obj = project_obj.versions.get(slug=version)
         try:
-            NodeSnapshot.objects.get(hash=node_hash, node__project=project_obj, node__version=version_obj, node__page=page, commit=commit)
+            NodeSnapshot.objects.get(hash=content_hash, node__project=project_obj,
+                                     node__version=version_obj, node__page=page,
+                                     commit=commit)
             return False  # ie, no new node was created.
         except NodeSnapshot.DoesNotExist:
             DocumentNode.objects.create(
-                hash=node_hash,
+                hash=content_hash,
                 page=page,
                 project=project_obj,
                 version=version_obj,
@@ -846,17 +860,34 @@ class Project(models.Model):
             )
         return True  # ie, it's True that a new node was created.
 
-    def add_comment(self, version_slug, page, hash, commit, user, text):
+    def add_comment(self, version_slug, page, content_hash, commit, user, text):
+        """Add comment to node
+
+        :param version_slug: Version slug to use for node lookup
+        :param page: Page to attach comment to
+        :param content_hash: Hash of content to apply comment to
+        :param commit: Commit that updated comment
+        :param user: :py:cls:`User` instance that created comment
+        :param text: Comment text
+        """
         from readthedocs.comments.models import DocumentNode
         try:
-            node = self.nodes.from_hash(version_slug, page, hash)
+            node = self.nodes.from_hash(version_slug, page, content_hash)
         except DocumentNode.DoesNotExist:
             version = self.versions.get(slug=version_slug)
-            node = self.nodes.create(version=version, page=page, hash=hash, commit=commit)
+            node = self.nodes.create(version=version, page=page,
+                                     hash=content_hash, commit=commit)
         return node.comments.create(user=user, text=text)
 
 
 class ImportedFile(models.Model):
+
+    """Imported files model
+
+    This tracks files that are output from documentation builds, useful for
+    things like CDN invalidation.
+    """
+
     project = models.ForeignKey('Project', verbose_name=_('Project'),
                                 related_name='imported_files')
     version = models.ForeignKey('builds.Version', verbose_name=_('Version'),

--- a/readthedocs/projects/search_indexes.py
+++ b/readthedocs/projects/search_indexes.py
@@ -1,12 +1,18 @@
 # -*- coding: utf-8 -*-
 
+"""
+Project search indexes
+
+.. deprecated::
+    Read the Docs no longer uses Haystack in production and the core team does
+    not maintain this code. Use at your own risk, this may go away soon.
+"""
+
 import codecs
 import os
 
 from django.conf import settings
 from django.utils.html import strip_tags
-
-#from haystack import site
 from haystack import indexes
 from haystack.fields import CharField
 
@@ -18,6 +24,9 @@ log = logging.getLogger(__name__)
 
 
 class ProjectIndex(indexes.SearchIndex, indexes.Indexable):
+
+    """Project search index"""
+
     text = CharField(document=True, use_template=True)
     author = CharField()
     title = CharField(model_attr='name')
@@ -35,12 +44,15 @@ class ProjectIndex(indexes.SearchIndex, indexes.Indexable):
         return Project
 
     def index_queryset(self, using=None):
-        "Used when the entire index for model is updated."
+        """Used when the entire index for model is updated"""
         return self.get_model().objects.public()
 
 
-#Should prob make a common subclass for this and FileIndex
+# TODO Should prob make a common subclass for this and FileIndex
 class ImportedFileIndex(indexes.SearchIndex, indexes.Indexable):
+
+    """Search index for imported files"""
+
     text = CharField(document=True)
     author = CharField()
     project = CharField(model_attr='project__name', faceted=True)
@@ -58,12 +70,11 @@ class ImportedFileIndex(indexes.SearchIndex, indexes.Indexable):
         return obj.get_absolute_url()
 
     def prepare_text(self, obj):
+        """Prepare the text of the html file
+
+        This only works on machines that have the html files for the projects
+        checked out.
         """
-        Prepare the text of the html file.
-        This only works on machines that have the html
-        files for the projects checked out.
-        """
-        #Import this here to hopefully fix tests for now.
         from pyquery import PyQuery
         full_path = obj.project.rtd_build_path()
         file_path = os.path.join(full_path, obj.path.lstrip('/'))
@@ -71,29 +82,30 @@ class ImportedFileIndex(indexes.SearchIndex, indexes.Indexable):
             with codecs.open(file_path, encoding='utf-8', mode='r') as f:
                 content = f.read()
         except IOError as e:
-            log.info('(Search Index) Unable to index file: %s, error :%s' % (file_path, e))
+            log.info('(Search Index) Unable to index file: %s, error :%s',
+                     file_path, e)
             return
-        log.debug('(Search Index) Indexing %s:%s' % (obj.project, obj.path))
-        DOCUMENT_PYQUERY_PATH = getattr(settings, 'DOCUMENT_PYQUERY_PATH',
+        log.debug('(Search Index) Indexing %s:%s', obj.project, obj.path)
+        document_pyquery_path = getattr(settings, 'DOCUMENT_PYQUERY_PATH',
                                         'div.document')
         try:
             to_index = strip_tags(PyQuery(content)(
-                DOCUMENT_PYQUERY_PATH).html()).replace(u'¶', '')
+                document_pyquery_path).html()).replace(u'¶', '')
         except ValueError:
-            #Pyquery returns ValueError if div.document doesn't exist.
+            # Pyquery returns ValueError if div.document doesn't exist.
             return
         if not to_index:
-            log.info('(Search Index) Unable to index file: %s:%s, empty file' % (obj.project,
-                                                                  file_path))
+            log.info('(Search Index) Unable to index file: %s:%s, empty file',
+                     obj.project, file_path)
         else:
-            log.debug('(Search Index) %s:%s length: %s' % (obj.project, file_path,
-                                            len(to_index)))
+            log.debug('(Search Index) %s:%s length: %s', obj.project, file_path,
+                      len(to_index))
         return to_index
 
     def get_model(self):
         return ImportedFile
 
     def index_queryset(self, using=None):
-        "Used when the entire index for model is updated."
+        """Used when the entire index for model is updated"""
         return (self.get_model().objects
                 .filter(project__privacy_level=constants.PUBLIC))

--- a/readthedocs/projects/signals.py
+++ b/readthedocs/projects/signals.py
@@ -1,13 +1,12 @@
+"""Project signals"""
+
 import logging
-import json
 
 import django.dispatch
-from django.conf import settings
 from django.contrib import messages
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
 
-from readthedocs.builds import utils as build_utils
 from readthedocs.oauth import utils as oauth_utils
 
 before_vcs = django.dispatch.Signal(providing_args=["version"])
@@ -24,10 +23,7 @@ log = logging.getLogger(__name__)
 
 @receiver(project_import)
 def handle_project_import(sender, **kwargs):
-    """
-    Add post-commit hook on project import.
-    """
-
+    """Add post-commit hook on project import"""
     project = sender
     request = kwargs.get('request')
 
@@ -41,6 +37,8 @@ def handle_project_import(sender, **kwargs):
                     resp = oauth_utils.add_github_webhook(session, project)
                     if resp.status_code == 201:
                         messages.success(request, _('GitHub webhook activated'))
+                # pylint: disable=bare-except
+                # TODO this should be audited for exception types
                 except:
                     log.exception('GitHub Hook creation failed', exc_info=True)
             elif provider == 'bitbucket':
@@ -48,5 +46,7 @@ def handle_project_import(sender, **kwargs):
                     resp = oauth_utils.add_bitbucket_webhook(session, project)
                     if resp.status_code == 200:
                         messages.success(request, _('BitBucket webhook activated'))
+                # pylint: disable=bare-except
+                # TODO this should be audited for exception types
                 except:
                     log.exception('BitBucket Hook creation failed', exc_info=True)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1,15 +1,15 @@
-"""Tasks related to projects, including fetching repository code, cleaning
-``conf.py`` files, and rebuilding documentation.
+"""Tasks related to projects
+
+This includes fetching repository code, cleaning ``conf.py`` files, and
+rebuilding documentation.
 """
-import fnmatch
+
 import os
-import sys
 import shutil
 import json
 import logging
 import socket
 import requests
-import datetime
 import hashlib
 from collections import defaultdict
 
@@ -18,23 +18,18 @@ from djcelery import celery as celery_app
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
-from slumber.exceptions import HttpClientError
-from docker import errors as docker_errors
 
-from readthedocs.builds.constants import (LATEST, BUILD_STATE_TRIGGERED,
+from readthedocs.builds.constants import (LATEST,
                                           BUILD_STATE_CLONING,
                                           BUILD_STATE_INSTALLING,
-                                          BUILD_STATE_BUILDING,
-                                          BUILD_STATE_FINISHED)
+                                          BUILD_STATE_BUILDING)
 from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import send_email, run_on_app_servers
 from readthedocs.cdn.purge import purge
 from readthedocs.doc_builder.loader import get_builder_class
-from readthedocs.doc_builder.base import restoring_chdir
 from readthedocs.doc_builder.environments import (LocalEnvironment,
                                                   DockerEnvironment)
-from readthedocs.doc_builder.exceptions import (BuildEnvironmentError,
-                                                BuildEnvironmentWarning)
+from readthedocs.doc_builder.exceptions import BuildEnvironmentError
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.projects.models import ImportedFile, Project
 from readthedocs.projects.utils import make_api_version, make_api_project
@@ -57,6 +52,7 @@ HTML_ONLY = getattr(settings, 'HTML_ONLY_PROJECTS', ())
 
 
 class UpdateDocsTask(Task):
+
     """
     The main entry point for updating documentation.
 
@@ -72,6 +68,7 @@ class UpdateDocsTask(Task):
         from the shell, for example.
 
     """
+
     max_retries = 5
     default_retry_delay = (7 * 60)
     name = 'update_docs'
@@ -93,8 +90,7 @@ class UpdateDocsTask(Task):
             self.project = project
 
     def run(self, pk, version_pk=None, build_pk=None, record=True, docker=False,
-            search=True, force=False, intersphinx=True, localmedia=True,
-            basic=False, **kwargs):
+            search=True, force=False, localmedia=True, **kwargs):
         env_cls = LocalEnvironment
         if docker or settings.DOCKER_ENABLE:
             env_cls = DockerEnvironment
@@ -147,18 +143,14 @@ class UpdateDocsTask(Task):
 
     @staticmethod
     def get_project(project_pk):
-        """
-        Get project from API
-        """
+        """Get project from API"""
         project_data = api_v1.project(project_pk).get()
         project = make_api_project(project_data)
         return project
 
     @staticmethod
     def get_version(project, version_pk):
-        """
-        Ensure we're using a sane version.
-        """
+        """Ensure we're using a sane version"""
         if version_pk:
             version_data = api_v1.version(version_pk).get()
         else:
@@ -198,6 +190,7 @@ class UpdateDocsTask(Task):
     def setup_vcs(self):
         """
         Update the checkout of the repo to make sure it's the latest.
+
         This also syncs versions in the DB.
 
         :param build_env: Build environment
@@ -209,7 +202,7 @@ class UpdateDocsTask(Task):
                          version=self.version.slug,
                          msg='Updating docs from VCS'))
         try:
-            update_output = update_imported_docs(self.version.pk)
+            update_imported_docs(self.version.pk)
             commit = self.project.vcs_repo(self.version.slug).commit
             if commit:
                 self.build['commit'] = commit
@@ -266,7 +259,7 @@ class UpdateDocsTask(Task):
 
         cmd = [
             'python',
-            self.project.venv_bin(version=self.version.slug, bin='pip'),
+            self.project.venv_bin(version=self.version.slug, filename='pip'),
             'install',
             '--use-wheel',
             '--find-links={0}'.format(wheeldir),
@@ -301,7 +294,7 @@ class UpdateDocsTask(Task):
         if requirements_file_path:
             self.build_env.run(
                 'python',
-                self.project.venv_bin(version=self.version.slug, bin='pip'),
+                self.project.venv_bin(version=self.version.slug, filename='pip'),
                 'install',
                 '--exists-action=w',
                 '-r{0}'.format(requirements_file_path),
@@ -316,7 +309,7 @@ class UpdateDocsTask(Task):
             if getattr(settings, 'USE_PIP_INSTALL', False):
                 self.build_env.run(
                     'python',
-                    self.project.venv_bin(version=self.version.slug, bin='pip'),
+                    self.project.venv_bin(version=self.version.slug, filename='pip'),
                     'install',
                     '--ignore-installed',
                     '.',
@@ -360,6 +353,7 @@ class UpdateDocsTask(Task):
         return outcomes
 
     def build_docs_html(self):
+        """Build HTML docs"""
         html_builder = get_builder_class(self.project.documentation_type)(
             self.build_env
         )
@@ -384,7 +378,7 @@ class UpdateDocsTask(Task):
         return success
 
     def build_docs_search(self):
-        '''Build search data with separate build'''
+        """Build search data with separate build"""
         if self.build_search:
             if self.project.is_type_mkdocs:
                 return self.build_docs_class('mkdocs_json')
@@ -393,14 +387,14 @@ class UpdateDocsTask(Task):
         return False
 
     def build_docs_localmedia(self):
-        '''Get local media files with separate build'''
+        """Get local media files with separate build"""
         if self.build_localmedia:
             if self.project.is_type_sphinx:
                 return self.build_docs_class('sphinx_singlehtmllocalmedia')
         return False
 
     def build_docs_pdf(self):
-        '''Build PDF docs'''
+        """Build PDF docs"""
         if (self.project.slug in HTML_ONLY or
                 not self.project.is_type_sphinx or
                 not self.project.enable_pdf_build):
@@ -408,7 +402,7 @@ class UpdateDocsTask(Task):
         return self.build_docs_class('sphinx_pdf')
 
     def build_docs_epub(self):
-        '''Build ePub docs'''
+        """Build ePub docs"""
         if (self.project.slug in HTML_ONLY or
                 not self.project.is_type_sphinx or
                 not self.project.enable_epub_build):
@@ -438,7 +432,9 @@ update_docs = celery_app.tasks[UpdateDocsTask.name]
 @task()
 def update_imported_docs(version_pk):
     """
-    Check out or update the given project's repository.
+    Check out or update the given project's repository
+
+    :param version_pk: Version id to update
     """
     version_data = api_v1.version(version_pk).get()
     version = make_api_version(version_data)
@@ -512,9 +508,7 @@ def update_imported_docs(version_pk):
 @task(queue='web')
 def finish_build(version_pk, build_pk, hostname=None, html=False,
                  localmedia=False, search=False, pdf=False, epub=False):
-    """
-    Build Finished, do house keeping bits
-    """
+    """Build Finished, do house keeping bits"""
     version = Version.objects.get(pk=version_pk)
     build = Build.objects.get(pk=build_pk)
 
@@ -553,45 +547,76 @@ def finish_build(version_pk, build_pk, hostname=None, html=False,
 
 
 @task(queue='web')
-def move_files(version_pk, hostname, html=False, localmedia=False, search=False, pdf=False, epub=False):
+def move_files(version_pk, hostname, html=False, localmedia=False, search=False,
+               pdf=False, epub=False):
+    """Task to move built documentation to web servers
+
+    :param version_pk: Version id to sync files for
+    :param hostname: Hostname to sync to
+    :param html: Sync HTML
+    :type html: bool
+    :param localmedia: Sync local media files
+    :type localmedia: bool
+    :param search: Sync search files
+    :type search: bool
+    :param pdf: Sync PDF files
+    :type pdf: bool
+    :param epub: Sync ePub files
+    :type epub: bool
+    """
     version = Version.objects.get(pk=version_pk)
 
     if html:
-        from_path = version.project.artifact_path(version=version.slug, type=version.project.documentation_type)
+        from_path = version.project.artifact_path(
+            version=version.slug, type_=version.project.documentation_type)
         target = version.project.rtd_build_path(version.slug)
         Syncer.copy(from_path, target, host=hostname)
 
     if 'sphinx' in version.project.documentation_type:
         if localmedia:
-            from_path = version.project.artifact_path(version=version.slug, type='sphinx_localmedia')
-            to_path = version.project.get_production_media_path(type='htmlzip', version_slug=version.slug, include_file=False)
+            from_path = version.project.artifact_path(
+                version=version.slug, type_='sphinx_localmedia')
+            to_path = version.project.get_production_media_path(
+                type_='htmlzip', version_slug=version.slug, include_file=False)
             Syncer.copy(from_path, to_path, host=hostname)
 
         if search:
-            from_path = version.project.artifact_path(version=version.slug, type='sphinx_search')
-            to_path = version.project.get_production_media_path(type='json', version_slug=version.slug, include_file=False)
+            from_path = version.project.artifact_path(
+                version=version.slug, type_='sphinx_search')
+            to_path = version.project.get_production_media_path(
+                type_='json', version_slug=version.slug, include_file=False)
             Syncer.copy(from_path, to_path, host=hostname)
 
         # Always move PDF's because the return code lies.
         if pdf:
-            from_path = version.project.artifact_path(version=version.slug, type='sphinx_pdf')
-            to_path = version.project.get_production_media_path(type='pdf', version_slug=version.slug, include_file=False)
+            from_path = version.project.artifact_path(version=version.slug,
+                                                      type_='sphinx_pdf')
+            to_path = version.project.get_production_media_path(
+                type_='pdf', version_slug=version.slug, include_file=False)
             Syncer.copy(from_path, to_path, host=hostname)
         if epub:
-            from_path = version.project.artifact_path(version=version.slug, type='sphinx_epub')
-            to_path = version.project.get_production_media_path(type='epub', version_slug=version.slug, include_file=False)
+            from_path = version.project.artifact_path(version=version.slug,
+                                                      type_='sphinx_epub')
+            to_path = version.project.get_production_media_path(
+                type_='epub', version_slug=version.slug, include_file=False)
             Syncer.copy(from_path, to_path, host=hostname)
 
     if 'mkdocs' in version.project.documentation_type:
         if search:
-            from_path = version.project.artifact_path(version=version.slug, type='mkdocs_json')
-            to_path = version.project.get_production_media_path(type='json', version_slug=version.slug, include_file=False)
+            from_path = version.project.artifact_path(version=version.slug,
+                                                      type_='mkdocs_json')
+            to_path = version.project.get_production_media_path(
+                type_='json', version_slug=version.slug, include_file=False)
             Syncer.copy(from_path, to_path, host=hostname)
 
 
 @task(queue='web')
 def update_search(version_pk, commit):
+    """Task to update search indexes
 
+    :param version_pk: Version id to update
+    :param commit: Commit that updated index
+    """
     version = Version.objects.get(pk=version_pk)
 
     if version.project.is_type_sphinx:
@@ -599,11 +624,13 @@ def update_search(version_pk, commit):
     elif version.project.is_type_mkdocs:
         page_list = process_mkdocs_json(version, build_dir=False)
     else:
-        log.error('Unknown documentation type: %s' % version.project.documentation_type)
+        log.error('Unknown documentation type: %s',
+                  version.project.documentation_type)
         return
 
     log_msg = ' '.join([page['path'] for page in page_list])
-    log.info("(Search Index) Sending Data: %s [%s]" % (version.project.slug, log_msg))
+    log.info("(Search Index) Sending Data: %s [%s]", version.project.slug,
+             log_msg)
     index_search_request(
         version=version,
         page_list=page_list,
@@ -631,28 +658,39 @@ def fileify(version_pk, commit):
         return
 
     if not commit:
-        log.info(LOG_TEMPLATE.format(
-            project=project.slug, version=version.slug, msg='Imported File not being built because no commit information'))
+        log.info(LOG_TEMPLATE
+                 .format(project=project.slug, version=version.slug,
+                         msg=('Imported File not being built because no commit '
+                              'information')))
 
     path = project.rtd_build_path(version.slug)
     if path:
-        log.info(LOG_TEMPLATE.format(
-            project=version.project.slug, version=version.slug, msg='Creating ImportedFiles'))
+        log.info(LOG_TEMPLATE
+                 .format(project=version.project.slug, version=version.slug,
+                         msg='Creating ImportedFiles'))
         _manage_imported_files(version, path, commit)
     else:
-        log.info(LOG_TEMPLATE.format(project=project.slug, version=version.slug, msg='No ImportedFile files'))
+        log.info(LOG_TEMPLATE
+                 .format(project=project.slug, version=version.slug,
+                         msg='No ImportedFile files'))
 
 
 def _manage_imported_files(version, path, commit):
+    """Update imported files for version
+
+    :param version: Version instance
+    :param path: Path to search
+    :param commit: Commit that updated path
+    """
     changed_files = set()
-    for root, dirnames, filenames in os.walk(path):
+    for root, __, filenames in os.walk(path):
         for filename in filenames:
             dirpath = os.path.join(root.replace(path, '').lstrip('/'),
                                    filename.lstrip('/'))
             full_path = os.path.join(root, filename)
             md5 = hashlib.md5(open(full_path, 'rb').read()).hexdigest()
             try:
-                obj, created = ImportedFile.objects.get_or_create(
+                obj, __ = ImportedFile.objects.get_or_create(
                     project=version.project,
                     version=version,
                     path=dirpath,
@@ -668,7 +706,9 @@ def _manage_imported_files(version, path, commit):
                 obj.commit = commit
             obj.save()
     # Delete ImportedFiles from previous versions
-    ImportedFile.objects.filter(project=version.project, version=version).exclude(commit=commit).delete()
+    ImportedFile.objects.filter(project=version.project,
+                                version=version
+                                ).exclude(commit=commit).delete()
     # Purge Cache
     purge(changed_files)
 
@@ -685,6 +725,12 @@ def send_notifications(version_pk, build_pk):
 
 
 def email_notification(version, build, email):
+    """Send email notifications for build failure
+
+    :param version: :py:cls:`Version` instance that failed
+    :param build: :py:cls:`Build` instance that failed
+    :param email: Email recipient address
+    """
     log.debug(LOG_TEMPLATE.format(project=version.project.slug, version=version.slug,
                                   msg='sending email to: %s' % email))
     context = {'version': version,
@@ -713,6 +759,12 @@ def email_notification(version, build, email):
 
 
 def webhook_notification(version, build, hook_url):
+    """Send webhook notification for project webhook
+
+    :param version: Version instance to send hook for
+    :param build: Build instance that failed
+    :param hook_url: Hook URL to send to
+    """
     project = version.project
 
     data = json.dumps({
@@ -724,7 +776,9 @@ def webhook_notification(version, build, hook_url):
             'date': build.date.strftime('%Y-%m-%d %H:%M:%S'),
         }
     })
-    log.debug(LOG_TEMPLATE.format(project=project.slug, version='', msg='sending notification to: %s' % hook_url))
+    log.debug(LOG_TEMPLATE
+              .format(project=project.slug, version='',
+                      msg='sending notification to: %s' % hook_url))
     requests.post(hook_url, data=data)
 
 
@@ -774,20 +828,6 @@ def update_static_metadata(project_pk, path=None):
         ))
 
 
-def update_docs_pull(record=False, force=False):
-    """
-    A high-level interface that will update all of the projects.
-
-    This is mainly used from a cronjob or management command.
-    """
-    for version in Version.objects.filter(built=True):
-        try:
-            update_docs.run(pk=version.project.pk, version_pk=version.pk,
-                            record=record)
-        except Exception, e:
-            log.error("update_docs_pull failed", exc_info=True)
-
-
 # Random Tasks
 @task()
 def remove_dir(path):
@@ -797,13 +837,13 @@ def remove_dir(path):
     This is mainly a wrapper around shutil.rmtree so that app servers
     can kill things on the build server.
     """
-    log.info("Removing %s" % path)
+    log.info("Removing %s", path)
     shutil.rmtree(path)
 
 
 @task(queue='web')
 def clear_artifacts(version_pk):
-    """ Remove artifacts from the web servers. """
+    """Remove artifacts from the web servers"""
     version = Version.objects.get(pk=version_pk)
     clear_pdf_artifacts(version)
     clear_epub_artifacts(version)
@@ -812,15 +852,21 @@ def clear_artifacts(version_pk):
 
 
 def clear_pdf_artifacts(version):
-    run_on_app_servers('rm -rf %s' % version.project.get_production_media_path(type='pdf', version_slug=version.slug))
+    run_on_app_servers('rm -rf %s'
+                       % version.project.get_production_media_path(
+                           type_='pdf', version_slug=version.slug))
 
 
 def clear_epub_artifacts(version):
-    run_on_app_servers('rm -rf %s' % version.project.get_production_media_path(type='epub', version_slug=version.slug))
+    run_on_app_servers('rm -rf %s'
+                       % version.project.get_production_media_path(
+                           type_='epub', version_slug=version.slug))
 
 
 def clear_htmlzip_artifacts(version):
-    run_on_app_servers('rm -rf %s' % version.project.get_production_media_path(type='htmlzip', version_slug=version.slug))
+    run_on_app_servers('rm -rf %s'
+                       % version.project.get_production_media_path(
+                           type_='htmlzip', version_slug=version.slug))
 
 
 def clear_html_artifacts(version):

--- a/readthedocs/projects/templatetags/projects_tags.py
+++ b/readthedocs/projects/templatetags/projects_tags.py
@@ -1,3 +1,5 @@
+"""Project template tags and filters"""
+
 from django import template
 
 from readthedocs.projects.version_handling import comparable_version
@@ -8,9 +10,7 @@ register = template.Library()
 
 @register.filter
 def sort_version_aware(versions):
-    """
-    Takes a list of versions objects and sort them caring about version schemes
-    """
+    """Takes a list of versions objects and sort them using version schemes"""
     return sorted(
         versions,
         key=lambda version: comparable_version(version.verbose_name),
@@ -19,7 +19,5 @@ def sort_version_aware(versions):
 
 @register.filter
 def is_project_user(user, project):
-    """
-    Return if user is a member of project.users
-    """
+    """Return if user is a member of project.users"""
     return user in project.users.all()

--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -1,3 +1,5 @@
+"""Project URLs for authenticated users"""
+
 from django.conf.urls import patterns, url
 
 from readthedocs.projects.views.private import AliasList, ProjectDashboard, ImportView
@@ -36,7 +38,7 @@ urlpatterns = patterns(
         'readthedocs.projects.views.private.project_manage',
         name='projects_manage'),
 
-    url(r'^(?P<project_slug>[-\w]+)/alias/(?P<id>\d+)/',
+    url(r'^(?P<project_slug>[-\w]+)/alias/(?P<alias_id>\d+)/',
         'readthedocs.projects.views.private.edit_alias',
         name='projects_alias_edit'),
 

--- a/readthedocs/projects/urls/public.py
+++ b/readthedocs/projects/urls/public.py
@@ -1,9 +1,12 @@
+"""Project URLS for public users"""
+
 from django.conf.urls import patterns, url
 
 from readthedocs.projects.views.public import ProjectIndex, ProjectDetailView
 
 from readthedocs.builds import views as build_views
 from readthedocs.constants import pattern_opts
+
 
 urlpatterns = patterns(
     # base view, flake8 complains if it is on the previous line.
@@ -28,7 +31,7 @@ urlpatterns = patterns(
         'readthedocs.projects.views.public.project_downloads',
         name='project_downloads'),
 
-    url((r'^(?P<project_slug>{project_slug})/downloads/(?P<type>[-\w]+)/'
+    url((r'^(?P<project_slug>{project_slug})/downloads/(?P<type_>[-\w]+)/'
          r'(?P<version_slug>{version_slug})/$'.format(**pattern_opts)),
         'readthedocs.projects.views.public.project_download_media',
         name='project_download_media'),

--- a/readthedocs/projects/version_handling.py
+++ b/readthedocs/projects/version_handling.py
@@ -1,3 +1,5 @@
+"""Project version handling"""
+
 from collections import defaultdict
 from packaging.version import Version
 from packaging.version import InvalidVersion
@@ -7,10 +9,12 @@ from readthedocs.builds.constants import STABLE_VERBOSE_NAME
 
 
 def get_major(version):
+    # pylint: disable=protected-access
     return version._version.release[0]
 
 
 def get_minor(version):
+    # pylint: disable=protected-access
     try:
         return version._version.release[1]
     except IndexError:
@@ -18,6 +22,9 @@ def get_minor(version):
 
 
 class VersionManager(object):
+
+    """Prune list of versions based on version windows"""
+
     def __init__(self):
         self._state = defaultdict(lambda: defaultdict(list))
 
@@ -27,7 +34,7 @@ class VersionManager(object):
     def prune_major(self, num_latest):
         all_keys = sorted(set(self._state.keys()))
         major_keep = []
-        for to_keep in range(num_latest):
+        for __ in range(num_latest):
             if len(all_keys) > 0:
                 major_keep.append(all_keys.pop(-1))
         for to_remove in all_keys:
@@ -37,7 +44,7 @@ class VersionManager(object):
         for major, minors in self._state.items():
             all_keys = sorted(set(minors.keys()))
             minor_keep = []
-            for to_keep in range(num_latest):
+            for __ in range(num_latest):
                 if len(all_keys) > 0:
                     minor_keep.append(all_keys.pop(-1))
             for to_remove in all_keys:
@@ -47,8 +54,9 @@ class VersionManager(object):
         for major, minors in self._state.items():
             for minor in minors.keys():
                 try:
-                    self._state[major][minor] = sorted(set(self._state[major][minor]))[-num_latest:]
-                except TypeError, e:
+                    self._state[major][minor] = sorted(
+                        set(self._state[major][minor]))[-num_latest:]
+                except TypeError:
                     # Raise these for now.
                     raise
 
@@ -65,6 +73,15 @@ class VersionManager(object):
 
 
 def version_windows(versions, major=1, minor=1, point=1):
+    """Return list of versions that have been pruned to version windows
+
+    Uses :py:cls:`VersionManager` to prune the list of versions
+
+    :param versions: List of version strings
+    :param major: Major version window
+    :param minor: Minor version window
+    :param point: Point version window
+    """
     # TODO: This needs some documentation on how VersionManager etc works and
     # some examples what the expected outcome is.
 
@@ -101,8 +118,8 @@ def comparable_version(version_string):
     The ``LATEST`` version shall always beat other versions in comparision.
     ``STABLE`` should be listed second. If we cannot figure out the version
     number then we still assume it's bigger than all other versions since we
-    cannot predict what it is."""
-
+    cannot predict what it is.
+    """
     comparable = parse_version_failsafe(version_string)
     if not comparable:
         if version_string == LATEST_VERBOSE_NAME:
@@ -135,7 +152,7 @@ def sort_versions(version_list):
         reverse=True))
 
 
-def highest_version(version_list, version_test=None):
+def highest_version(version_list):
     versions = sort_versions(version_list)
     if versions:
         return versions[0]
@@ -144,7 +161,8 @@ def highest_version(version_list, version_test=None):
 
 
 def determine_stable_version(version_list):
-    """
+    """Determine a stable version for version list
+
     Takes a list of ``Version`` model instances and returns the version
     instance which can be considered the most recent stable one. It will return
     ``None`` if there is no stable version in the list.

--- a/readthedocs/projects/views/base.py
+++ b/readthedocs/projects/views/base.py
@@ -1,11 +1,14 @@
+"""Base project views used for subclassing"""
+
 from readthedocs.projects.models import Project
 
 
 class ProjectOnboardMixin(object):
-    '''Add project onboard context data to project object views'''
+
+    """Add project onboard context data to project object views"""
 
     def get_context_data(self, **kwargs):
-        '''Add onboard context data'''
+        """Add onboard context data"""
         context = super(ProjectOnboardMixin, self).get_context_data(**kwargs)
         # If more than 1 project, don't show onboarding at all. This could
         # change in the future, to onboard each user maybe?

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -1,12 +1,13 @@
+"""Project views for authenticated users"""
+
 import logging
 import shutil
-import json
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib import messages
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotAllowed, Http404
+from django.http import HttpResponseRedirect, HttpResponseNotAllowed, Http404
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render_to_response, render
 from django.template import RequestContext
@@ -15,11 +16,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from formtools.wizard.views import SessionWizardView
 
-from allauth.socialaccount.models import SocialToken
-from requests_oauthlib import OAuth2Session
-
 from readthedocs.bookmarks.models import Bookmark
-from readthedocs.builds import utils as build_utils
 from readthedocs.builds.models import Version
 from readthedocs.builds.forms import AliasForm, VersionForm
 from readthedocs.builds.filters import VersionFilter
@@ -28,7 +25,7 @@ from readthedocs.core.utils import trigger_build
 from readthedocs.oauth.models import GithubProject, BitbucketProject
 from readthedocs.oauth import utils as oauth_utils
 from readthedocs.projects.forms import (
-    ProjectBackendForm, ProjectBasicsForm, ProjectExtraForm,
+    ProjectBasicsForm, ProjectExtraForm,
     ProjectAdvancedForm, UpdateProjectForm, SubprojectForm,
     build_versions_form, UserForm, EmailHookForm, TranslationForm,
     RedirectForm, WebHookForm)
@@ -53,10 +50,8 @@ class PrivateViewMixin(LoginRequiredMixin):
 
 class ProjectDashboard(PrivateViewMixin, ListView):
 
-    """
-    A dashboard!  If you aint know what that means you aint need to.
-    Essentially we show you an overview of your content.
-    """
+    """Project dashboard"""
+
     model = Project
     template_name = 'projects/project_dashboard.html'
 
@@ -65,8 +60,9 @@ class ProjectDashboard(PrivateViewMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(ProjectDashboard, self).get_context_data(**kwargs)
-        filter = VersionFilter(constants.IMPORTANT_VERSION_FILTERS, queryset=self.get_queryset())
-        context['filter'] = filter
+        version_filter = VersionFilter(constants.IMPORTANT_VERSION_FILTERS,
+                                       queryset=self.get_queryset())
+        context['filter'] = version_filter
 
         bookmarks = Bookmark.objects.filter(user=self.request.user)
 
@@ -79,11 +75,11 @@ class ProjectDashboard(PrivateViewMixin, ListView):
 
 
 @login_required
-def project_manage(request, project_slug):
-    """
-    The management view for a project, where you will have links to edit
-    the projects' configuration, edit the files associated with that
-    project, etc.
+def project_manage(__, project_slug):
+    """Project management view
+
+    Where you will have links to edit the projects' configuration, edit the
+    files associated with that project, etc.
 
     Now redirects to the normal /projects/<slug> view.
     """
@@ -103,7 +99,8 @@ def project_comments_moderation(request, project_slug):
 
 @login_required
 def project_edit(request, project_slug):
-    """
+    """Project edit view
+
     Edit an existing project - depending on what type of project is being
     edited (created or imported) a different form will be displayed
     """
@@ -130,7 +127,8 @@ def project_edit(request, project_slug):
 
 @login_required
 def project_advanced(request, project_slug):
-    """
+    """Project advanced admin view
+
     Edit an existing project - depending on what type of project is being
     edited (created or imported) a different form will be displayed
     """
@@ -155,7 +153,8 @@ def project_advanced(request, project_slug):
 
 @login_required
 def project_versions(request, project_slug):
-    """
+    """Project versions view
+
     Shows the available versions and lets the user choose which ones he would
     like to have built.
     """
@@ -184,6 +183,7 @@ def project_versions(request, project_slug):
 
 @login_required
 def project_version_detail(request, project_slug, version_slug):
+    """Project version detail page"""
     project = get_object_or_404(Project.objects.for_admin_user(request.user), slug=project_slug)
     version = get_object_or_404(
         Version.objects.public(user=request.user, project=project, only_active=False),
@@ -205,7 +205,8 @@ def project_version_detail(request, project_slug, version_slug):
 
 @login_required
 def project_delete(request, project_slug):
-    """
+    """Project delete confirmation view
+
     Make a project as deleted on POST, otherwise show a form asking for
     confirmation of delete.
     """
@@ -230,14 +231,14 @@ def project_delete(request, project_slug):
 
 class ImportWizardView(PrivateViewMixin, SessionWizardView):
 
-    '''Project import wizard'''
+    """Project import wizard"""
 
     form_list = [('basics', ProjectBasicsForm),
                  ('extra', ProjectExtraForm)]
     condition_dict = {'extra': lambda self: self.is_advanced()}
 
-    def get_form_kwargs(self, step):
-        '''Get args to pass into form instantiation'''
+    def get_form_kwargs(self, step=None):
+        """Get args to pass into form instantiation"""
         kwargs = {}
         kwargs['user'] = self.request.user
         if step == 'basics':
@@ -257,16 +258,16 @@ class ImportWizardView(PrivateViewMixin, SessionWizardView):
         return form
 
     def get_template_names(self):
-        '''Return template names based on step name'''
+        """Return template names based on step name"""
         return 'projects/import_{0}.html'.format(self.steps.current)
 
     def done(self, form_list, **kwargs):
-        '''Save form data as object instance
+        """Save form data as object instance
 
         Don't save form data directly, instead bypass documentation building and
         other side effects for now, by signalling a save without commit. Then,
         finish by added the members to the project and saving.
-        '''
+        """
         # expect the first form
         basics_form = form_list[0]
         # Save the basics form to create the project instance, then alter
@@ -283,19 +284,19 @@ class ImportWizardView(PrivateViewMixin, SessionWizardView):
                                             args=[project.slug]))
 
     def is_advanced(self):
-        '''Determine if the user selected the `show advanced` field'''
+        """Determine if the user selected the `show advanced` field"""
         data = self.get_cleaned_data_for_step('basics') or {}
         return data.get('advanced', True)
 
 
 class ImportView(PrivateViewMixin, TemplateView):
 
-    '''On GET, show the source select template, on POST, mock out a wizard
+    """On GET, show the source select template, on POST, mock out a wizard
 
     If we are accepting POST data, use the fields to seed the initial data in
     :py:cls:`ImportWizardView`.  The import templates will redirect the form to
     `/dashboard/import`
-    '''
+    """
 
     template_name = 'projects/project_import.html'
     wizard_class = ImportWizardView
@@ -313,7 +314,8 @@ class ImportView(PrivateViewMixin, TemplateView):
 
 
 class ImportDemoView(PrivateViewMixin, View):
-    '''View to pass request on to import form to import demo project'''
+
+    """View to pass request on to import form to import demo project"""
 
     form_class = ProjectBasicsForm
     request = None
@@ -321,7 +323,7 @@ class ImportDemoView(PrivateViewMixin, View):
     kwargs = None
 
     def get(self, request, *args, **kwargs):
-        '''Process link request as a form post to the project import form'''
+        """Process link request as a form post to the project import form"""
         self.request = request
         self.args = args
         self.kwargs = kwargs
@@ -342,7 +344,7 @@ class ImportDemoView(PrivateViewMixin, View):
                 messages.success(
                     request, _('Your demo project is currently being imported'))
             else:
-                for (_f, msg) in form.errors.items():
+                for (__, msg) in form.errors.items():
                     log.error(msg)
                 messages.error(request,
                                _('There was a problem adding the demo project'))
@@ -351,7 +353,7 @@ class ImportDemoView(PrivateViewMixin, View):
                                             args=[project.slug]))
 
     def get_form_data(self):
-        '''Get form data to post to import form'''
+        """Get form data to post to import form"""
         return {
             'name': '{0}-demo'.format(self.request.user.username),
             'repo_type': 'git',
@@ -359,15 +361,16 @@ class ImportDemoView(PrivateViewMixin, View):
         }
 
     def get_form_kwargs(self):
-        '''Form kwargs passed in during instantiation'''
+        """Form kwargs passed in during instantiation"""
         return {'user': self.request.user}
 
 
 @login_required
-def edit_alias(request, project_slug, id=None):
+def edit_alias(request, project_slug, alias_id=None):
+    """Edit project alias form view"""
     proj = get_object_or_404(Project.objects.for_admin_user(request.user), slug=project_slug)
-    if id:
-        alias = proj.aliases.get(pk=id)
+    if alias_id:
+        alias = proj.aliases.get(pk=alias_id)
         form = AliasForm(instance=alias, data=request.POST or None)
     else:
         form = AliasForm(request.POST or None)
@@ -396,6 +399,7 @@ class AliasList(PrivateViewMixin, ListView):
 
 @login_required
 def project_subprojects(request, project_slug):
+    """Project subprojects view and form view"""
     project = get_object_or_404(Project.objects.for_admin_user(request.user),
                                 slug=project_slug)
 
@@ -433,6 +437,7 @@ def project_subprojects_delete(request, project_slug, child_slug):
 
 @login_required
 def project_users(request, project_slug):
+    """Project users view and form view"""
     project = get_object_or_404(Project.objects.for_admin_user(request.user),
                                 slug=project_slug)
 
@@ -467,6 +472,7 @@ def project_users_delete(request, project_slug):
 
 @login_required
 def project_notifications(request, project_slug):
+    """Project notification view and form view"""
     project = get_object_or_404(Project.objects.for_admin_user(request.user),
                                 slug=project_slug)
 
@@ -514,6 +520,7 @@ def project_comments_settings(request, project_slug):
 
 @login_required
 def project_notifications_delete(request, project_slug):
+    """Project notifications delete confirmation view"""
     if request.method != 'POST':
         raise Http404
     project = get_object_or_404(Project.objects.for_admin_user(request.user),
@@ -531,6 +538,7 @@ def project_notifications_delete(request, project_slug):
 
 @login_required
 def project_translations(request, project_slug):
+    """Project translations view and form view"""
     project = get_object_or_404(Project.objects.for_admin_user(request.user),
                                 slug=project_slug)
     form = TranslationForm(data=request.POST or None, parent=project)
@@ -561,6 +569,7 @@ def project_translations_delete(request, project_slug, child_slug):
 
 @login_required
 def project_redirects(request, project_slug):
+    """Project redirects view and form view"""
     project = get_object_or_404(Project.objects.for_admin_user(request.user),
                                 slug=project_slug)
 
@@ -582,6 +591,7 @@ def project_redirects(request, project_slug):
 
 @login_required
 def project_redirects_delete(request, project_slug):
+    """Project redirect delete view"""
     if request.method != 'POST':
         return HttpResponseNotAllowed('Only POST is allowed')
     project = get_object_or_404(Project.objects.for_admin_user(request.user),
@@ -598,7 +608,7 @@ def project_redirects_delete(request, project_slug):
 
 @login_required
 def project_import_github(request):
-    '''Show form that prefills import form with data from GitHub'''
+    """Show form that prefills import form with data from GitHub"""
     github_connected = oauth_utils.import_github(
         user=request.user, sync=False)
     repos = GithubProject.objects.filter(users__in=[request.user])
@@ -628,8 +638,7 @@ def project_import_github(request):
 
 @login_required
 def project_import_bitbucket(request):
-    '''Show form that prefills import form with data from BitBucket'''
-
+    """Show form that prefills import form with data from BitBucket"""
     bitbucket_connected = oauth_utils.import_bitbucket(
         user=request.user, sync=False)
     repos = BitbucketProject.objects.filter(users__in=[request.user])
@@ -659,6 +668,10 @@ def project_import_bitbucket(request):
 
 @login_required
 def project_version_delete_html(request, project_slug, version_slug):
+    """Project version 'delete' HTML
+
+    This marks a version as not built
+    """
     project = get_object_or_404(Project.objects.for_admin_user(request.user), slug=project_slug)
     version = get_object_or_404(
         Version.objects.public(user=request.user, project=project, only_active=False),

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -1,4 +1,5 @@
-import collections
+"""Public project views"""
+
 import operator
 import os
 import json
@@ -35,6 +36,9 @@ mimetypes.add_type("application/epub+zip", ".epub")
 
 
 class ProjectIndex(ListView):
+
+    """List view of public :py:cls:`Project` instances"""
+
     model = Project
 
     def get_queryset(self):
@@ -65,7 +69,7 @@ project_index = ProjectIndex.as_view()
 
 class ProjectDetailView(ProjectOnboardMixin, DetailView):
 
-    '''Display project onboard steps'''
+    """Display project onboard steps"""
 
     model = Project
     slug_url_kwarg = 'project_slug'
@@ -117,9 +121,7 @@ def _badge_return(redirect, url):
 # TODO remove this, it's a temporary fix to heavy database usage
 @cache_page(60 * 30)
 def project_badge(request, project_slug, redirect=True):
-    """
-    Return a sweet badge for the project
-    """
+    """Return a sweet badge for the project"""
     version_slug = request.GET.get('version', LATEST)
     style = request.GET.get('style', 'flat')
     try:
@@ -147,9 +149,7 @@ def project_badge(request, project_slug, redirect=True):
 
 
 def project_downloads(request, project_slug):
-    """
-    A detail view for a project with various dataz
-    """
+    """A detail view for a project with various dataz"""
     project = get_object_or_404(Project.objects.protected(request.user), slug=project_slug)
     versions = Version.objects.public(user=request.user, project=project)
     version_data = SortedDict()
@@ -181,9 +181,10 @@ def project_downloads(request, project_slug):
     )
 
 
-def project_download_media(request, project_slug, type, version_slug):
+def project_download_media(request, project_slug, type_, version_slug):
     """
     Download a specific piece of media.
+
     Perform an auth check if serving in private mode.
     """
     # Do private project auth checks
@@ -192,14 +193,15 @@ def project_download_media(request, project_slug, type, version_slug):
         raise Http404
     privacy_level = getattr(settings, 'DEFAULT_PRIVACY_LEVEL', 'public')
     if privacy_level == 'public' or settings.DEBUG:
-        path = os.path.join(settings.MEDIA_URL, type, project_slug, version_slug,
-                            '%s.%s' % (project_slug, type.replace('htmlzip', 'zip')))
+        path = os.path.join(settings.MEDIA_URL, type_, project_slug, version_slug,
+                            '%s.%s' % (project_slug, type_.replace('htmlzip', 'zip')))
         return HttpResponseRedirect(path)
     else:
         # Get relative media path
-        path = queryset[0].get_production_media_path(type=type, version_slug=version_slug).replace(
-            settings.PRODUCTION_ROOT, '/prod_artifacts'
-        )
+        path = (queryset[0]
+                .get_production_media_path(
+                    type_=type_, version_slug=version_slug)
+                .replace(settings.PRODUCTION_ROOT, '/prod_artifacts'))
         content_type, encoding = mimetypes.guess_type(path)
         content_type = content_type or 'application/octet-stream'
         response = HttpResponse(content_type=content_type)
@@ -213,9 +215,7 @@ def project_download_media(request, project_slug, type, version_slug):
 
 
 def search_autocomplete(request):
-    """
-    return a json list of project names
-    """
+    """Return a json list of project names"""
     if 'term' in request.GET:
         term = request.GET['term']
     else:
@@ -234,9 +234,7 @@ def search_autocomplete(request):
 
 
 def version_autocomplete(request, project_slug):
-    """
-    return a json list of version names
-    """
+    """Return a json list of version names"""
     queryset = Project.objects.public(request.user)
     get_object_or_404(queryset, slug=project_slug)
     versions = Version.objects.public(request.user)
@@ -256,20 +254,20 @@ def version_filter_autocomplete(request, project_slug):
     queryset = Project.objects.public(request.user)
     project = get_object_or_404(queryset, slug=project_slug)
     versions = Version.objects.public(request.user)
-    filter = VersionSlugFilter(request.GET, queryset=versions)
-    format = request.GET.get('format', 'json')
+    version_filter = VersionSlugFilter(request.GET, queryset=versions)
+    resp_format = request.GET.get('format', 'json')
 
-    if format == 'json':
-        names = filter.qs.values_list('slug', flat=True)
+    if resp_format == 'json':
+        names = version_filter.qs.values_list('slug', flat=True)
         json_response = json.dumps(list(names))
         return HttpResponse(json_response, content_type='text/javascript')
-    elif format == 'html':
+    elif resp_format == 'html':
         return render_to_response(
             'core/version_list.html',
             {
                 'project': project,
                 'versions': versions,
-                'filter': filter,
+                'filter': version_filter,
             },
             context_instance=RequestContext(request),
         )
@@ -278,9 +276,7 @@ def version_filter_autocomplete(request, project_slug):
 
 
 def file_autocomplete(request, project_slug):
-    """
-    return a json list of version names
-    """
+    """Return a json list of file names"""
     if 'term' in request.GET:
         term = request.GET['term']
     else:
@@ -288,10 +284,10 @@ def file_autocomplete(request, project_slug):
     queryset = ImportedFile.objects.filter(project__slug=project_slug, path__icontains=term)[:20]
 
     ret_list = []
-    for file in queryset:
+    for filename in queryset:
         ret_list.append({
-            'label': file.path,
-            'value': file.path,
+            'label': filename.path,
+            'value': filename.path,
         })
 
     json_response = json.dumps(ret_list)
@@ -299,9 +295,7 @@ def file_autocomplete(request, project_slug):
 
 
 def elastic_project_search(request, project_slug):
-    """
-    Use elastic search to search in a project.
-    """
+    """Use elastic search to search in a project"""
     queryset = Project.objects.protected(request.user)
     project = get_object_or_404(queryset, slug=project_slug)
     version_slug = request.GET.get('version', LATEST)
@@ -375,9 +369,9 @@ def elastic_project_search(request, project_slug):
 
 
 def project_versions(request, project_slug):
-    """
-    Shows the available versions and lets the user choose which ones he would
-    like to have built.
+    """Project version list view
+
+    Shows the available versions and lets the user choose which ones to build.
     """
     project = get_object_or_404(Project.objects.protected(request.user),
                                 slug=project_slug)
@@ -408,9 +402,7 @@ def project_versions(request, project_slug):
 
 
 def project_analytics(request, project_slug):
-    """
-    Have a analytics API placeholder
-    """
+    """Have a analytics API placeholder"""
     project = get_object_or_404(Project.objects.protected(request.user),
                                 slug=project_slug)
     analytics_cache = cache.get('analytics:%s' % project_slug)
@@ -424,7 +416,7 @@ def project_analytics(request, project_slug):
             )
             analytics = resp.json()
             cache.set('analytics:%s' % project_slug, resp.content, 1800)
-        except:
+        except requests.exceptions.RequestException:
             analytics = None
 
     if analytics:
@@ -455,9 +447,7 @@ def project_analytics(request, project_slug):
 
 
 def project_embed(request, project_slug):
-    """
-    Have a content API placeholder
-    """
+    """Have a content API placeholder"""
     project = get_object_or_404(Project.objects.protected(request.user),
                                 slug=project_slug)
     version = project.versions.get(slug=LATEST)

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -49,7 +49,7 @@ class TestCeleryBuilding(RTDTestCase):
 
     def test_clear_artifacts(self):
         version = self.project.versions.all()[0]
-        directory = self.project.get_production_media_path(type='pdf', version_slug=version.slug)
+        directory = self.project.get_production_media_path(type_='pdf', version_slug=version.slug)
         os.makedirs(directory)
         self.assertTrue(exists(directory))
         result = tasks.clear_artifacts.delay(version_pk=version.pk)

--- a/readthedocs/search/parse_json.py
+++ b/readthedocs/search/parse_json.py
@@ -19,7 +19,7 @@ def process_all_json_files(version, build_dir=True):
         full_path = version.project.full_json_path(version.slug)
     else:
         full_path = version.project.get_production_media_path(
-            type='json', version_slug=version.slug, include_file=False)
+            type_='json', version_slug=version.slug, include_file=False)
     html_files = []
     for root, dirs, files in os.walk(full_path):
         for filename in fnmatch.filter(files, '*.fjson'):

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -17,7 +17,7 @@ def process_mkdocs_json(version, build_dir=True):
         full_path = version.project.full_json_path(version.slug)
     else:
         full_path = version.project.get_production_media_path(
-            type='json', version_slug=version.slug, include_file=False)
+            type_='json', version_slug=version.slug, include_file=False)
 
     html_files = []
     for root, dirs, files in os.walk(full_path):


### PR DESCRIPTION
This lints project code to medium strictness and conforms to pep257. This uses
some additional options to reduce false errors, which I'll add in a separate PR.
This should pass our normal linting without a problem, except the minor change
to unused variable name regex.

This adds `__` to the default list of `_` and `dummy*` for unused arguments. I
prefer the default of `_`, but that overlaps with the translation helper `_()`.
I'd be happy to rethink a scheme here.

Fixes #1472, refs #1474