### PR TITLE
Remove project artifacts from all web servers on project delete

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -825,3 +825,16 @@ def clear_htmlzip_artifacts(version):
 
 def clear_html_artifacts(version):
     run_on_app_servers('rm -rf %s' % version.project.rtd_build_path(version=version.slug))
+
+
+@task(queue='web')
+def remove_path_from_web(path):
+    """
+    Remove the given path from the web servers file system.
+    """
+    # Santity check  for spaces in the path since spaces would result in
+    # deleting unpredictable paths with "rm -rf".
+    assert ' ' not in path, "No spaces allowed in path"
+
+    # TODO: We need some proper escaping here for the given path.
+    run_on_app_servers('rm -rf {path}'.format(path=path))

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -34,6 +34,7 @@ from readthedocs.projects.forms import (
     RedirectForm, WebHookForm)
 from readthedocs.projects.models import Project, EmailHook, WebHook
 from readthedocs.projects import constants, tasks
+from readthedocs.projects.tasks import remove_path_from_web
 
 
 from readthedocs.projects.signals import project_import
@@ -214,7 +215,8 @@ def project_delete(request, project_slug):
 
     if request.method == 'POST':
         # Remove the repository checkout
-        shutil.rmtree(project.doc_path, ignore_errors=True)
+        remove_path_from_web.delay(path=project.doc_path)
+
         # Delete the project and everything related to it
         project.delete()
         messages.success(request, _('Project deleted'))


### PR DESCRIPTION
Currently we only did that on the server where the project deletion was triggered.

Related #1579.