### PR TITLE
Add explicit pip cache path to pip install calls and models

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -412,6 +412,11 @@ class Project(models.Model):
     def venv_path(self, version=LATEST):
         return os.path.join(self.doc_path, 'envs', version)
 
+    @property
+    def pip_cache_path(self):
+        """Path to pip cache"""
+        return os.path.join(self.doc_path, '.cache', 'pip')
+
     #
     # Paths for symlinks in project doc_path.
     #

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -261,6 +261,8 @@ class UpdateDocsTask(Task):
             'install',
             '--use-wheel',
             '-U',
+            '--cache-dir',
+            self.project.pip_cache_path,
         ]
         if self.project.use_system_packages:
             # Other code expects sphinx-build to be installed inside the
@@ -294,6 +296,8 @@ class UpdateDocsTask(Task):
                 self.project.venv_bin(version=self.version.slug, filename='pip'),
                 'install',
                 '--exists-action=w',
+                '--cache-dir',
+                self.project.pip_cache_path,
                 '-r{0}'.format(requirements_file_path),
                 cwd=checkout_path,
                 bin_path=self.project.venv_bin(version=self.version.slug)
@@ -309,6 +313,8 @@ class UpdateDocsTask(Task):
                     self.project.venv_bin(version=self.version.slug, filename='pip'),
                     'install',
                     '--ignore-installed',
+                    '--cache-dir',
+                    self.project.pip_cache_path,
                     '.',
                     cwd=checkout_path,
                     bin_path=self.project.venv_bin(version=self.version.slug)


### PR DESCRIPTION
This moves the pip cache to a project-local path, so that it persists into new docker containers.

Fixes #1783