### PR TITLE
Refactor and fix reindex_elasticsearch management command

### DIFF
--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -7,8 +7,7 @@ from django.conf import settings
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version
-from readthedocs.search import parse_json
-from readthedocs.restapi.utils import index_search_request
+from readthedocs.projects.tasks import update_search
 
 log = logging.getLogger(__name__)
 
@@ -48,9 +47,6 @@ class Command(BaseCommand):
                 commit = None
 
             try:
-                page_list = parse_json.process_all_json_files(version, build_dir=False)
-                index_search_request(
-                    version=version, page_list=page_list, commit=commit,
-                    project_scale=0, page_scale=0, section=False, delete=False)
+                update_search(version.pk, commit)
             except Exception:
-                log.error('Build failed for %s' % version, exc_info=True)
+                log.error('Reindex failed for %s' % version, exc_info=True)

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -47,6 +47,7 @@ class Command(BaseCommand):
                 commit = None
 
             try:
-                update_search(version.pk, commit)
+                update_search(version.pk, commit,
+                              delete_non_commit_files=False)
             except Exception:
                 log.error('Reindex failed for %s' % version, exc_info=True)

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         project = options['project']
 
         if project:
-            queryset = Version.objects.public(project__slug=project)
+            queryset = Version.objects.public().filter(project__slug=project)
             log.info("Building all versions for %s" % project)
         elif getattr(settings, 'INDEX_ONLY_LATEST', True):
             queryset = Version.objects.public().filter(slug=LATEST)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -613,11 +613,12 @@ def move_files(version_pk, hostname, html=False, localmedia=False, search=False,
 
 
 @task(queue='web')
-def update_search(version_pk, commit):
+def update_search(version_pk, commit, delete_non_commit_files=True):
     """Task to update search indexes
 
     :param version_pk: Version id to update
     :param commit: Commit that updated index
+    :param delete_non_commit_files: Delete files not in commit from index
     """
     version = Version.objects.get(pk=version_pk)
 
@@ -642,6 +643,7 @@ def update_search(version_pk, commit):
         # Don't index sections to speed up indexing.
         # They aren't currently exposed anywhere.
         section=False,
+        delete=delete_non_commit_files,
     )
 
 


### PR DESCRIPTION
The command was obviously broken as explained in #1641. This PR fixes the outstanding bugs and added a simple check whether the passed in project slug actually exists.

I have tested it until elasticsearch is actually involved, no further since I don't have a working elasticsearch setup.

Please note that the semantics changed very slightly as the now used `update_search` does not pass the `delete=False` flag to `index_search_request` as the previous code in the management command did. Please consider this during review.

In my understanding the same logig used for the actual search index updates on the server via `update_search` should also work for a manual reindex.

Fixes #1641.