### PR TITLE
Fix generation of canonical_page when it ends on "index"

### DIFF
--- a/readthedocs/templates/sphinx/layout.html
+++ b/readthedocs/templates/sphinx/layout.html
@@ -3,21 +3,27 @@
 {% block extrahead %}
 {{ super() }}
 <!-- RTD Extra Head -->
-{% set ending = "/" if builder == "readthedocsdirhtml" else ".html" %}
-{% set canonical_page = pagename + ending %}
+{% if pagename == "index" %}
+    {% set canonical_page = "" %}
+{% elif pagename.endswith("/index") %}
+    {% set canonical_page = pagename[:-("/index"|length)] + "/" %}
+{% else %}
+    {% set ending = "/" if builder == "readthedocsdirhtml" else ".html" %}
+    {% set canonical_page = pagename + ending %}
+{% endif %}
 {% if canonical_url %}
   {% if single_version %}
   <!-- 
   Single version, so link without a language or version 
   http://docs.readthedocs.org/en/latest/canonical.html
   -->
-  <link rel="canonical" href="{{ canonical_url }}{{ canonical_page.replace("index.html", "").replace("index/", "") }}" />
+  <link rel="canonical" href="{{ canonical_url }}{{ canonical_page }}" />
   {% else %}
   <!-- 
   Always link to the latest version, as canonical.
   http://docs.readthedocs.org/en/latest/canonical.html
   -->
-  <link rel="canonical" href="{{ canonical_url }}{{ rtd_language }}/latest/{{ canonical_page.replace("index.html", "").replace("index/", "") }}" />
+  <link rel="canonical" href="{{ canonical_url }}{{ rtd_language }}/latest/{{ canonical_page }}" />
   {% endif %}
 {% else %}
 <!-- 
@@ -25,7 +31,7 @@ Read the Docs is acting as the canonical URL for your project.
 If you want to change it, more info is available in our docs:
   http://docs.readthedocs.org/en/latest/canonical.html
 -->
-<link rel="canonical" href="http://{{ slug }}.readthedocs.org/{{ rtd_language }}/latest/{{ canonical_page.replace("index.html", "").replace("index/", "") }}" />
+<link rel="canonical" href="http://{{ slug }}.readthedocs.org/{{ rtd_language }}/latest/{{ canonical_page }}" />
 {% endif %}
 <script type="text/javascript">
   // This is included here because other places don't have access to the pagename variable.


### PR DESCRIPTION
Previously the canonical url for the `genindex.html` were broken because the `index.html` bit was stripped.

Fixes #1114.