### PR TITLE
STY: Fix PEP8 - E712 linting error (fixes tests)

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -450,7 +450,7 @@ class DockerEnvironment(BuildEnvironment):
             # locking code, so we throw an exception.
             state = self.container_state()
             if state is not None:
-                if state.get('Running') == True:
+                if state.get('Running') is True:
                     exc = BuildEnvironmentError(
                         _('A build environment is currently '
                           'running for this version'))


### PR DESCRIPTION
Was causing some build failures on the linting step. This is one easy way to fix it. This assumes the comparison to `True` as opposed to using `__nonzero__` is important.