### PR TITLE
Alter direct calls to redis using intermediate redis settings

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -44,7 +44,7 @@ class BuildList(BuildBase, ListView):
         context['versions'] = Version.objects.public(user=self.request.user, project=self.project)
 
         try:
-            redis = Redis(**settings.REDIS)
+            redis = Redis.from_url(settings.BROKER_URL)
             context['queue_length'] = redis.llen('celery')
         except ConnectionError:
             context['queue_length'] = None

--- a/readthedocs/projects/utils.py
+++ b/readthedocs/projects/utils.py
@@ -7,8 +7,9 @@ import traceback
 import logging
 from httplib2 import Http
 
-from django.conf import settings
 import redis
+from django.conf import settings
+from django.core.cache import cache
 
 
 log = logging.getLogger(__name__)
@@ -149,18 +150,21 @@ def purge_version(version, mainsite=False, subdomain=False, cname=False):
                 log.info("Purging %s on readthedocs.org", root_url)
                 h.request(to_purge, method="PURGE", headers=headers)
             if cname:
-                redis_conn = redis.Redis(**settings.REDIS)
-                for cnamed in redis_conn.smembers('rtd_slug:v1:%s'
-                                                  % version.project.slug):
-                    headers = {'Host': cnamed}
-                    url = "/en/%s/*" % version.slug
-                    to_purge = "http://%s%s" % (server, url)
-                    log.info("Purging %s on %s", url, cnamed)
-                    h.request(to_purge, method="PURGE", headers=headers)
-                    root_url = "/"
-                    to_purge = "http://%s%s" % (server, root_url)
-                    log.info("Purging %s on %s", root_url, cnamed)
-                    h.request(to_purge, method="PURGE", headers=headers)
+                try:
+                    redis_client = cache.get_client(None)
+                    for cnamed in redis_client.smembers('rtd_slug:v1:%s'
+                                                        % version.project.slug):
+                        headers = {'Host': cnamed}
+                        url = "/en/%s/*" % version.slug
+                        to_purge = "http://%s%s" % (server, url)
+                        log.info("Purging %s on %s", url, cnamed)
+                        h.request(to_purge, method="PURGE", headers=headers)
+                        root_url = "/"
+                        to_purge = "http://%s%s" % (server, root_url)
+                        log.info("Purging %s on %s", root_url, cnamed)
+                        h.request(to_purge, method="PURGE", headers=headers)
+                except (AttributeError, redis.exceptions.ConnectionError):
+                    pass
 
 
 class DictObj(object):

--- a/readthedocs/settings/onebox.py
+++ b/readthedocs/settings/onebox.py
@@ -9,11 +9,6 @@ DATABASES = {
     }
 }
 
-REDIS = {
-    'host': 'localhost',
-    'port': 6379,
-    'db': 0,
-}
 BROKER_URL = 'redis://localhost:6379/0'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 CELERY_ALWAYS_EAGER = False

--- a/readthedocs/settings/sqlite.py
+++ b/readthedocs/settings/sqlite.py
@@ -9,12 +9,6 @@ DATABASES = {
     }
 }
 
-REDIS = {
-    'host': 'localhost',
-    'port': 6379,
-    'db': 0,
-}
-
 BROKER_URL = 'redis://localhost:6379/0'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 # CELERY_ALWAYS_EAGER = False

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -2,7 +2,7 @@
 psycopg2==2.4.6
 gunicorn==19.1.0
 pysolr==2.0.13
-django-redis-cache==0.9.5
+django-redis-cache==1.6.3
 django-mailgun==0.2.2
 
 hiredis==0.1.2

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -22,7 +22,7 @@ slumber==0.6.0
 lxml==3.3.5
 
 # Basic tools
-redis==2.7.1
+redis==2.10.3
 celery==3.1.18
 django-celery==3.1.16
 django-allauth==0.21.0


### PR DESCRIPTION
Redis will be split up into calls to redis cache server and redis celery
server.  Instead of calling the intermediate object in settings, use existing
configuration for these two databases.

This bumps the version number for redis_cache, as it's far behind, as well as
the version for redis.