### PR TITLE
Remove *args, **kwargs from manager public/api/_add_user_repos methods

### DIFF
--- a/readthedocs/api/base.py
+++ b/readthedocs/api/base.py
@@ -140,7 +140,7 @@ class VersionResource(ModelResource):
     #     return bundle
 
     def get_object_list(self, request):
-        self._meta.queryset = Version.objects.api(user=request.user, only_active=False)
+        self._meta.queryset = Version.objects.api(user=request.user)
         return super(VersionResource, self).get_object_list(request)
 
     def version_compare(self, request, project_slug, base=None, **kwargs):

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -66,7 +66,7 @@ class ProjectManager(models.Manager):
 
 class RelatedProjectManager(models.Manager):
 
-    def _add_user_repos(self, queryset, user=None, *args, **kwargs):
+    def _add_user_repos(self, queryset, user=None):
         # Hack around get_objects_for_user not supporting global perms
         if user.has_perm('projects.view_project'):
             return self.get_queryset().all().distinct()
@@ -92,7 +92,7 @@ class RelatedProjectManager(models.Manager):
 class RelatedBuildManager(models.Manager):
     '''For models with association to a project through :py:cls:`Build`'''
 
-    def _add_user_repos(self, queryset, user=None, *args, **kwargs):
+    def _add_user_repos(self, queryset, user=None):
         # Hack around get_objects_for_user not supporting global perms
         if user.has_perm('projects.view_project'):
             return self.get_queryset().all().distinct()
@@ -118,7 +118,7 @@ class RelatedBuildManager(models.Manager):
 
 class VersionManager(RelatedProjectManager):
 
-    def _add_user_repos(self, queryset, user=None, *args, **kwargs):
+    def _add_user_repos(self, queryset, user=None):
         queryset = super(VersionManager, self)._add_user_repos(queryset, user)
         if user and user.is_authenticated():
             # Add in possible user-specific views

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -60,7 +60,7 @@ class ProjectManager(models.Manager):
     def dashboard(self, user=None, *args, **kwargs):
         return self.for_admin_user(user)
 
-    def api(self, user=None, *args, **kwargs):
+    def api(self, user=None):
         return self.public(user)
 
 
@@ -85,7 +85,7 @@ class RelatedProjectManager(models.Manager):
             queryset = queryset.filter(project=project)
         return queryset
 
-    def api(self, user=None, *args, **kwargs):
+    def api(self, user=None):
         return self.public(user)
 
 
@@ -112,7 +112,7 @@ class RelatedBuildManager(models.Manager):
             queryset = queryset.filter(build__project=project)
         return queryset
 
-    def api(self, user=None, *args, **kwargs):
+    def api(self, user=None):
         return self.public(user)
 
 
@@ -142,7 +142,7 @@ class VersionManager(RelatedProjectManager):
             queryset = queryset.filter(active=True)
         return queryset
 
-    def api(self, user=None, *args, **kwargs):
+    def api(self, user=None):
         return self.public(user, only_active=False)
 
     def create_stable(self, **kwargs):

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -41,7 +41,7 @@ class ProjectManager(models.Manager):
         else:
             return self.none()
 
-    def public(self, user=None, *args, **kwargs):
+    def public(self, user=None):
         queryset = self.filter(privacy_level=constants.PUBLIC)
         if user:
             return self._add_user_repos(queryset, user)
@@ -77,7 +77,7 @@ class RelatedProjectManager(models.Manager):
             queryset = self.get_queryset().filter(project__pk__in=pks) | queryset
         return queryset.distinct()
 
-    def public(self, user=None, project=None, *args, **kwargs):
+    def public(self, user=None, project=None):
         queryset = self.filter(project__privacy_level=constants.PUBLIC)
         if user:
             queryset = self._add_user_repos(queryset, user)
@@ -104,7 +104,7 @@ class RelatedBuildManager(models.Manager):
                         .filter(build__project__pk__in=pks) | queryset)
         return queryset.distinct()
 
-    def public(self, user=None, project=None, *args, **kwargs):
+    def public(self, user=None, project=None):
         queryset = self.filter(build__project__privacy_level=constants.PUBLIC)
         if user:
             queryset = self._add_user_repos(queryset, user)
@@ -131,7 +131,7 @@ class VersionManager(RelatedProjectManager):
                 queryset = self.get_queryset().all().distinct()
         return queryset.distinct()
 
-    def public(self, user=None, project=None, only_active=True, *args, **kwargs):
+    def public(self, user=None, project=None, only_active=True):
         queryset = self.filter(project__privacy_level=constants.PUBLIC,
                                privacy_level=constants.PUBLIC)
         if user:


### PR DESCRIPTION
The arguments have been used wrongly at least once (see point one in #1641).

I tried to find all usages of those methods and didn't find a case were we need to catch all args/kwargs. I see that this was an attempt to unify the signatures of all the same-named methods. However IMO we should fail loudly if we an argument does not have an effect.