### PR TITLE
Handle proper resolution of privacy level on versions.

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -61,8 +61,7 @@ class ProjectRelationship(models.Model):
 
     # HACK
     def get_absolute_url(self):
-        private = self.child.privacy_level == constants.PRIVATE
-        return resolve(self.child, private=private)
+        return resolve(self.child)
 
 
 class Project(models.Model):
@@ -333,8 +332,7 @@ class Project(models.Model):
 
         Always use http for now, to avoid content warnings.
         """
-        if private is None:
-            private = self.privacy_level == constants.PRIVATE
+        import ipdb; ipdb.set_trace()
         return resolve(project=self, version_slug=version_slug, language=lang_slug, private=private)
 
     def get_builds_url(self):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -332,7 +332,6 @@ class Project(models.Model):
 
         Always use http for now, to avoid content warnings.
         """
-        import ipdb; ipdb.set_trace()
         return resolve(project=self, version_slug=version_slug, language=lang_slug, private=private)
 
     def get_builds_url(self):

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -332,6 +332,22 @@ class ResolverTests(ResolverBase):
             self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
         with override_settings(USE_SUBDOMAIN=True):
             url = resolve(project=self.pip)
+            self.assertEqual(url, 'http://pip.readthedocs.org/en/latest/')
+            url = resolve(project=self.pip, private=False)
+            self.assertEqual(url, 'http://pip.readthedocs.org/en/latest/')
+
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
+    def test_resolver_private_version_override(self):
+        latest = self.pip.versions.first()
+        latest.privacy_level = PRIVATE
+        latest.save()
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve(project=self.pip)
+            self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+            url = resolve(project=self.pip, private=False)
+            self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve(project=self.pip)
             self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
             url = resolve(project=self.pip, private=False)
             self.assertEqual(url, 'http://pip.readthedocs.org/en/latest/')


### PR DESCRIPTION
Previously we were defaulting to the project privacy,
which led to broken privacy guessing on `latest` versions.