### PR TITLE
Make explicit: no Mkdocs automatic PDF generation.

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -40,6 +40,8 @@ and then default to the top-level of your documentation.
 Then Mkdocs will build any files with an ``.md`` extension.
 If you have a ``README.md``,
 it will be transformed into an ``index.md`` automatically.
+As MkDocs doesn't support automatic PDF generation,
+Read the Docs cannot create a PDF version of your documentation with the *Mkdocs* option.
 
 Understanding what's going on
 -----------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -76,7 +76,7 @@ Then in your ``conf.py``:
     source_suffix = ['.rst', '.md']
 
 .. note:: Markdown doesn't support a lot of the features of Sphinx,
-          like inline markup, directives, and automatic PDF generation.
+          like inline markup and directives.
           However, it works for basic prose content.
 
 .. _import-docs:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -76,7 +76,7 @@ Then in your ``conf.py``:
     source_suffix = ['.rst', '.md']
 
 .. note:: Markdown doesn't support a lot of the features of Sphinx,
-          like inline markup and directives.
+          like inline markup, directives, and automatic PDF generation.
           However, it works for basic prose content.
 
 .. _import-docs:


### PR DESCRIPTION
As MkDocs doesn't support automatic PDF generation, selecting the
Mkdocs documentation type means that you can't enable PDF builds.  Where
Mkdocs or markdown is mentioned in the docs, this is more explicit.  Related to issue #1635 .