### PR TITLE
URLs in ReadTheDocs are case-sensitive

### DIFF
--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -21,6 +21,8 @@ your docs whenever you push updates:
 * Check "Active"
 * Click "Add service"
 
+**Note:** The GitHub URL in your ReadTheDocs project must match the URL on GitHub. The URL on ReadTheDocs is case-sensitive.
+
 Bitbucket
 -----------
 


### PR DESCRIPTION
If case-sensitivity is not observed when entering the URL during the setup of your RTD project, then the project will appear to work correctly, however automatic updates on GitHub changes will not work correctly.