### PR TITLE
Replace Version.get_vcs_slug() and Version.remote_slug with Version.commit_name

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -25,10 +25,14 @@ BUILD_TYPES = (
     ('dash', _('Dash')),
 )
 
+BRANCH = 'branch'
+TAG = 'tag'
+UNKNOWN = 'unknown'
+
 VERSION_TYPES = (
-    ('branch', _('Branch')),
-    ('tag', _('Tag')),
-    ('unknown', _('Unknown')),
+    (BRANCH, _('Branch')),
+    (TAG, _('Tag')),
+    (UNKNOWN, _('Unknown')),
 )
 
 LATEST = 'latest'

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -21,7 +21,7 @@ from readthedocs.projects.constants import (PRIVACY_CHOICES, REPO_TYPE_GIT,
 
 from .constants import (BUILD_STATE, BUILD_TYPES, VERSION_TYPES,
                         LATEST, NON_REPOSITORY_VERSIONS, STABLE,
-                        BUILD_STATE_FINISHED)
+                        BUILD_STATE_FINISHED, BRANCH)
 from .version_slug import VersionSlugField
 
 
@@ -100,7 +100,7 @@ class Version(models.Model):
     @property
     def commit_name(self):
         """Return the branch name, the tag name or the revision identifier."""
-        if self.type == 'branch':
+        if self.type == BRANCH:
             return self.identifier
         if self.verbose_name in NON_REPOSITORY_VERSIONS:
             return self.identifier

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -73,7 +73,7 @@ class BaseSphinx(BaseBuilder):
             raise ProjectImportError('Conf file not found'), None, trace
         outfile.write("\n")
         conf_py_path = self.version.get_conf_py_path()
-        remote_version = self.version.get_vcs_slug()
+        remote_version = self.version.commit_name
 
         github_user, github_repo = version_utils.get_github_username_repo(
             url=self.project.repo)

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -10,6 +10,7 @@ from django.template.loader import render_to_string
 from django.conf import settings
 
 from readthedocs.builds import utils as version_utils
+from readthedocs.builds.constants import BRANCH
 from readthedocs.projects.utils import safe_write
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.restapi.client import api
@@ -76,12 +77,12 @@ class BaseSphinx(BaseBuilder):
 
         github_user, github_repo = version_utils.get_github_username_repo(
             url=self.project.repo)
-        github_version_is_editable = (self.version.type == 'branch')
+        github_version_is_editable = (self.version.type == BRANCH)
         display_github = github_user is not None
 
         bitbucket_user, bitbucket_repo = version_utils.get_bitbucket_username_repo(
             url=self.project.repo)
-        bitbucket_version_is_editable = (self.version.type == 'branch')
+        bitbucket_version_is_editable = (self.version.type == BRANCH)
         display_bitbucket = bitbucket_user is not None
 
         rtd_ctx = {

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -3,6 +3,8 @@ from django.db import models
 
 from guardian.shortcuts import get_objects_for_user
 
+from readthedocs.builds.constants import BRANCH
+from readthedocs.builds.constants import TAG
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import LATEST_VERBOSE_NAME
 from readthedocs.builds.constants import STABLE
@@ -152,7 +154,7 @@ class VersionManager(RelatedProjectManager):
             'machine': True,
             'active': True,
             'identifier': STABLE,
-            'type': 'tag',
+            'type': TAG,
         }
         defaults.update(kwargs)
         return self.create(**defaults)
@@ -164,7 +166,7 @@ class VersionManager(RelatedProjectManager):
             'machine': True,
             'active': True,
             'identifier': LATEST,
-            'type': 'branch',
+            'type': BRANCH,
         }
         defaults.update(kwargs)
         return self.create(**defaults)

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -12,6 +12,7 @@ from django.utils.safestring import mark_safe
 
 from guardian.shortcuts import assign
 
+from readthedocs.builds.constants import TAG
 from readthedocs.core.utils import trigger_build
 from readthedocs.redirects.models import Redirect
 from readthedocs.projects import constants
@@ -272,7 +273,7 @@ def build_versions_form(project):
     for version in versions_qs:
         field_name = 'version-%s' % version.slug
         privacy_name = 'privacy-%s' % version.slug
-        if version.type == 'tag':
+        if version.type == TAG:
             label = "%s (%s)" % (version.verbose_name, version.identifier[:8])
         else:
             label = version.verbose_name

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -312,7 +312,7 @@ class Project(models.Model):
             if not self.versions.filter(slug=LATEST).exists():
                 self.versions.create_latest(identifier=branch)
             # if not self.versions.filter(slug=STABLE).exists():
-            #     self.versions.create_stable(type='branch', identifier=branch)
+            #     self.versions.create_stable(type=BRANCH, identifier=branch)
         except Exception:
             log.error('Error creating default branches', exc_info=True)
 

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -8,6 +8,7 @@ from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRe
 from rest_framework.response import Response
 
 from readthedocs.builds.constants import LATEST
+from readthedocs.builds.constants import TAG
 from readthedocs.builds.models import Version
 from readthedocs.donate.models import SupporterPromo
 from readthedocs.projects.models import Project
@@ -74,7 +75,7 @@ def footer_html(request):
     else:
         path = ""
 
-    if version.type == 'tag' and version.project.has_pdf(version.slug):
+    if version.type == TAG and version.project.has_pdf(version.slug):
         print_url = (
             'https://keminglabs.com/print-the-docs/quote?project={project}&version={version}'
             .format(

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -7,6 +7,8 @@ from rest_framework.decorators import detail_route
 from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
 from rest_framework.response import Response
 
+from readthedocs.builds.constants import BRANCH
+from readthedocs.builds.constants import TAG
 from readthedocs.builds.filters import VersionFilter
 from readthedocs.builds.models import Build, BuildCommandResult, Version
 from readthedocs.core.utils import trigger_build
@@ -109,11 +111,11 @@ class ProjectViewSet(viewsets.ModelViewSet):
             added_versions = set()
             if 'tags' in data:
                 ret_set = api_utils.sync_versions(
-                    project=project, versions=data['tags'], type='tag')
+                    project=project, versions=data['tags'], type=TAG)
                 added_versions.update(ret_set)
             if 'branches' in data:
                 ret_set = api_utils.sync_versions(
-                    project=project, versions=data['branches'], type='branch')
+                    project=project, versions=data['branches'], type=BRANCH)
                 added_versions.update(ret_set)
             deleted_versions = api_utils.delete_versions(project, data)
         except Exception, e:

--- a/readthedocs/rtd_tests/tests/test_supported.py
+++ b/readthedocs/rtd_tests/tests/test_supported.py
@@ -2,6 +2,7 @@ import json
 
 from django.test import TestCase
 
+from readthedocs.builds.constants import TAG
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
 
@@ -13,11 +14,11 @@ class TestSupportedVersions(TestCase):
         self.pip = Project.objects.create(name='Pip', slug='pip')
         Version.objects.create(project=self.pip, identifier='0.1',
                                verbose_name='0.1', slug='0.1',
-                               type='tag',
+                               type=TAG,
                                active=True)
         Version.objects.create(project=self.pip, identifier='0.2',
                                verbose_name='0.2', slug='0.2',
-                               type='tag',
+                               type=TAG,
                                active=True)
 
     def test_supported_versions(self):
@@ -55,6 +56,6 @@ class TestSupportedVersions(TestCase):
         self.assertEqual(self.pip.versions.get(slug='0.1').supported, False)
         self.assertEqual(self.pip.versions.get(slug='0.2').supported, True)
         Version.objects.create(project=self.pip, identifier='0.1.1',
-                               verbose_name='0.1.1', type='tag', active=True)
+                               verbose_name='0.1.1', type=TAG, active=True)
         # This gets set to False on creation.
         self.assertEqual(self.pip.versions.get(slug='0.1.1').supported, False)

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -1,0 +1,50 @@
+from django.test import TestCase
+from django_dynamic_fixture import get
+from django_dynamic_fixture import new
+
+from readthedocs.builds.constants import BRANCH
+from readthedocs.builds.constants import LATEST
+from readthedocs.builds.constants import STABLE
+from readthedocs.builds.constants import TAG
+from readthedocs.builds.models import Version
+from readthedocs.projects.constants import REPO_TYPE_GIT
+from readthedocs.projects.constants import REPO_TYPE_HG
+from readthedocs.projects.models import Project
+
+
+class VersionCommitNameTests(TestCase):
+    def test_branch_name(self):
+        version = new(Version, identifier='release-2.5.x',
+                      slug='release-2.5.x', verbose_name='release-2.5.x',
+                      type=BRANCH)
+        self.assertEqual(version.commit_name, 'release-2.5.x')
+
+    def test_tag_name(self):
+        version = new(Version, identifier='10f1b29a2bd2', slug='release-2.5.0',
+                      verbose_name='release-2.5.0', type=TAG)
+        self.assertEqual(version.commit_name, 'release-2.5.0')
+
+    def test_branch_with_name_stable(self):
+        version = new(Version, identifier='origin/stable', slug=STABLE,
+                      verbose_name='stable', type=BRANCH)
+        self.assertEqual(version.commit_name, 'stable')
+
+    def test_stable_version_tag(self):
+        version = new(Version,
+                      identifier='3d92b728b7d7b842259ac2020c2fa389f13aff0d',
+                      slug=STABLE, verbose_name=STABLE, type=TAG)
+        self.assertEqual(version.commit_name,
+                         '3d92b728b7d7b842259ac2020c2fa389f13aff0d')
+
+    def test_hg_latest_branch(self):
+        hg_project = get(Project, repo_type=REPO_TYPE_HG)
+        version = new(Version, identifier='default', slug=LATEST,
+                      verbose_name=LATEST, type=BRANCH, project=hg_project)
+        self.assertEqual(version.commit_name, 'default')
+
+    def test_git_latest_branch(self):
+        git_project = get(Project, repo_type=REPO_TYPE_GIT)
+        version = new(Version, project=git_project,
+                      identifier='origin/master', slug=LATEST,
+                      verbose_name=LATEST, type=BRANCH)
+        self.assertEqual(version.commit_name, 'master')


### PR DESCRIPTION
The two places were solving the same problem but with different results. That is undesired and resulted in invalid behaviour. The commit_name property unifies those now and has tests to make sure it works the way intended.

The problem with this on-first-sight-easy problem is that we currently do store different things in "identifier", "slug", "verbose_name" fields depending if its a branch or tag, if it's a special version (like stable, latest) etc. The cleanest solution would be to refactor the Version model to expose those information more easily and store branch_name, tag_name, explicitly.

One problem of this manifested in #1637 