### PR TITLE
Drop bzr from requirements

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -30,7 +30,6 @@ django-allauth==0.21.0
 dnspython==1.11.0
 
 # VCS
-bzr==2.6
 launchpadlib==1.10.2
 mercurial==2.6.3
 httplib2==0.7.7


### PR DESCRIPTION
It isn't on pip anymore? We're not using it as a library anyways. This should be a system level dependency if it isn't already.