### PR TITLE
Updated documentation with respect to the issue #1908

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -66,7 +66,7 @@ Of course, replacing `MOCK_MODULES` with the modules that you want to mock out.
 
         from mock import Mock as MagicMock
 
-If such libraries are installed are installed via ``setup.py``, you also will need to remove all the C-dependent libraries from your ``install_requires`` in the RTD environment.
+If such libraries are installed via ``setup.py``, you also will need to remove all the C-dependent libraries from your ``install_requires`` in the RTD environment.
 
 `Client Error 401` when building documentation
 ----------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -66,6 +66,8 @@ Of course, replacing `MOCK_MODULES` with the modules that you want to mock out.
 
         from mock import Mock as MagicMock
 
+If such libraries are installed are installed via ``setup.py``, you also will need to remove all the C-dependent libraries from your ``install_requires`` in the RTD environment.
+
 `Client Error 401` when building documentation
 ----------------------------------------------
 


### PR DESCRIPTION
Added to FAQ about the C modules the need to remove the C-dependent libraries from setup so that the project can be properly installed in the RTD.