### PR TITLE
ENH: Activate/deactivate conda environment for build duration

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -5,6 +5,7 @@ rebuilding documentation.
 """
 
 import os
+import sys
 import shutil
 import json
 import logging
@@ -142,6 +143,19 @@ class UpdateDocsTask(Task):
 
             self.setup_environment()
 
+            # Activate the conda environment
+            if self.config.use_conda:
+                os.environ['CONDA_DEFAULT_ENV'] = self.python_env.version.slug
+                os.environ['CONDA_ENV_PATH'] = os.path.join(
+                    self.project.doc_path,
+                    'conda',
+                    self.python_env.version.slug
+                )
+                sys.path.insert(
+                    0, os.path.join(os.environ['CONDA_ENV_PATH'], "bin")
+                )
+                os.environ["PATH"] = ":".join(sys.path)
+
             # TODO the build object should have an idea of these states, extend
             # the model to include an idea of these outcomes
             outcomes = self.build_docs()
@@ -159,6 +173,13 @@ class UpdateDocsTask(Task):
                     pdf=outcomes['pdf'],
                     epub=outcomes['epub'],
                 )
+
+        # Deactivate the conda environment
+        if self.config.use_conda:
+            del os.environ['CONDA_DEFAULT_ENV']
+            del os.environ['CONDA_ENV_PATH']
+            sys.path.remove(os.path.join(os.environ['CONDA_ENV_PATH'], "bin"))
+            os.environ["PATH"] = ":".join(sys.path)
 
         if self.build_env.failed:
             self.send_notifications()


### PR DESCRIPTION
**TL;DR:** Tries to simply activate the `conda` environment (for a `conda` build only) and deactivate after the build ends, but before sending out notifications.

**Detail:** This takes advantage of the fact that the builder will read information from the `os.environ` to use for its base environment. As a result, simply seed `os.environ` with what `conda` needs to recognize the environment. Simply strip this information out afterwards. Note that `PATH` had to be used here as the builder reads it instead of looking at `sys.path` (unless I have missed something).

**Todo:**
* [x] Activate the `conda` environment
* [x] Deactivate the `conda` environment
* [ ] Test `conda` environment is active

**Related:**
* Original conda support - https://github.com/rtfd/readthedocs.org/pull/1849
* Absorbed style fix - https://github.com/rtfd/readthedocs.org/pull/1920
* Conda support - https://github.com/rtfd/readthedocs.org/issues/857

Attn: @ericholscher