### PR TITLE
Fix logic in Project.conf_dir

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -184,10 +184,12 @@ class Version(models.Model):
         return data
 
     def get_conf_py_path(self):
-        conf_py_path = self.project.conf_file(self.slug)
-        conf_py_path = conf_py_path.replace(
-            self.project.checkout_path(self.slug), '')
-        return conf_py_path.replace('conf.py', '')
+        conf_py_path = self.project.conf_dir(self.slug)
+        if not conf_py_path.endswith('/'):
+            conf_py_path += '/'
+        checkout_prefix = self.project.checkout_path(self.slug)
+        conf_py_path = conf_py_path[len(checkout_prefix):]
+        return conf_py_path
 
     def get_build_path(self):
         '''Return version build path if path exists, otherwise `None`'''

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -185,10 +185,8 @@ class Version(models.Model):
 
     def get_conf_py_path(self):
         conf_py_path = self.project.conf_dir(self.slug)
-        if not conf_py_path.endswith('/'):
-            conf_py_path += '/'
         checkout_prefix = self.project.checkout_path(self.slug)
-        conf_py_path = conf_py_path[len(checkout_prefix):]
+        conf_py_path = os.path.relpath(conf_py_path, checkout_prefix)
         return conf_py_path
 
     def get_build_path(self):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -597,7 +597,7 @@ class Project(models.Model):
     def conf_dir(self, version=LATEST):
         conf_file = self.conf_file(version)
         if conf_file:
-            return conf_file.replace('/conf.py', '')
+            return os.path.dirname(conf_file)
 
     @property
     def is_type_sphinx(self):


### PR DESCRIPTION
The original implementation replaced "/conf.py" with an empty string, where it
only wanted to return the directory name of the conf.py file. This resulted in
problems when "/conf.py" was part of the directory name!

Fixes #1553.