### PR TITLE
Remove jsonp and browsable api renderers

### DIFF
--- a/readthedocs/comments/views.py
+++ b/readthedocs/comments/views.py
@@ -15,7 +15,7 @@ from rest_framework.decorators import (
 )
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.renderers import JSONRenderer, JSONPRenderer, BrowsableAPIRenderer
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer, Serializer
 from rest_framework.viewsets import ModelViewSet
@@ -47,7 +47,7 @@ support = WebSupport(
 
 @api_view(['GET'])
 @permission_classes([permissions.IsAuthenticatedOrReadOnly])
-@renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@renderer_classes((JSONRenderer,))
 def get_options(request):
     base_opts = support.base_comment_opts
     base_opts['addCommentURL'] = '/api/v2/comments/'
@@ -57,7 +57,7 @@ def get_options(request):
 
 @api_view(['GET'])
 @permission_classes([permissions.IsAuthenticatedOrReadOnly])
-@renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@renderer_classes((JSONRenderer,))
 def get_metadata(request):
     """
     Check for get_metadata
@@ -70,7 +70,7 @@ def get_metadata(request):
 @api_view(['GET', 'POST'])
 @permission_classes([permissions.AllowAny])
 @authentication_classes([UnsafeSessionAuthentication])
-@renderer_classes((JSONRenderer, JSONPRenderer))
+@renderer_classes((JSONRenderer,))
 def attach_comment(request):
     comment_id = request.POST.get('comment', '')
     comment = DocumentComment.objects.get(pk=comment_id)

--- a/readthedocs/restapi/views/core_views.py
+++ b/readthedocs/restapi/views/core_views.py
@@ -1,5 +1,5 @@
 from rest_framework import decorators, permissions, status
-from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 import json
@@ -18,7 +18,7 @@ from readthedocs.core.templatetags.core_tags import make_document_url
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def cname(request):
     """
     Get the slug that a particular hostname resolves to.
@@ -44,7 +44,7 @@ def cname(request):
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def docurl(request):
     """
     Get the url that a slug resolves to.
@@ -71,7 +71,7 @@ def docurl(request):
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def embed(request):
     """
     Embed a section of content from any Read the Docs page.

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -3,7 +3,7 @@ from django.template import RequestContext, loader as template_loader
 from django.conf import settings
 
 from rest_framework import decorators, permissions
-from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
+from rest_framework.renderers import JSONPRenderer, JSONRenderer
 from rest_framework.response import Response
 
 from readthedocs.builds.constants import LATEST
@@ -44,7 +44,7 @@ def get_version_compare_data(project, base_version=None):
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer, JSONPRenderer))
 def footer_html(request):
     project_slug = request.GET.get('project', None)
     version_slug = request.GET.get('version', None)

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -3,7 +3,7 @@ import logging
 from django.shortcuts import get_object_or_404
 from rest_framework import decorators, permissions, viewsets, status
 from rest_framework.decorators import detail_route
-from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from readthedocs.builds.constants import BRANCH
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 class ProjectViewSet(viewsets.ModelViewSet):
     permission_classes = [APIPermission]
-    renderer_classes = (JSONRenderer, JSONPRenderer, BrowsableAPIRenderer)
+    renderer_classes = (JSONRenderer,)
     serializer_class = ProjectSerializer
     filter_class = ProjectFilter
     model = Project
@@ -162,7 +162,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
 class VersionViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-    renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
+    renderer_classes = (JSONRenderer,)
     serializer_class = VersionSerializer
     filter_class = VersionFilter
     model = Version
@@ -173,7 +173,7 @@ class VersionViewSet(viewsets.ReadOnlyModelViewSet):
 
 class BuildViewSet(viewsets.ModelViewSet):
     permission_classes = [APIRestrictedPermission]
-    renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
+    renderer_classes = (JSONRenderer,)
     model = Build
 
     def get_queryset(self):
@@ -192,7 +192,7 @@ class BuildViewSet(viewsets.ModelViewSet):
 
 class BuildCommandViewSet(viewsets.ModelViewSet):
     permission_classes = [APIRestrictedPermission]
-    renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
+    renderer_classes = (JSONRenderer,)
     serializer_class = BuildCommandSerializer
     model = BuildCommandResult
 
@@ -202,7 +202,7 @@ class BuildCommandViewSet(viewsets.ModelViewSet):
 
 class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated, RelatedProjectIsOwner)
-    renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
+    renderer_classes = (JSONRenderer,)
     model = EmailHook
 
     def get_queryset(self):
@@ -211,7 +211,7 @@ class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
 
 class DomainViewSet(viewsets.ModelViewSet):
     permission_classes = [APIRestrictedPermission]
-    renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
+    renderer_classes = (JSONRenderer,)
     serializer_class = DomainSerializer
     filter_class = DomainFilter
     model = Domain
@@ -222,7 +222,7 @@ class DomainViewSet(viewsets.ModelViewSet):
 
 class RemoteOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsOwner]
-    renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
+    renderer_classes = (JSONRenderer,)
     serializer_class = RemoteOrganizationSerializer
     model = RemoteOrganization
 
@@ -232,7 +232,7 @@ class RemoteOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
 
 class RemoteRepositoryViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsOwner]
-    renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
+    renderer_classes = (JSONRenderer,)
     serializer_class = RemoteRepositorySerializer
     model = RemoteRepository
 

--- a/readthedocs/restapi/views/search_views.py
+++ b/readthedocs/restapi/views/search_views.py
@@ -1,7 +1,7 @@
 import logging
 
 from rest_framework import decorators, permissions, status
-from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from readthedocs.builds.constants import LATEST
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 @decorators.api_view(['POST'])
 @decorators.permission_classes((permissions.IsAdminUser,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def index_search(request):
     """
     Add things to the search index.
@@ -37,7 +37,7 @@ def index_search(request):
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def search(request):
     project_slug = request.GET.get('project', None)
     version_slug = request.GET.get('version', LATEST)
@@ -54,8 +54,10 @@ def search(request):
                 "query": {
                     "bool": {
                         "should": [
-                            {"match": {"title": {"query": query, "boost": 10}}},
-                            {"match": {"headers": {"query": query, "boost": 5}}},
+                            {"match": {
+                                "title": {"query": query, "boost": 10}}},
+                            {"match": {
+                                "headers": {"query": query, "boost": 5}}},
                             {"match": {"content": {"query": query}}},
                         ]
                     }
@@ -90,7 +92,7 @@ def search(request):
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def project_search(request):
     query = request.GET.get('q', None)
     if query is None:
@@ -120,7 +122,7 @@ def project_search(request):
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def section_search(request):
     """
     Search for a Section of content on Read the Docs.
@@ -166,7 +168,8 @@ def section_search(request):
     version_slug = request.GET.get('version', LATEST)
     path_slug = request.GET.get('path', None)
 
-    log.debug("(API Section Search) [%s:%s] %s" % (project_slug, version_slug, query))
+    log.debug("(API Section Search) [%s:%s] %s" %
+              (project_slug, version_slug, query))
 
     kwargs = {}
     body = {
@@ -176,7 +179,8 @@ def section_search(request):
                 "query": {
                     "bool": {
                         "should": [
-                            {"match": {"title": {"query": query, "boost": 10}}},
+                            {"match": {
+                                "title": {"query": query, "boost": 10}}},
                             {"match": {"content": {"query": query}}},
                         ]
                     }

--- a/readthedocs/restapi/views/task_views.py
+++ b/readthedocs/restapi/views/task_views.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.urlresolvers import reverse
 from rest_framework import decorators, permissions
-from rest_framework.renderers import JSONPRenderer, JSONRenderer, BrowsableAPIRenderer
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from redis import ConnectionError
 
@@ -35,8 +35,7 @@ def get_status_data(task_name, state, data, error=None):
 
 @decorators.api_view(['GET'])
 @decorators.permission_classes((permissions.AllowAny,))
-@decorators.renderer_classes(
-    (JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def job_status(request, task_id):
     try:
         task_name, state, public_data, error = get_public_task_data(request, task_id)
@@ -49,8 +48,7 @@ def job_status(request, task_id):
 
 @decorators.api_view(['POST'])
 @decorators.permission_classes((permissions.IsAuthenticated,))
-@decorators.renderer_classes(
-    (JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+@decorators.renderer_classes((JSONRenderer,))
 def sync_remote_repositories(request):
     result = tasks.sync_remote_repositories.delay(
         user_id=request.user.id)


### PR DESCRIPTION
Allow jsonp on the footer views, but remove it & browsable API from everywhere else, since we aren't using them. 