### PR TITLE
Correctly handling view_project/view_version permissions on user add/remove

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _, ugettext
 
-from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
 from readthedocs.privacy.loader import (VersionManager, RelatedProjectManager,
@@ -153,8 +152,6 @@ class Version(models.Model):
         Add permissions to the Version for all owners on save.
         """
         obj = super(Version, self).save(*args, **kwargs)
-        for owner in self.project.users.all():
-            assign('view_version', owner, self)
         self.project.sync_supported_versions()
         return obj
 

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -10,8 +10,6 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 
-from guardian.shortcuts import assign
-
 from readthedocs.builds.constants import TAG
 from readthedocs.core.utils import trigger_build
 from readthedocs.redirects.models import Redirect
@@ -375,8 +373,6 @@ class UserForm(forms.Form):
 
     def save(self):
         self.project.users.add(self.user)
-        # Force update of permissions
-        assign('view_project', self.user, self.project)
         return self.user
 
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -897,20 +897,23 @@ class Project(models.Model):
             "You must add users to the project via the `users` field "
             "on the project instance.")
 
+        def perform_action(set_perm, users, project):
+            for user in users:
+                set_perm('view_project', user, project)
+                for version in project.versions.all():
+                    set_perm('view_version', user, version)
+
         if action == 'post_add':
             users = User.objects.filter(pk__in=pk_set)
-            for user in users:
-                assign_perm('view_project', user, obj=instance)
+            perform_action(assign_perm, users, instance)
 
         if action == 'pre_remove':
             users = User.objects.filter(pk__in=pk_set)
-            for user in users:
-                remove_perm('view_project', user, obj=instance)
+            perform_action(remove_perm, users, instance)
 
         if action == 'pre_clear':
             users = instance.users.all()
-            for user in users:
-                remove_perm('view_project', user, obj=instance)
+            perform_action(remove_perm, users, instance)
 
 
 signals.m2m_changed.connect(

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -10,10 +10,12 @@ from django.contrib.auth.models import User
 from django.core.exceptions import MultipleObjectsReturned
 from django.core.urlresolvers import reverse
 from django.db import models
+from django.db.models import signals
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
 
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
+from guardian.shortcuts import remove_perm
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import LATEST_VERBOSE_NAME
@@ -67,6 +69,9 @@ class Project(models.Model):
     modified_date = models.DateTimeField(_('Modified date'), auto_now=True)
 
     # Generally from conf.py
+
+    # Notice that adding/removing users is intercepted by set_user_permissions
+    # method.
     users = models.ManyToManyField(User, verbose_name=_('User'),
                                    related_name='projects')
     name = models.CharField(_('Name'), max_length=255)
@@ -283,8 +288,6 @@ class Project(models.Model):
             if self.slug == '':
                 raise Exception(_("Model must have slug"))
         super(Project, self).save(*args, **kwargs)
-        for owner in self.users.all():
-            assign('view_project', owner, self)
         try:
             if self.default_branch:
                 latest = self.versions.get(slug=LATEST)
@@ -886,6 +889,33 @@ class Project(models.Model):
             node = self.nodes.create(version=version, page=page,
                                      hash=content_hash, commit=commit)
         return node.comments.create(user=user, text=text)
+
+    @classmethod
+    def set_user_permissions(cls, sender, instance, action, reverse, pk_set,
+                             **kwargs):
+        assert not reverse, (
+            "You must add users to the project via the `users` field "
+            "on the project instance.")
+
+        if action == 'post_add':
+            users = User.objects.filter(pk__in=pk_set)
+            for user in users:
+                assign_perm('view_project', user, obj=instance)
+
+        if action == 'pre_remove':
+            users = User.objects.filter(pk__in=pk_set)
+            for user in users:
+                remove_perm('view_project', user, obj=instance)
+
+        if action == 'pre_clear':
+            users = instance.users.all()
+            for user in users:
+                remove_perm('view_project', user, obj=instance)
+
+
+signals.m2m_changed.connect(
+    Project.set_user_permissions,
+    sender=Project._meta.get_field('users').rel.through)
 
 
 class ImportedFile(models.Model):

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -1,5 +1,7 @@
 import json
+from django.contrib.auth.models import User
 from django.test import TestCase
+from guardian.shortcuts import get_objects_for_user
 from readthedocs.builds.constants import LATEST
 from readthedocs.projects.models import Project
 from rest_framework.reverse import reverse
@@ -83,3 +85,28 @@ class TestProject(TestCase):
         self.pip.enable_epub_build = False
         with fake_paths_by_regex('\.epub$'):
             self.assertFalse(self.pip.has_epub(LATEST))
+
+    def test_users_relations_sets_permissions(self):
+        john = get(User)
+        maggy = get(User)
+
+        project = get(Project)
+
+        def get_projects(user):
+            return get_objects_for_user(user, 'projects.view_project')
+
+        self.assertTrue(project not in get_projects(john))
+
+        project.users.add(john)
+        self.assertTrue(project in get_projects(john))
+
+        project.users.remove(john)
+        self.assertTrue(project not in get_projects(john))
+
+        project.users.add(maggy)
+        self.assertTrue(project not in get_projects(john))
+        self.assertTrue(project in get_projects(maggy))
+
+        project.users = [john]
+        self.assertTrue(project in get_projects(john))
+        self.assertTrue(project not in get_projects(maggy))

--- a/readthedocs/rtd_tests/tests/test_version_model.py
+++ b/readthedocs/rtd_tests/tests/test_version_model.py
@@ -1,0 +1,42 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django_dynamic_fixture import get
+from guardian.shortcuts import get_objects_for_user
+
+from readthedocs.builds.models import Version
+from readthedocs.projects.models import Project
+
+
+class VersionPermissionTests(TestCase):
+    def test_version_save_sets_permission(self):
+        user = get(User)
+        project = get(Project)
+
+        versions = get_objects_for_user(user, 'builds.view_version')
+        self.assertEqual(len(versions), 0)
+
+        version = get(Version, project=project)
+        versions = get_objects_for_user(user, 'builds.view_version')
+        self.assertTrue(version not in versions)
+
+        # When user is added after version.
+        project.users.add(user)
+        versions = get_objects_for_user(user, 'builds.view_version')
+        self.assertTrue(version in versions)
+
+        # When user is moved for existing version.
+        project.users.remove(user)
+        versions = get_objects_for_user(user, 'builds.view_version')
+        self.assertTrue(version not in versions)
+
+        # When user is added before version.
+        project.users.add(user)
+        second = get(Version, project=project)
+        versions = get_objects_for_user(user, 'builds.view_version')
+        self.assertTrue(second in versions)
+
+        # When project users are reset.
+        project.users = []
+        second = get(Version, project=project)
+        versions = get_objects_for_user(user, 'builds.view_version')
+        self.assertTrue(second not in versions)


### PR DESCRIPTION
Move project's assign view permission logic and handling for `view_version` into set_user_permissions method.

That was previously handled in a few different places. We now unify it and testing. Also we remove the `view_project` permission correctly when a user is removed from the project.

Fixes #943.