### PR TITLE
Add a BuildManager & proper UI around filtered out builds

### DIFF
--- a/readthedocs/api/base.py
+++ b/readthedocs/api/base.py
@@ -140,7 +140,7 @@ class VersionResource(ModelResource):
     #     return bundle
 
     def get_object_list(self, request):
-        self._meta.queryset = Version.objects.api(user=request.user, only_active=False)
+        self._meta.queryset = Version.objects.api(user=request.user)
         return super(VersionResource, self).get_object_list(request)
 
     def version_compare(self, request, project_slug, base=None, **kwargs):

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -11,11 +11,10 @@ from django.utils.translation import ugettext_lazy as _, ugettext
 from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
-from readthedocs.privacy.loader import (VersionManager, RelatedProjectManager,
-                                        RelatedBuildManager)
+from readthedocs.privacy.loader import (VersionManager, RelatedBuildManager,
+                                        BuildManager)
 from readthedocs.projects.models import Project
-from readthedocs.projects.constants import (PRIVACY_CHOICES, REPO_TYPE_GIT,
-                                            REPO_TYPE_HG, GITHUB_URL,
+from readthedocs.projects.constants import (PRIVACY_CHOICES, GITHUB_URL,
                                             GITHUB_REGEXS, BITBUCKET_URL,
                                             BITBUCKET_REGEXS)
 from readthedocs.core.resolver import resolve
@@ -321,7 +320,7 @@ class Build(models.Model):
 
     # Manager
 
-    objects = RelatedProjectManager()
+    objects = BuildManager()
 
     class Meta:
         ordering = ['-date']
@@ -349,6 +348,7 @@ class Build(models.Model):
 
 
 class BuildCommandResultMixin(object):
+
     '''Mixin for common command result methods/properties
 
     Shared methods between the database model :py:cls:`BuildCommandResult` and

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -16,19 +16,21 @@ from redis import Redis, ConnectionError
 log = logging.getLogger(__name__)
 
 
-class BuildList(ListView):
-    model = Build
+class BaseBuild(object):
 
     def get_queryset(self):
         self.project_slug = self.kwargs.get('project_slug', None)
-
         self.project = get_object_or_404(
             Project.objects.protected(self.request.user),
             slug=self.project_slug
         )
-        queryset = Build.objects.filter(project=self.project)
+        queryset = Build.objects.public(user=self.request.user, project=self.project)
 
         return queryset
+
+
+class BuildList(BaseBuild, ListView):
+    model = Build
 
     def get_context_data(self, **kwargs):
         context = super(BuildList, self).get_context_data(**kwargs)
@@ -50,26 +52,17 @@ class BuildList(ListView):
         return context
 
 
-class BuildDetail(DetailView):
+class BuildDetail(BaseBuild, DetailView):
     model = Build
     pk_url_kwarg = 'build_pk'
-
-    def get_queryset(self):
-        self.project_slug = self.kwargs.get('project_slug', None)
-
-        self.project = get_object_or_404(
-            Project.objects.protected(self.request.user),
-            slug=self.project_slug
-        )
-        queryset = Build.objects.filter(project=self.project)
-
-        return queryset
 
     def get_context_data(self, **kwargs):
         context = super(BuildDetail, self).get_context_data(**kwargs)
         context['project'] = self.project
         return context
 
+
+# Old build view redirects
 
 def builds_redirect_list(request, project_slug):
     return HttpResponsePermanentRedirect(reverse('builds_project_list', args=[project_slug]))

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -16,7 +16,8 @@ from redis import Redis, ConnectionError
 log = logging.getLogger(__name__)
 
 
-class BaseBuild(object):
+class BuildBase(object):
+    model = Build
 
     def get_queryset(self):
         self.project_slug = self.kwargs.get('project_slug', None)
@@ -29,8 +30,7 @@ class BaseBuild(object):
         return queryset
 
 
-class BuildList(BaseBuild, ListView):
-    model = Build
+class BuildList(BuildBase, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(BuildList, self).get_context_data(**kwargs)
@@ -52,8 +52,7 @@ class BuildList(BaseBuild, ListView):
         return context
 
 
-class BuildDetail(BaseBuild, DetailView):
-    model = Build
+class BuildDetail(BuildBase, DetailView):
     pk_url_kwarg = 'build_pk'
 
     def get_context_data(self, **kwargs):

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -7,6 +7,7 @@ def readthedocs_processor(request):
         'PRODUCTION_DOMAIN': getattr(settings, 'PRODUCTION_DOMAIN', None),
         'USE_SUBDOMAINS': getattr(settings, 'USE_SUBDOMAINS', None),
         'GLOBAL_ANALYTICS_CODE': getattr(settings, 'GLOBAL_ANALYTICS_CODE', 'UA-17997319-1'),
-        'TEMPLATE_ROOT': getattr(settings, 'TEMPLATE_ROOT', None) + '/',
+        'SITE_ROOT': getattr(settings, 'SITE_ROOT', '') + '/',
+        'TEMPLATE_ROOT': getattr(settings, 'TEMPLATE_ROOT', '') + '/',
     }
     return exports

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -123,7 +123,7 @@ class BuildManager(models.Manager):
     """
 
     def _add_user_repos(self, queryset, user=None):
-        if user.has_perm('builds.view_version'):
+        if user.has_perm('projects.view_project'):
             return self.get_queryset().all().distinct()
         if user.is_authenticated():
             user_queryset = get_objects_for_user(user, 'builds.view_version')

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -71,7 +71,7 @@ class VersionManager(models.Manager):
     """
 
     def _add_user_repos(self, queryset, user):
-        if user.has_perm('projects.view_project'):
+        if user.has_perm('builds.view_version'):
             return self.get_queryset().all().distinct()
         if user.is_authenticated():
             user_queryset = get_objects_for_user(user, 'builds.view_version')
@@ -123,7 +123,7 @@ class BuildManager(models.Manager):
     """
 
     def _add_user_repos(self, queryset, user=None):
-        if user.has_perm('projects.view_project'):
+        if user.has_perm('builds.view_version'):
             return self.get_queryset().all().distinct()
         if user.is_authenticated():
             user_queryset = get_objects_for_user(user, 'builds.view_version')

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -14,18 +14,16 @@ from readthedocs.projects import constants
 
 class ProjectManager(models.Manager):
 
+    """
+    Projects take into account their own privacy_level setting.
+    """
+
     def _add_user_repos(self, queryset, user):
-        # Avoid circular import
-        from readthedocs.projects.models import Project
-        # Show all projects to super user
         if user.has_perm('projects.view_project'):
-            return Project.objects.all().distinct()
-        # Show user projects to user
+            return self.get_queryset().all().distinct()
         if user.is_authenticated():
-            # Add in possible user-specific views
             user_queryset = get_objects_for_user(user, 'projects.view_project')
-            return user_queryset | queryset
-        # User has no special privs
+            queryset = user_queryset | queryset
         return queryset.distinct()
 
     def for_user_and_viewer(self, user, viewer):
@@ -66,107 +64,22 @@ class ProjectManager(models.Manager):
         return self.public(user)
 
 
-class RelatedProjectManager(models.Manager):
+class VersionManager(models.Manager):
 
-    def _add_user_repos(self, queryset, user=None):
-        # Hack around get_objects_for_user not supporting global perms
+    """
+    Versions take into account their own privacy_level setting.
+    """
+
+    def _add_user_repos(self, queryset, user):
         if user.has_perm('projects.view_project'):
             return self.get_queryset().all().distinct()
         if user.is_authenticated():
-            # Add in possible user-specific views
-            project_qs = get_objects_for_user(user, 'projects.view_project')
-            pks = [p.pk for p in project_qs]
-            queryset = self.get_queryset().filter(project__pk__in=pks) | queryset
-        return queryset.distinct()
-
-    def public(self, user=None, project=None):
-        queryset = self.filter(project__privacy_level=constants.PUBLIC)
-        if user:
-            queryset = self._add_user_repos(queryset, user)
-        if project:
-            queryset = queryset.filter(project=project)
-        return queryset
-
-    def api(self, user=None):
-        return self.public(user)
-
-
-class RelatedBuildManager(models.Manager):
-
-    '''For models with association to a project through :py:cls:`Build`'''
-
-    def _add_user_repos(self, queryset, user=None):
-        # Hack around get_objects_for_user not supporting global perms
-        if user.has_perm('projects.view_project'):
-            return self.get_queryset().all().distinct()
-        if user.is_authenticated():
-            # Add in possible user-specific views
-            project_qs = get_objects_for_user(user, 'projects.view_project')
-            pks = [p.pk for p in project_qs]
-            queryset = (self.get_queryset()
-                        .filter(build__project__pk__in=pks) | queryset)
-        return queryset.distinct()
-
-    def public(self, user=None, project=None):
-        queryset = self.filter(build__project__privacy_level=constants.PUBLIC)
-        if user:
-            queryset = self._add_user_repos(queryset, user)
-        if project:
-            queryset = queryset.filter(build__project=project)
-        return queryset
-
-    def api(self, user=None):
-        return self.public(user)
-
-
-class BuildManager(RelatedProjectManager):
-    """
-    Build objects mostly related to Versions,
-    but should also take into account the privacy of the Project as well.
-    """
-
-    def _add_user_repos(self, queryset, user=None):
-        queryset = super(BuildManager, self)._add_user_repos(queryset, user)
-        if user and user.is_authenticated():
-            # Add in possible user-specific views
             user_queryset = get_objects_for_user(user, 'builds.view_version')
-            pks = [p.pk for p in user_queryset]
-            queryset = self.get_queryset().filter(version__pk__in=pks).distinct() | queryset
-        elif user:
-            # Hack around get_objects_for_user not supporting global perms
-            global_access = user.has_perm('builds.view_version')
-            if global_access:
-                queryset = self.get_queryset().all().distinct()
-        return queryset.distinct()
-
-    def public(self, user=None, project=None):
-        queryset = self.filter(project__privacy_level=constants.PUBLIC,
-                               version__privacy_level=constants.PUBLIC)
-        if user:
-            queryset = self._add_user_repos(queryset, user)
-        if project:
-            queryset = queryset.filter(project=project)
-        return queryset
-
-
-class VersionManager(RelatedProjectManager):
-
-    def _add_user_repos(self, queryset, user=None):
-        queryset = super(VersionManager, self)._add_user_repos(queryset, user)
-        if user and user.is_authenticated():
-            # Add in possible user-specific views
-            user_queryset = get_objects_for_user(user, 'builds.view_version')
-            queryset = user_queryset.distinct() | queryset
-        elif user:
-            # Hack around get_objects_for_user not supporting global perms
-            global_access = user.has_perm('builds.view_version')
-            if global_access:
-                queryset = self.get_queryset().all().distinct()
+            queryset = user_queryset | queryset
         return queryset.distinct()
 
     def public(self, user=None, project=None, only_active=True):
-        queryset = self.filter(project__privacy_level=constants.PUBLIC,
-                               privacy_level=constants.PUBLIC)
+        queryset = self.filter(privacy_level=constants.PUBLIC)
         if user:
             queryset = self._add_user_repos(queryset, user)
         if project:
@@ -203,15 +116,88 @@ class VersionManager(RelatedProjectManager):
         return self.create(**defaults)
 
 
-class AdminPermission(object):
+class BuildManager(models.Manager):
 
-    @classmethod
-    def is_admin(cls, user, project):
-        return user in project.users.all()
+    """
+    Build objects take into account the privacy of the Version they relate to.
+    """
+
+    def _add_user_repos(self, queryset, user=None):
+        if user.has_perm('builds.view_version'):
+            return self.get_queryset().all().distinct()
+        if user.is_authenticated():
+            user_queryset = get_objects_for_user(user, 'builds.view_version')
+            pks = [p.pk for p in user_queryset]
+            queryset = self.get_queryset().filter(version__pk__in=pks) | queryset
+        return queryset.distinct()
+
+    def public(self, user=None, project=None):
+        queryset = self.filter(version__privacy_level=constants.PUBLIC)
+        if user:
+            queryset = self._add_user_repos(queryset, user)
+        if project:
+            queryset = queryset.filter(project=project)
+        return queryset
+
+    def api(self, user=None):
+        return self.public(user)
 
 
-class AdminNotAuthorized(ValueError):
-    pass
+class RelatedProjectManager(models.Manager):
+
+    """
+    A manager for things that relate to Project and need to get their perms from the project.
+
+    This shouldn't be used as a subclass.
+    """
+
+    def _add_user_repos(self, queryset, user=None):
+        # Hack around get_objects_for_user not supporting global perms
+        if user.has_perm('projects.view_project'):
+            return self.get_queryset().all().distinct()
+        if user.is_authenticated():
+            # Add in possible user-specific views
+            project_qs = get_objects_for_user(user, 'projects.view_project')
+            pks = [p.pk for p in project_qs]
+            queryset = self.get_queryset().filter(project__pk__in=pks) | queryset
+        return queryset.distinct()
+
+    def public(self, user=None, project=None):
+        queryset = self.filter(project__privacy_level=constants.PUBLIC)
+        if user:
+            queryset = self._add_user_repos(queryset, user)
+        if project:
+            queryset = queryset.filter(project=project)
+        return queryset
+
+    def api(self, user=None):
+        return self.public(user)
+
+
+class RelatedBuildManager(models.Manager):
+
+    '''For models with association to a project through :py:cls:`Build`'''
+
+    def _add_user_repos(self, queryset, user=None):
+        if user.has_perm('builds.view_version'):
+            return self.get_queryset().all().distinct()
+        if user.is_authenticated():
+            user_queryset = get_objects_for_user(user, 'builds.view_version')
+            pks = [p.pk for p in user_queryset]
+            queryset = self.get_queryset().filter(
+                build__version__pk__in=pks) | queryset
+        return queryset.distinct()
+
+    def public(self, user=None, project=None):
+        queryset = self.filter(build__version__privacy_level=constants.PUBLIC)
+        if user:
+            queryset = self._add_user_repos(queryset, user)
+        if project:
+            queryset = queryset.filter(build__project=project)
+        return queryset
+
+    def api(self, user=None):
+        return self.public(user)
 
 
 class RelatedUserManager(models.Manager):
@@ -223,3 +209,14 @@ class RelatedUserManager(models.Manager):
         if not user.is_authenticated():
             return self.none()
         return self.filter(users=user)
+
+
+class AdminPermission(object):
+
+    @classmethod
+    def is_admin(cls, user, project):
+        return user in project.users.all()
+
+
+class AdminNotAuthorized(ValueError):
+    pass

--- a/readthedocs/privacy/loader.py
+++ b/readthedocs/privacy/loader.py
@@ -8,6 +8,10 @@ ProjectManager = import_by_path(
 VersionManager = import_by_path(
     getattr(settings, 'VERSION_MANAGER',
             'readthedocs.privacy.backend.VersionManager'))
+BuildManager = import_by_path(
+    getattr(settings, 'BUILD_MANAGER',
+            'readthedocs.privacy.backend.BuildManager'))
+
 RelatedProjectManager = import_by_path(
     getattr(settings, 'RELATED_PROJECT_MANAGER',
             'readthedocs.privacy.backend.RelatedProjectManager'))

--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -11,6 +11,7 @@
     <div class="rst-other-versions">
       {% endif %}
 
+      {% block versions %}
       {% if translations %}
       <dl>
         <dt>Languages</dt>
@@ -44,7 +45,9 @@
         {% endfor %}
       </dl>
       {% endif %}
+      {% endblock %}
 
+      {% block downloads %}
       {% if downloads %}
       <dl>
         <dt>Downloads</dt>
@@ -53,7 +56,9 @@
         {% endfor %}
       </dl>
       {% endif %}
+      {% endblock %}
 
+      {% block readthedocs %}
       <dl>
         <!-- These are kept as relative links for internal installs that are http -->
         <dt>On Read the Docs</dt>
@@ -67,6 +72,9 @@
           <a href="//{{ settings.PRODUCTION_DOMAIN }}{% url 'project_downloads' project.slug %}">Downloads</a>
         </dd>
       </dl>
+      {% endblock %}
+
+      {% block vcs %}
 
       {% if github_edit_url %}
       <dl>
@@ -86,7 +94,9 @@
         </dd>
       </dl>
       {% endif %}
+      {% endblock %}
 
+      {% block search %}
       <dl>
         <dt>Search</dt>
         <dd>
@@ -97,6 +107,7 @@
           </div>
         </dd>
       </dl>
+      {% endblock %}
 
 
 

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import get_object_or_404
-from django.template import loader as template_loader
+from django.template import RequestContext, loader as template_loader
 from django.conf import settings
-from django.core.context_processors import csrf
 
 from rest_framework import decorators, permissions
 from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
@@ -121,8 +120,8 @@ def footer_html(request):
         'bitbucket_url': version.get_bitbucket_url(docroot, page_slug, source_suffix),
     }
 
-    context.update(csrf(request))
-    html = template_loader.get_template('restapi/footer.html').render(context)
+    request_context = RequestContext(request, context)
+    html = template_loader.get_template('restapi/footer.html').render(request_context)
     resp_data = {
         'html': html,
         'version_active': version.active,

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -55,6 +55,10 @@ class PrivacyTests(TestCase):
         proj.num_point = 2
         proj.save()
 
+        latest = proj.versions.get(slug='latest')
+        latest.privacy_level = version_privacy_level
+        latest.save()
+
         self.assertAlmostEqual(Project.objects.count(), 1)
         r = self.client.get('/projects/django-kong/')
         self.assertEqual(r.status_code, 200)

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -122,10 +122,14 @@ class PrivacyTests(TestCase):
         self.assertEqual(Version.objects.get(slug='test-slug').privacy_level, 'private')
         r = self.client.get('/projects/django-kong/')
         self.assertTrue('test-slug' in r.content)
+        r = self.client.get('/projects/django-kong/builds/')
+        self.assertTrue('test-slug' in r.content)
 
         # Make sure it doesn't show up as tester
         self.client.login(username='tester', password='test')
         r = self.client.get('/projects/django-kong/')
+        self.assertTrue('test-slug' not in r.content)
+        r = self.client.get('/projects/django-kong/builds/')
         self.assertTrue('test-slug' not in r.content)
 
     def test_public_branch(self):

--- a/readthedocs/templates/builds/build_list.html
+++ b/readthedocs/templates/builds/build_list.html
@@ -50,6 +50,7 @@ Filters
         <div class="module">
           <div class="module-wrapper">
 
+            {% if versions %}
             <div class="module-header">
               <div style="float:right;">
                 <form method="post" action="{% url "generic_build" project.pk %}">
@@ -67,6 +68,8 @@ Filters
                   </form>
                 </div>
               </div>
+            {% endif %}
+
               <h1>{% trans "Recent Builds" %}</h1>
             </div>
 

--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -66,7 +66,7 @@
 
       {% empty %}
       <p>
-      No active versions.
+      {% trans "No active versions." %}
       </p>
       {% endfor %}
       </ul>

--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -24,7 +24,6 @@
   <!-- END onboard -->
   {% endif %}
 
-{% if versions %}
 
   <div class="module-header">
     <h3>{% trans "Versions" %}</h3>
@@ -64,11 +63,17 @@
             </ul>
           {% endif %}
         </li>
+
+      {% empty %}
+      <p>
+      No active versions.
+      </p>
       {% endfor %}
       </ul>
     </div>
   </div>
 
+{% if versions %}
   <div class="build_a_version">
     <h3>{% trans "Build a version" %}</h3>
     <div class="version_right">

--- a/readthedocs/templates/core/project_downloads.html
+++ b/readthedocs/templates/core/project_downloads.html
@@ -26,7 +26,7 @@
   {% endif %}
 
 {% empty %}
-  <li class="module-item col-span">
+    <p>
     {% trans "No downloads for this project." %}
-  </li>
+    </p>
 {% endfor %}

--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -64,6 +64,11 @@ Versions
 
               </li>
               {% endblock active-versions %}
+
+            {% empty %}
+            <p>
+            No active versions.
+            </p>
             {% endfor %}
           </ul>
         </div>

--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -67,7 +67,7 @@ Versions
 
             {% empty %}
             <p>
-            No active versions.
+            {% trans "No active versions." %}
             </p>
             {% endfor %}
           </ul>


### PR DESCRIPTION
This adds a specific Build manager that checks the privacy level of the Version, so that we can show the proper list of builds.

Also adds some saner handling to default empty states in the templates, and removes the `*args` and `**kwargs` arguments to the templates, as this was not necessary. 