### PR TITLE
Set Cache-Control: no-cache for redirects to badges

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -15,6 +15,7 @@ from django.contrib.auth.models import User
 from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
+from django.views.decorators.cache import cache_control
 from django.views.generic import ListView, DetailView
 from django.utils.datastructures import SortedDict
 from django.views.decorators.cache import cache_page
@@ -120,6 +121,7 @@ def _badge_return(redirect, url):
 
 # TODO remove this, it's a temporary fix to heavy database usage
 @cache_page(60 * 30)
+@cache_control(no_cache=True)
 def project_badge(request, project_slug, redirect=True):
     """Return a sweet badge for the project"""
     version_slug = request.GET.get('version', LATEST)

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -120,7 +120,7 @@ def _badge_return(redirect, url):
 
 
 # TODO remove this, it's a temporary fix to heavy database usage
-@cache_page(60 * 30)
+@cache_page(60 * 5)
 @cache_control(no_cache=True)
 def project_badge(request, project_slug, redirect=True):
     """Return a sweet badge for the project"""

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -119,8 +119,6 @@ def _badge_return(redirect, url):
         return http_response
 
 
-# TODO remove this, it's a temporary fix to heavy database usage
-@cache_page(60 * 5)
 @cache_control(no_cache=True)
 def project_badge(request, project_slug, redirect=True):
     """Return a sweet badge for the project"""


### PR DESCRIPTION
The badges provided by readthedocs.org are created using shields.io, using a redirect. We did not have the Cache-Control set on those redirects which might make GitHub cache the badges too aggressively when they are used in a README file.

The https://github.com/github/markup/issues/224 issue explains that we need to set the Cache-Control and ETag header to disable caching for the badges. However we are not serving the badges, but redirecting, so we just need to try out whether a Cache-Control header on the redirect has any effect. I did a quick google search but was not able to find if it's valid to set ETag headers on a redirect. I think it's nonsense as the body of a redirect response is usually empty.

Related #1612 