### PR TITLE
Some Python2/3 compatibility fixes.

### DIFF
--- a/readthedocs/api/base.py
+++ b/readthedocs/api/base.py
@@ -93,7 +93,7 @@ class ProjectResource(ModelResource, SearchMixin):
             self._sync_versions(project, data['tags'])
             self._sync_versions(project, data['branches'])
             deleted_versions = self._delete_versions(project, data)
-        except Exception, e:
+        except Exception as e:
             return self.create_response(
                 request,
                 {'exception': e.message},

--- a/readthedocs/api/utils.py
+++ b/readthedocs/api/utils.py
@@ -165,7 +165,7 @@ class EnhancedModelResource(ModelResource):
 
         try:
             return self.get_object_list(request).filter(**applicable_filters)
-        except ValueError, e:
+        except ValueError as e:
             raise NotFound(ugettext("Invalid resource lookup data provided "
                                     "(mismatched type).: %(error)s")
                            % {'error': e})

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -2,7 +2,7 @@ import getpass
 import logging
 import os
 
-from urlparse import urlparse
+from six.moves import urllib_parse
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
@@ -35,7 +35,7 @@ def run_on_app_servers(command):
 
 
 def clean_url(url):
-    parsed = urlparse(url)
+    parsed = urllib_parse.urlparse(url)
     if parsed.scheme:
         scheme, netloc = parsed.scheme, parsed.netloc
     elif parsed.netloc:

--- a/readthedocs/core/views.py
+++ b/readthedocs/core/views.py
@@ -184,7 +184,7 @@ def _build_url(url, branches):
                 url, ' '.join(not_building))
             pc_log.info(msg)
             return HttpResponse(msg)
-    except Exception, e:
+    except Exception as e:
         if e.__class__ == NoProjectException:
             raise
         msg = "(URL Build) Failed: %s:%s" % (url, e)

--- a/readthedocs/oauth/migrations/0003_move_github.py
+++ b/readthedocs/oauth/migrations/0003_move_github.py
@@ -108,7 +108,7 @@ def forwards_move_repos(apps, schema_editor):
             else:
                 new_repo.clone_url = data.get('clone_url')
             new_repo.json = json.dumps(data)
-        except SyntaxError, ValueError:
+        except SyntaxError as ValueError:
             pass
         new_repo.save()
         log.info('Migrated project: %s', project.name)
@@ -149,7 +149,7 @@ def forwards_move_repos(apps, schema_editor):
                 new_repo.clone_url = clone_urls.get('ssh', project.git_url)
             else:
                 new_repo.clone_url = clone_urls.get('https', project.html_url)
-        except SyntaxError, ValueError:
+        except SyntaxError as ValueError:
             pass
         new_repo.save()
         log.info('Migrated project: %s', project.name)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -108,7 +108,7 @@ class UpdateDocsTask(Task):
                     _('Builds for this project are temporarily disabled'))
             try:
                 self.setup_vcs()
-            except vcs_support_utils.LockTimeout, e:
+            except vcs_support_utils.LockTimeout as e:
                 self.retry(exc=e, throw=False)
                 raise BuildEnvironmentError(
                     'Version locked, retrying in 5 minutes.',
@@ -499,7 +499,7 @@ def update_imported_docs(version_pk):
 
         try:
             api_v2.project(project.pk).sync_versions.post(version_post_data)
-        except Exception, e:
+        except Exception as e:
             print "Sync Versions Exception: %s" % e.message
     return ret_dict
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -18,8 +18,11 @@ django-vanilla-views==1.0.4
 pytest-django==2.8.0
 
 requests==2.3.0
-slumber==0.6.0
+slumber==0.7.1
 lxml==3.3.5
+
+# Python 2/3 compat
+six
 
 # Basic tools
 redis==2.7.1
@@ -45,7 +48,7 @@ beautifulsoup4==4.1.3
 Unipath==0.2.1
 django-kombu==0.9.4
 django-secure==0.1.2
-mimeparse==0.1.3
+mimeparse==0.1.4
 mock==1.0.1
 stripe==1.20.2
 django-copyright==1.0.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -48,7 +48,7 @@ beautifulsoup4==4.1.3
 Unipath==0.2.1
 django-kombu==0.9.4
 django-secure==0.1.2
-mimeparse==0.1.4
+python-mimeparse==0.1.4
 mock==1.0.1
 stripe==1.20.2
 django-copyright==1.0.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -18,7 +18,7 @@ django-vanilla-views==1.0.4
 pytest-django==2.8.0
 
 requests==2.3.0
-slumber==0.7.1
+slumber==0.6
 lxml==3.3.5
 
 # Python 2/3 compat
@@ -48,7 +48,7 @@ beautifulsoup4==4.1.3
 Unipath==0.2.1
 django-kombu==0.9.4
 django-secure==0.1.2
-python-mimeparse==0.1.4
+mimeparse==0.1.3
 mock==1.0.1
 stripe==1.20.2
 django-copyright==1.0.0


### PR DESCRIPTION
A few minor fixes for Python 3 compatibility.

Bump slumber and mimeparse to Python3 Compatible versions.

Add six, and use it for imports who have moved in between 2 and 3.
Use `as` keywords in a few places for exceptions.

The server can now start on Py3, but 500 at first page rendering.