### PR TITLE
Example of increased strictness on linting

### DIFF
--- a/prospector-more.yml
+++ b/prospector-more.yml
@@ -1,0 +1,47 @@
+inherits: prospector
+
+strictness: medium
+
+ignore-paths:
+  - docs/
+  - acl/
+  - api/
+  - betterversion/
+  - bookmarks/
+  - builds/
+  - cdn/
+  - comments/
+  - core/
+  - djangome/
+  - doc_builder/
+  - donate/
+  - gold/
+  - locale/
+  - notifications/
+  - oauth/
+  - payments/
+  - privacy/
+  - profiles/
+  - projects/
+  - redirects/
+  - restapi/
+  - rtd/
+  - rtd_tests/
+  - search/
+  - settings/
+  - static/
+  - tastyapi/
+  - templates/
+  - vcs_support/
+
+pylint:
+  options:
+    docstring-min-length: 20
+    dummy-variables-rgx: '_$|__$|dummy'
+    max-line-length: 100
+  disable:
+    - logging-format-interpolation
+    - too-many-arguments
+
+pep257:
+  run: true

--- a/prospector.yml
+++ b/prospector.yml
@@ -8,7 +8,7 @@ uses:
   - celery
 
 ignore-paths:
-  - docs
+  - docs/
 
 ignore-patterns:
   - /migrations/
@@ -25,19 +25,15 @@ pylint:
   disable:
     - logging-format-interpolation
 
-pyflakes:
-  disable:
-    - F999
-
 mccabe:
   run: false
 
 pep257:
   run: false
   disable:
-      - D105
-      - D211
-      - D104
+    - D105
+    - D211
+    - D104
 
 pyflakes:
   disable:

--- a/readthedocs/constants.py
+++ b/readthedocs/constants.py
@@ -1,3 +1,5 @@
+"""Common constants"""
+
 from readthedocs.builds.version_slug import VERSION_SLUG_REGEX
 from readthedocs.projects.constants import LANGUAGES_REGEX, PROJECT_SLUG_REGEX
 

--- a/readthedocs/integrations/models.py
+++ b/readthedocs/integrations/models.py
@@ -75,6 +75,7 @@ class HttpExchangeManager(models.Manager):
         return obj
 
     def delete_limit(self, related_object, limit=10):
+        # pylint: disable=protected-access
         queryset = self.filter(
             content_type=ContentType.objects.get(
                 app_label=related_object._meta.app_label,

--- a/readthedocs/wsgi.py
+++ b/readthedocs/wsgi.py
@@ -1,6 +1,8 @@
+"""WSGI application helper"""
+
 import os
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.postgres")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "readthedocs.settings.dev")
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION

--- a/tox.ini
+++ b/tox.ini
@@ -23,5 +23,9 @@ deps = -r{toxinidir}/requirements/lint.txt
 commands =
     prospector \
     --profile-path={toxinidir} \
+    --profile=prospector-more \
+    --die-on-tool-error
+    prospector \
+    --profile-path={toxinidir} \
     --profile=prospector \
     --die-on-tool-error


### PR DESCRIPTION
This increases prospector base profile to medium strictness, enables pep257,
and adds some additional pylint rules to filter out docstring related failures.
This limits docstrings to methods/classes less than 10 lines, which should be
readable already. Docstrings wouldn't hurt in this case of course, but we won't
require them on everything.
