### PR TITLE
Allow anonymous read access for endpoints protected by APIRestrictedPermission

### DIFF
--- a/readthedocs/restapi/permissions.py
+++ b/readthedocs/restapi/permissions.py
@@ -45,7 +45,7 @@ class APIPermission(permissions.IsAuthenticatedOrReadOnly):
         return has_perm or (request.user and request.user.is_staff)
 
 
-class APIRestrictedPermission(permissions.IsAdminUser):
+class APIRestrictedPermission(permissions.BasePermission):
     """Allow admin write, authenticated and anonymous read only
 
     This differs from :py:cls:`APIPermission` by not allowing for authenticated
@@ -53,6 +53,12 @@ class APIRestrictedPermission(permissions.IsAdminUser):
     by admin users to coordinate build instance creation, but only should be
     readable by end users.
     """
+
+    def has_permission(self, request, view):
+        return (
+            request.method in permissions.SAFE_METHODS or
+            (request.user and request.user.is_staff)
+        )
 
     def has_object_permission(self, request, view, obj):
         return (

--- a/readthedocs/rtd_tests/tests/test_api_permissions.py
+++ b/readthedocs/rtd_tests/tests/test_api_permissions.py
@@ -1,0 +1,81 @@
+from functools import partial
+from mock import Mock
+from unittest import TestCase
+
+from readthedocs.restapi.permissions import APIRestrictedPermission
+
+
+class APIRestrictedPermissionTests(TestCase):
+    def get_request(self, method, is_admin):
+        request = Mock()
+        request.method = method
+        request.user.is_staff = is_admin
+        return request
+
+    def assertAllow(self, handler, method, is_admin, obj=None):
+        if obj is None:
+            self.assertTrue(handler.has_permission(
+                request=self.get_request(method, is_admin=is_admin),
+                view=None))
+        else:
+            self.assertTrue(handler.has_object_permission(
+                request=self.get_request(method, is_admin=is_admin),
+                view=None,
+                obj=obj))
+
+    def assertDisallow(self, handler, method, is_admin, obj=None):
+        if obj is None:
+            self.assertFalse(handler.has_permission(
+                request=self.get_request(method, is_admin=is_admin),
+                view=None))
+        else:
+            self.assertFalse(handler.has_object_permission(
+                request=self.get_request(method, is_admin=is_admin),
+                view=None,
+                obj=obj))
+
+    def test_non_object_permissions(self):
+        handler = APIRestrictedPermission()
+
+        assertAllow = partial(self.assertAllow, handler, obj=None)
+        assertDisallow = partial(self.assertDisallow, handler, obj=None)
+
+        assertAllow('GET', is_admin=False)
+        assertAllow('HEAD', is_admin=False)
+        assertAllow('OPTIONS', is_admin=False)
+        assertDisallow('DELETE', is_admin=False)
+        assertDisallow('PATCH', is_admin=False)
+        assertDisallow('POST', is_admin=False)
+        assertDisallow('PUT', is_admin=False)
+
+        assertAllow('GET', is_admin=True)
+        assertAllow('HEAD', is_admin=True)
+        assertAllow('OPTIONS', is_admin=True)
+        assertAllow('DELETE', is_admin=True)
+        assertAllow('PATCH', is_admin=True)
+        assertAllow('POST', is_admin=True)
+        assertAllow('PUT', is_admin=True)
+
+    def test_object_permissions(self):
+        handler = APIRestrictedPermission()
+
+        obj = Mock()
+
+        assertAllow = partial(self.assertAllow, handler, obj=obj)
+        assertDisallow = partial(self.assertDisallow, handler, obj=obj)
+
+        assertAllow('GET', is_admin=False)
+        assertAllow('HEAD', is_admin=False)
+        assertAllow('OPTIONS', is_admin=False)
+        assertDisallow('DELETE', is_admin=False)
+        assertDisallow('PATCH', is_admin=False)
+        assertDisallow('POST', is_admin=False)
+        assertDisallow('PUT', is_admin=False)
+
+        assertAllow('GET', is_admin=True)
+        assertAllow('HEAD', is_admin=True)
+        assertAllow('OPTIONS', is_admin=True)
+        assertAllow('DELETE', is_admin=True)
+        assertAllow('PATCH', is_admin=True)
+        assertAllow('POST', is_admin=True)
+        assertAllow('PUT', is_admin=True)


### PR DESCRIPTION
This was not working as advertised in the docstring.

Fixes #1659.