### PR TITLE
Hide "Edit on Github" link if page is a auto-created page

### DIFF
--- a/readthedocs/templates/sphinx/sphinx_rtd_theme/breadcrumbs.html
+++ b/readthedocs/templates/sphinx/sphinx_rtd_theme/breadcrumbs.html
@@ -6,7 +6,7 @@
       {% endfor %}
     <li>{{ title }}</li>
       <li class="wy-breadcrumbs-aside">
-        {% if pagename != "search" %}
+        {% if hasdoc(pagename) %}
           {% if display_github %}
             <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-github"> Edit on GitHub</a>
           {% elif display_bitbucket %}


### PR DESCRIPTION
We can use the [hasdoc function](http://sphinx-doc.org/templating.html#hasdoc) to detect if the current page is a "physical", i.e. real page or if it's autocreated.

I tested this on the Tornado project with the "search.html" page and the auto inlined source file pages, like http://www.tornadoweb.org/en/stable/_modules/tornado/stack_context.html

Related #1637 