### PR TITLE
Do a small builder refactor.

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -108,8 +108,8 @@ def load_yaml_config(version):
                 'name': version.slug,
             },
         )[0]
-    except InvalidConfig as e:  # This is a subclass of ConfigError, so has to come first
-        raise ProjectImportError(e.message)
+    except InvalidConfig:  # This is a subclass of ConfigError, so has to come first
+        raise
     except ConfigError:
         config = BuildConfig(
             env_config={},

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -36,6 +36,7 @@ log = logging.getLogger(__name__)
 
 
 class BuildCommand(BuildCommandResultMixin):
+
     '''Wrap command execution for execution in build environments
 
     This wraps subprocess commands with some logic to handle exceptions,
@@ -177,6 +178,7 @@ class BuildCommand(BuildCommandResultMixin):
 
 
 class DockerBuildCommand(BuildCommand):
+
     '''Create a docker container and run a command inside the container
 
     Build command to execute in docker container
@@ -248,6 +250,7 @@ class DockerBuildCommand(BuildCommand):
 
 
 class BuildEnvironment(object):
+
     '''
     Base build environment
 
@@ -259,11 +262,13 @@ class BuildEnvironment(object):
     :param record: Record status of build object
     '''
 
-    def __init__(self, project=None, version=None, build=None, record=True):
+    def __init__(self, project=None, version=None, build=None, record=True, environment=None):
         self.project = project
         self.version = version
         self.build = build
         self.record = record
+        self.environment = environment or {}
+
         self.commands = []
         self.failure = None
         self.start_time = datetime.utcnow()
@@ -408,11 +413,13 @@ class BuildEnvironment(object):
 
 
 class LocalEnvironment(BuildEnvironment):
+
     '''Local execution environment'''
     command_class = BuildCommand
 
 
 class DockerEnvironment(BuildEnvironment):
+
     '''
     Docker build environment, uses docker to contain builds
 
@@ -597,8 +604,7 @@ class DockerEnvironment(BuildEnvironment):
                     },
                 }),
                 detach=True,
-                environment={'READTHEDOCS_VERSION': self.version.slug,
-                             'READTHEDOCS_PROJECT': self.project.slug},
+                environment=self.environment,
                 mem_limit=self.container_mem_limit,
             )
             client.start(container=self.container_id)

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -236,11 +236,9 @@ class DockerBuildCommand(BuildCommand):
         """
         bash_escape_re = re.compile(r"([\t\ \!\"\#\$\&\'\(\)\*\:\;\<\>\?\@"
                                     r"\[\\\]\^\`\{\|\}\~])")
-        prefix = 'READTHEDOCS=True '
+        prefix = ''
         if self.bin_path:
             prefix += 'PATH={0}:$PATH '.format(self.bin_path)
-        if 'CONDA_ENVS_PATH' in self.environment:
-            prefix += 'CONDA_ENVS_PATH={0} '.format(self.environment['CONDA_ENVS_PATH'])
         return ("/bin/sh -c 'cd {cwd} && {prefix}{cmd}'"
                 .format(
                     cwd=self.cwd,
@@ -322,6 +320,12 @@ class BuildEnvironment(object):
         :param warn_only: Don't raise an exception on command failure
         '''
         warn_only = kwargs.pop('warn_only', False)
+        # Remove PATH from env, and set it to bin_path if it isn't passed in
+        env_path = self.environment.pop('PATH', None)
+        if 'bin_path' not in kwargs and env_path:
+            kwargs['bin_path'] = env_path
+        assert 'environment' not in kwargs, "environment can't be passed in via commands."
+        kwargs['environment'] = self.environment
         kwargs['build_env'] = self
         build_cmd = cls(cmd, **kwargs)
         self.commands.append(build_cmd)

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -94,6 +94,7 @@ class Virtualenv(PythonEnvironment):
             '-mvirtualenv',
             site_packages,
             env_path,
+            bin_path=None,  # Don't use virtualenv bin that doesn't exist yet
         )
 
     def install_core_requirements(self):
@@ -180,6 +181,7 @@ class Conda(PythonEnvironment):
             '--name',
             self.version.slug,
             'python={python_version}'.format(python_version=self.config.python_version),
+            bin_path=None,  # Don't use conda bin that doesn't exist yet
         )
 
     def install_core_requirements(self):

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -4,6 +4,7 @@ import shutil
 
 from django.conf import settings
 
+from readthedocs.builds.constants import LATEST
 from readthedocs.doc_builder.config import ConfigWrapper
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.projects.constants import LOG_TEMPLATE
@@ -34,7 +35,7 @@ class PythonEnvironment(object):
 
         # Handle deleting old build dir
         build_dir = os.path.join(
-            self.venv_path(),
+            self.venv_path(version=self.version.slug),
             'build')
         if os.path.exists(build_dir):
             self._log('Removing existing build directory')
@@ -46,14 +47,14 @@ class PythonEnvironment(object):
             if getattr(settings, 'USE_PIP_INSTALL', False):
                 self.build_env.run(
                     'python',
-                    self.venv_bin(filename='pip'),
+                    self.venv_bin(version=self.version.slug, filename='pip'),
                     'install',
                     '--ignore-installed',
                     '--cache-dir',
                     self.project.pip_cache_path,
                     '.',
                     cwd=self.checkout_path,
-                    bin_path=self.venv_bin()
+                    bin_path=self.venv_bin(version=self.version.slug)
                 )
             else:
                 self.build_env.run(
@@ -62,16 +63,17 @@ class PythonEnvironment(object):
                     'install',
                     '--force',
                     cwd=self.checkout_path,
-                    bin_path=self.venv_bin()
+                    bin_path=self.venv_bin(version=self.version.slug)
                 )
 
-    def venv_bin(self, filename=None):
+    def venv_bin(self, version=LATEST, filename=None):
         """Return path to the virtualenv bin path, or a specific binary
 
+        :param version: Version slug to use in path name
         :param filename: If specified, add this filename to the path return
         :returns: Path to virtualenv bin or filename in virtualenv bin
         """
-        parts = [self.venv_path(), 'bin']
+        parts = [self.venv_path(version), 'bin']
         if filename is not None:
             parts.append(filename)
         return os.path.join(*parts)
@@ -79,14 +81,14 @@ class PythonEnvironment(object):
 
 class Virtualenv(PythonEnvironment):
 
-    def venv_path(self):
-        return os.path.join(self.project.doc_path, 'envs', self.version.slug)
+    def venv_path(self, version=LATEST):
+        return os.path.join(self.project.doc_path, 'envs', version)
 
     def setup_base(self):
         site_packages = '--no-site-packages'
         if self.config.use_system_site_packages:
             site_packages = '--system-site-packages'
-        env_path = self.venv_path()
+        env_path = self.venv_path(version=self.version.slug)
         self.build_env.run(
             self.config.python_interpreter,
             '-mvirtualenv',
@@ -112,7 +114,7 @@ class Virtualenv(PythonEnvironment):
 
         cmd = [
             'python',
-            self.venv_bin(filename='pip'),
+            self.venv_bin(version=self.version.slug, filename='pip'),
             'install',
             '--use-wheel',
             '-U',
@@ -128,7 +130,7 @@ class Virtualenv(PythonEnvironment):
         cmd.extend(requirements)
         self.build_env.run(
             *cmd,
-            bin_path=self.venv_bin()
+            bin_path=self.venv_bin(version=self.version.slug)
         )
 
     def install_user_requirements(self):
@@ -147,21 +149,21 @@ class Virtualenv(PythonEnvironment):
         if requirements_file_path:
             self.build_env.run(
                 'python',
-                self.venv_bin(filename='pip'),
+                self.venv_bin(version=self.version.slug, filename='pip'),
                 'install',
                 '--exists-action=w',
                 '--cache-dir',
                 self.project.pip_cache_path,
                 '-r{0}'.format(requirements_file_path),
                 cwd=self.checkout_path,
-                bin_path=self.venv_bin()
+                bin_path=self.venv_bin(version=self.version.slug)
             )
 
 
 class Conda(PythonEnvironment):
 
-    def venv_path(self):
-        return os.path.join(self.project.doc_path, 'conda', self.version.slug)
+    def venv_path(self, version=LATEST):
+        return os.path.join(self.project.doc_path, 'conda', version)
 
     def setup_base(self):
         conda_env_path = os.path.join(self.project.doc_path, 'conda')
@@ -216,7 +218,7 @@ class Conda(PythonEnvironment):
 
         pip_cmd = [
             'python',
-            self.venv_bin(filename='pip'),
+            self.venv_bin(version=self.version.slug, filename='pip'),
             'install',
             '-U',
             '--cache-dir',
@@ -225,7 +227,7 @@ class Conda(PythonEnvironment):
         pip_cmd.extend(pip_requirements)
         self.build_env.run(
             *pip_cmd,
-            bin_path=self.venv_bin()
+            bin_path=self.venv_bin(version=self.version.slug)
         )
 
     def install_user_requirements(self):

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -178,7 +178,6 @@ class Conda(PythonEnvironment):
             '--name',
             self.version.slug,
             'python={python_version}'.format(python_version=self.config.python_version),
-            environment={'CONDA_ENVS_PATH': conda_env_path}
         )
 
     def install_core_requirements(self):
@@ -204,8 +203,7 @@ class Conda(PythonEnvironment):
         ]
         cmd.extend(requirements)
         self.build_env.run(
-            *cmd,
-            environment={'CONDA_ENVS_PATH': conda_env_path}
+            *cmd
         )
 
         # Install pip-only things.
@@ -240,5 +238,4 @@ class Conda(PythonEnvironment):
             self.version.slug,
             '--file',
             self.config.conda_file,
-            environment={'CONDA_ENVS_PATH': conda_env_path}
         )

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -202,7 +202,7 @@ class UpdateDocsTask(Task):
         return dict((key, val) for (key, val) in build.items()
                     if key not in ['project', 'version', 'resource_uri',
                                    'absolute_uri'])
-        
+
     def setup_vcs(self):
         """
         Update the checkout of the repo to make sure it's the latest.
@@ -237,6 +237,7 @@ class UpdateDocsTask(Task):
             env.update({
                 'CONDA_ENVS_PATH': os.path.join(self.project.doc_path, 'conda'),
                 'CONDA_DEFAULT_ENV': self.version.slug,
+                'PATH': os.path.join(self.project.doc_path, 'conda', self.version.slug, 'bin')
             })
         return env
  

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -107,7 +107,6 @@ class UpdateDocsTask(Task):
         self.build_localmedia = localmedia
         self.build_force = force
 
-
         env_cls = LocalEnvironment
         self.setup_env = env_cls(project=self.project, version=self.version,
                                  build=self.build, record=record)
@@ -240,7 +239,6 @@ class UpdateDocsTask(Task):
                 'PATH': os.path.join(self.project.doc_path, 'conda', self.version.slug, 'bin')
             })
         return env
- 
 
     def update_documentation_type(self):
         """

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -238,6 +238,11 @@ class UpdateDocsTask(Task):
                 'CONDA_DEFAULT_ENV': self.version.slug,
                 'PATH': os.path.join(self.project.doc_path, 'conda', self.version.slug, 'bin')
             })
+        else:
+            env.update({
+                'PATH': os.path.join(self.project.doc_path, 'envs', self.version.slug, 'bin')
+            })
+
         return env
 
     def update_documentation_type(self):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -127,11 +127,11 @@ class UpdateDocsTask(Task):
 
             self.config = load_yaml_config(version=self.version)
 
-        bash_env = self.get_bash_env()
+        env_vars = self.get_env_vars()
         if docker or settings.DOCKER_ENABLE:
             env_cls = DockerEnvironment
         self.build_env = env_cls(project=self.project, version=self.version,
-                                 build=self.build, record=record, environment=bash_env)
+                                 build=self.build, record=record, environment=env_vars)
 
         # Environment used for building code, usually with Docker
         with self.build_env:
@@ -222,7 +222,7 @@ class UpdateDocsTask(Task):
             raise BuildEnvironmentError('Failed to import project',
                                         status_code=404)
 
-    def get_bash_env(self):
+    def get_env_vars(self):
         """
         Get bash environment variables used for all builder commands.
         """

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -169,7 +169,7 @@ class TestDockerEnvironment(TestCase):
 
         self.mocks.docker_client.exec_create.assert_called_with(
             container='version-foobar-of-pip-20',
-            cmd="/bin/sh -c 'cd /tmp && READTHEDOCS=True echo\\ test'",
+            cmd="/bin/sh -c 'cd /tmp && echo\\ test'",
             stderr=True,
             stdout=True
         )
@@ -344,7 +344,7 @@ class TestDockerBuildCommand(TestCase):
             cmd.get_wrapped_command(),
             ("/bin/sh -c "
              "'cd /tmp/foobar && "
-             "READTHEDOCS=True pip install requests'"))
+             "pip install requests'"))
         cmd = DockerBuildCommand(['python', '/tmp/foo/pip', 'install',
                                   'Django>1.7'],
                                  cwd='/tmp/foobar',
@@ -352,7 +352,7 @@ class TestDockerBuildCommand(TestCase):
         self.assertEqual(
             cmd.get_wrapped_command(),
             ("/bin/sh -c "
-             "'cd /tmp/foobar && READTHEDOCS=True PATH=/tmp/foo:$PATH "
+             "'cd /tmp/foobar && PATH=/tmp/foo:$PATH "
              "python /tmp/foo/pip install Django\>1.7'"))
 
     def test_unicode_output(self):


### PR DESCRIPTION
This adds:

* A Local environment for checkout & config reading (Host)
* A Build environment for pip/conda & doc building (Docker)
* Refactors how we pass Bash environments around 
* Cleans up the python environment to use internal state