### PR TITLE
Add mount for missing template path in docker container creation

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -17,7 +17,7 @@ from readthedocs.restapi.client import api
 from ..base import BaseBuilder, restoring_chdir
 from ..exceptions import BuildEnvironmentError
 from ..environments import BuildCommand
-from ..constants import TEMPLATE_DIR, STATIC_DIR, PDF_RE
+from ..constants import SPHINX_TEMPLATE_DIR, SPHINX_STATIC_DIR, PDF_RE
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class BaseSphinx(BaseBuilder):
         conf_template = render_to_string('sphinx/conf.py.conf',
                                          {'project': self.project,
                                           'version': self.version,
-                                          'template_dir': TEMPLATE_DIR,
+                                          'template_dir': SPHINX_TEMPLATE_DIR,
                                           'master_doc': master_doc,
                                           })
         conf_file = os.path.join(docs_dir, 'conf.py')
@@ -88,8 +88,8 @@ class BaseSphinx(BaseBuilder):
             'current_version': self.version.verbose_name,
             'project': project,
             'settings': settings,
-            'static_path': STATIC_DIR,
-            'template_path': TEMPLATE_DIR,
+            'static_path': SPHINX_STATIC_DIR,
+            'template_path': SPHINX_TEMPLATE_DIR,
             'conf_py_path': conf_py_path,
             'api_host': getattr(settings, 'SLUMBER_API_HOST', 'https://readthedocs.org'),
             # GitHub

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -1,4 +1,3 @@
-import re
 import os
 import sys
 import codecs
@@ -18,13 +17,9 @@ from readthedocs.restapi.client import api
 from ..base import BaseBuilder, restoring_chdir
 from ..exceptions import BuildEnvironmentError
 from ..environments import BuildCommand
-
+from ..constants import TEMPLATE_DIR, STATIC_DIR, PDF_RE
 
 log = logging.getLogger(__name__)
-
-TEMPLATE_DIR = '%s/readthedocs/templates/sphinx' % settings.SITE_ROOT
-STATIC_DIR = '%s/_static' % TEMPLATE_DIR
-PDF_RE = re.compile('Output written on (.*?)')
 
 
 class BaseSphinx(BaseBuilder):

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -1,8 +1,17 @@
 '''Doc build constants'''
 
+import os
+import re
+
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
+
+TEMPLATE_DIR = os.path.join(settings.SITE_ROOT, 'readthedocs', 'templates',
+                            'sphinx')
+STATIC_DIR = os.path.join(TEMPLATE_DIR, '_static')
+
+PDF_RE = re.compile('Output written on (.*?)')
 
 DOCKER_SOCKET = getattr(settings, 'DOCKER_SOCKET', 'unix:///var/run/docker.sock')
 DOCKER_VERSION = getattr(settings, 'DOCKER_VERSION', 'auto')

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -7,9 +7,9 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 
-TEMPLATE_DIR = os.path.join(settings.SITE_ROOT, 'readthedocs', 'templates',
-                            'sphinx')
-STATIC_DIR = os.path.join(TEMPLATE_DIR, '_static')
+SPHINX_TEMPLATE_DIR = os.path.join(settings.SITE_ROOT, 'readthedocs',
+                                   'templates', 'sphinx')
+SPHINX_STATIC_DIR = os.path.join(SPHINX_TEMPLATE_DIR, '_static')
 
 PDF_RE = re.compile('Output written on (.*?)')
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -29,7 +29,7 @@ from .exceptions import (BuildEnvironmentException, BuildEnvironmentError,
                          BuildEnvironmentWarning)
 from .constants import (DOCKER_SOCKET, DOCKER_VERSION, DOCKER_IMAGE,
                         DOCKER_LIMITS, DOCKER_TIMEOUT_EXIT_CODE,
-                        DOCKER_OOM_EXIT_CODE)
+                        DOCKER_OOM_EXIT_CODE, TEMPLATE_DIR)
 
 log = logging.getLogger(__name__)
 
@@ -576,10 +576,14 @@ class DockerEnvironment(BuildEnvironment):
                 name=self.container_id,
                 hostname=self.container_id,
                 host_config=create_host_config(binds={
+                    TEMPLATE_DIR: {
+                        'bind': TEMPLATE_DIR,
+                        'mode': 'r'
+                    },
                     self.project.doc_path: {
                         'bind': self.project.doc_path,
                         'mode': 'rw'
-                    }
+                    },
                 }),
                 detach=True,
                 mem_limit=self.container_mem_limit,

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -29,7 +29,7 @@ from .exceptions import (BuildEnvironmentException, BuildEnvironmentError,
                          BuildEnvironmentWarning)
 from .constants import (DOCKER_SOCKET, DOCKER_VERSION, DOCKER_IMAGE,
                         DOCKER_LIMITS, DOCKER_TIMEOUT_EXIT_CODE,
-                        DOCKER_OOM_EXIT_CODE, TEMPLATE_DIR)
+                        DOCKER_OOM_EXIT_CODE, SPHINX_TEMPLATE_DIR)
 
 log = logging.getLogger(__name__)
 
@@ -576,8 +576,8 @@ class DockerEnvironment(BuildEnvironment):
                 name=self.container_id,
                 hostname=self.container_id,
                 host_config=create_host_config(binds={
-                    TEMPLATE_DIR: {
-                        'bind': TEMPLATE_DIR,
+                    SPHINX_TEMPLATE_DIR: {
+                        'bind': SPHINX_TEMPLATE_DIR,
                         'mode': 'r'
                     },
                     self.project.doc_path: {


### PR DESCRIPTION
This could be all of rtd.org checkout as well. Without this mount, sphinx will
not inject the context data into the output docs, and will pass without failure.