### PR TITLE
Run pdflatex three times during PDF build

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -290,6 +290,10 @@ class PdfBuilder(BaseSphinx):
         for cmd in pdflatex_cmds:
             cmd_ret = self.build_env.run_command_class(
                 cls=LatexBuildCommand, cmd=cmd, cwd=latex_cwd, warn_only=True)
+            pdf_commands.append(cmd_ret)
+        for cmd in pdflatex_cmds:
+            cmd_ret = self.build_env.run_command_class(
+                cls=LatexBuildCommand, cmd=cmd, cwd=latex_cwd, warn_only=True)
             pdf_match = PDF_RE.search(cmd_ret.output)
             if pdf_match:
                 self.pdf_file_name = pdf_match.group(1).strip()

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -143,6 +143,7 @@ class BuildEnvironmentTests(TestCase):
             (('', ''), 1),  # latex
             (('', ''), 0),  # makeindex
             (('', ''), 0),  # latex
+            (('', ''), 0),  # latex
         ]
         mock_obj = mock.Mock()
         mock_obj.communicate.side_effect = [output for (output, status)
@@ -153,7 +154,7 @@ class BuildEnvironmentTests(TestCase):
 
         with build_env:
             built_docs = task.build_docs()
-        self.assertEqual(self.mocks.popen.call_count, 5)
+        self.assertEqual(self.mocks.popen.call_count, 6)
         self.assertTrue(build_env.failed)
 
     def test_build_pdf_latex_not_failure(self):
@@ -182,6 +183,7 @@ class BuildEnvironmentTests(TestCase):
             (('Output written on foo.pdf', ''), 1),  # latex
             (('', ''), 0),  # makeindex
             (('', ''), 0),  # latex
+            (('', ''), 0),  # latex
         ]
         mock_obj = mock.Mock()
         mock_obj.communicate.side_effect = [output for (output, status)
@@ -192,5 +194,5 @@ class BuildEnvironmentTests(TestCase):
 
         with build_env:
             built_docs = task.build_docs()
-        self.assertEqual(self.mocks.popen.call_count, 5)
+        self.assertEqual(self.mocks.popen.call_count, 6)
         self.assertTrue(build_env.successful)


### PR DESCRIPTION
We had a report in #1557 that creating the index for the PDF does not work and that it might be related to how often we run `pdflatex` during the build.

I'm not latex user so I don't know how reliable this is and I wasn't able to test it locally so far. But based on the interwebz it's often required to run pdflatex multiple times before you get the result you are expecting.

I'm hoping for some input from more experienced latex users.