### PR TITLE
Show rendered conf.py file in build logs

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -65,8 +65,9 @@ class BaseSphinx(BaseBuilder):
 
         project = self.project
         # Open file for appending.
+        outfile_path = project.conf_file(self.version.slug)
         try:
-            outfile = codecs.open(project.conf_file(self.version.slug), encoding='utf-8', mode='a')
+            outfile = codecs.open(outfile_path, encoding='utf-8', mode='a')
         except IOError:
             trace = sys.exc_info()[2]
             raise ProjectImportError('Conf file not found'), None, trace
@@ -121,6 +122,13 @@ class BaseSphinx(BaseBuilder):
             outfile.write(rtd_string)
         finally:
             outfile.close()
+
+        # Print the contents of conf.py in order to make the rendered
+        # configfile visible in the build logs
+        self.run(
+            'cat', os.path.basename(outfile_path),
+            cwd=os.path.dirname(outfile_path),
+        )
 
     def build(self, **kwargs):
         self.clean()

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -1,5 +1,19 @@
 {% load projects_tags %}
 
+
+###########################################################################
+#          auto-created readthedocs.org specific configuration            #
+###########################################################################
+
+
+#
+# The following code was added during an automated build on readthedocs.org
+# It is auto created and injected for every build. The result is based on the
+# conf.py.tmpl file found in the readthedocs.org codebase:
+# https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+#
+
+
 import sys
 from six import string_types
 


### PR DESCRIPTION
We had some tickets in the past resulting from users that didn't realize that Sphinx options might get overridden with the code that gets appended to the conf.py before every build (for example #1622, #885).

This PR includes the resulting conf.py as part of the build log in the users project panel and therefore increases the visibility a lot. I assume this will reduce confusion about what happens with the conf.py in the future.

It looks like this:
![screen1](https://cloud.githubusercontent.com/assets/88278/9852301/e7893c04-5afd-11e5-8cff-e81ed3b29c51.png)
