### PR TITLE
Add per-project, admin-only container image configuration

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -564,9 +564,12 @@ class DockerEnvironment(BuildEnvironment):
     def create_container(self):
         '''Create docker container'''
         client = self.get_client()
+        image = self.container_image
+        if self.project.container_image is not None:
+            image = self.project.container_image
         try:
             self.container = client.create_container(
-                image=self.container_image,
+                image=image,
                 command=('/bin/sh -c "sleep {time}; exit {exit}"'
                          .format(time=self.container_time_limit,
                                  exit=DOCKER_TIMEOUT_EXIT_CODE)),

--- a/readthedocs/projects/migrations/0004_add_project_container_image.py
+++ b/readthedocs/projects/migrations/0004_add_project_container_image.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0003_project_cdn_enabled'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='container_image',
+            field=models.CharField(max_length=64, null=True, verbose_name='Alternative container image', blank=True),
+        ),
+    ]

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -108,6 +108,8 @@ class Project(models.Model):
         help_text=_('Type of documentation you are building. <a href="http://'
                     'sphinx-doc.org/builders.html#sphinx.builders.html.'
                     'DirectoryHTMLBuilder">More info</a>.'))
+
+    # Project features
     allow_comments = models.BooleanField(_('Allow Comments'), default=False)
     comment_moderation = models.BooleanField(_('Comment Moderation)'), default=False)
     cdn_enabled = models.BooleanField(_('CDN Enabled'), default=False)
@@ -116,6 +118,8 @@ class Project(models.Model):
         help_text=_("Google Analytics Tracking ID "
                     "(ex. <code>UA-22345342-1</code>). "
                     "This may slow down your page loads."))
+    container_image = models.CharField(
+        _('Alternative container image'), max_length=64, null=True, blank=True)
 
     # Sphinx specific build options.
     enable_epub_build = models.BooleanField(


### PR DESCRIPTION
This allows for multiple container images, with varying support for resource
intensive tooling/etc.