### PR TITLE
Add support for public domain.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -67,3 +67,12 @@ USE_PIP_INSTALL
 Default: `False`
 
 Whether to use `pip install .` or `python setup.py install` when installing packages into the Virtualenv. Default is to use `python setup.py install`.
+
+
+PUBLIC_DOMAIN
+-------------
+
+Default: `settings.PRODUCTION_DOMAIN`
+
+A special domain for serving public documentation.
+If set, public docs will be linked here instead of the `PRODUCTION_DOMAIN`.

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -59,7 +59,9 @@ def base_resolve_path(project_slug, filename, version_slug=None, language=None, 
                       single_version=None, subproject_slug=None,  subdomain=None, cname=None):
     """ Resolve a with nothing smart, just filling in the blanks."""
 
-    if (subdomain or cname) and not private:
+    if private:
+        url = '/docs/{project_slug}/'
+    elif subdomain or cname:
         url = '/'
     else:
         url = '/docs/{project_slug}/'
@@ -122,6 +124,7 @@ def resolve_domain(project, private=None):
     relation = project.superprojects.first()
     subdomain = getattr(settings, 'USE_SUBDOMAIN', False)
     prod_domain = getattr(settings, 'PRODUCTION_DOMAIN')
+    public_domain = getattr(settings, 'PUBLIC_DOMAIN', prod_domain)
     if private is None:
         private = project.privacy_level == PRIVATE
 
@@ -140,9 +143,9 @@ def resolve_domain(project, private=None):
         return domain.domain
     elif subdomain:
         subdomain_slug = canonical_project.slug.replace('_', '-')
-        return "%s.%s" % (subdomain_slug, prod_domain)
+        return "%s.%s" % (subdomain_slug, public_domain)
     else:
-        return prod_domain
+        return public_domain
 
 
 def resolve(project, protocol='http', filename='', private=None, **kwargs):

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -235,6 +235,22 @@ class ResolverDomainTests(ResolverBase):
             url = resolve_domain(project=self.translation)
             self.assertEqual(url, 'pip.readthedocs.org')
 
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org', PUBLIC_DOMAIN='public.readthedocs.org')
+    def test_domain_public(self):
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve_domain(project=self.translation)
+            self.assertEqual(url, 'public.readthedocs.org')
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve_domain(project=self.translation)
+            self.assertEqual(url, 'pip.public.readthedocs.org')
+        # Private overrides domain
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve_domain(project=self.translation, private=True)
+            self.assertEqual(url, 'readthedocs.org')
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve_domain(project=self.translation, private=True)
+            self.assertEqual(url, 'readthedocs.org')
+
 
 class ResolverTests(ResolverBase):
 
@@ -319,3 +335,29 @@ class ResolverTests(ResolverBase):
             self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
             url = resolve(project=self.pip, private=False)
             self.assertEqual(url, 'http://pip.readthedocs.org/en/latest/')
+
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org', PUBLIC_DOMAIN='public.readthedocs.org')
+    def test_resolver_public_domain_overrides(self):
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve(project=self.pip, private=True)
+            self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+            url = resolve(project=self.pip, private=False)
+            self.assertEqual(url, 'http://public.readthedocs.org/docs/pip/en/latest/')
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve(project=self.pip, private=True)
+            self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+            url = resolve(project=self.pip, private=False)
+            self.assertEqual(url, 'http://pip.public.readthedocs.org/en/latest/')
+
+        # Domain overrides PUBLIC_DOMAIN
+        self.domain = get(Domain, domain='docs.foobar.com', project=self.pip, canonical=True)
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve(project=self.pip, private=True)
+            self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+            url = resolve(project=self.pip, private=False)
+            self.assertEqual(url, 'http://docs.foobar.com/en/latest/')
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve(project=self.pip, private=True)
+            self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+            url = resolve(project=self.pip, private=False)
+            self.assertEqual(url, 'http://docs.foobar.com/en/latest/')


### PR DESCRIPTION
This will be the domain that public documentation is served,
if it is different than private.

This allows for auth handling on private domains,
while allowing public docs to be cookie-free.