### PR TITLE
Display rtd.yml in build output

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -88,7 +88,7 @@ class ConfigWrapper(object):
     #         return self._project.documentation_type
 
 
-def load_yaml_config(version):
+def load_yaml_config(version, build_env):
     """
     Load a configuration from `readthedocs.yml` file.
 
@@ -104,6 +104,10 @@ def load_yaml_config(version):
                 'output_base': '',
             },
         )[0]
+        build_env.run(
+            'cat', 'readthedocs.yml',
+            cwd=checkout_path,
+        )
     except ConfigError:
         config = BuildConfig(
             env_config={},

--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -88,7 +88,7 @@ class ConfigWrapper(object):
     #         return self._project.documentation_type
 
 
-def load_yaml_config(version, build_env):
+def load_yaml_config(version, build_env=None):
     """
     Load a configuration from `readthedocs.yml` file.
 
@@ -104,10 +104,11 @@ def load_yaml_config(version, build_env):
                 'output_base': '',
             },
         )[0]
-        build_env.run(
-            'cat', 'readthedocs.yml',
-            cwd=checkout_path,
-        )
+        if build_env:
+            build_env.run(
+                'cat', 'readthedocs.yml',
+                cwd=checkout_path,
+            )
     except ConfigError:
         config = BuildConfig(
             env_config={},

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -107,13 +107,13 @@ class UpdateDocsTask(Task):
         self.build_localmedia = localmedia
         self.build_force = force
 
-        self.config = load_yaml_config(version=self.version)
-
         env_cls = LocalEnvironment
         if docker or settings.DOCKER_ENABLE:
             env_cls = DockerEnvironment
         self.build_env = env_cls(project=self.project, version=self.version,
                                  build=self.build, record=record)
+
+        self.config = load_yaml_config(version=self.version, build_env=self.build_env)
 
         python_env_cls = Virtualenv
         if self.config.use_conda:


### PR DESCRIPTION
This works similiarly to our handling of `conf.py`, for transparency in the build.