### PR TITLE
Add project level settings for containers and queues

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -87,11 +87,11 @@ def trigger_build(project, version=None, record=True, force=False, basic=False):
         )
         kwargs['build_pk'] = build.pk
 
-    queue = None
+    options = {}
     if project.build_queue is not None:
-        queue = 'build-{0}'.format(project.build_queue)
+        options['queue'] = 'build-{0}'.format(project.build_queue)
 
-    update_docs.apply_async(kwargs=kwargs, queue=queue)
+    update_docs.apply_async(kwargs=kwargs, **options)
 
     return build
 

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -54,8 +54,10 @@ def cname_to_slug(host):
 
 
 def trigger_build(project, version=None, record=True, force=False, basic=False):
-    """
-    An API to wrap the triggering of a build.
+    """Trigger build for project and version
+
+    If project has a ``build_queue``, execute task on this build queue. Queue
+    will be prefixed with ``build-`` to unify build queue names.
     """
     # Avoid circular import
     from readthedocs.projects.tasks import update_docs
@@ -85,10 +87,11 @@ def trigger_build(project, version=None, record=True, force=False, basic=False):
         )
         kwargs['build_pk'] = build.pk
 
-    update_docs.apply_async(
-        kwargs=kwargs,
-        queue=project.build_queue or None,
-    )
+    queue = None
+    if project.build_queue is not None:
+        queue = 'build-{0}'.format(project.build_queue)
+
+    update_docs.apply_async(kwargs=kwargs, queue=queue)
 
     return build
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -439,6 +439,10 @@ class DockerEnvironment(BuildEnvironment):
         self.container_name = None
         if self.version:
             self.container_name = slugify(unicode(self.version))
+        if self.project.container_mem_limit is not None:
+            self.container_mem_limit = self.project.container_mem_limit
+        if self.project.container_time_limit is not None:
+            self.container_time_limit = self.project.container_time_limit
 
     def __enter__(self):
         '''Start of environment context'''

--- a/readthedocs/projects/migrations/0013_add-container-limits.py
+++ b/readthedocs/projects/migrations/0013_add-container-limits.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0012_proper-name-for-install-project'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='build_queue',
+            field=models.CharField(max_length=32, null=True, verbose_name='Alternate build queue id', blank=True),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='container_mem_limit',
+            field=models.CharField(max_length=10, null=True, verbose_name='Container memory limit in MB', blank=True),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='container_time_limit',
+            field=models.CharField(max_length=10, null=True, verbose_name='Container time limit', blank=True),
+        ),
+    ]

--- a/readthedocs/projects/migrations/0013_add-container-limits.py
+++ b/readthedocs/projects/migrations/0013_add-container-limits.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='project',
             name='container_mem_limit',
-            field=models.CharField(max_length=10, null=True, verbose_name='Container memory limit in MB', blank=True),
+            field=models.CharField(help_text='Memory limit in Docker format -- example: <code>512m</code> or <code>1g</code>', max_length=10, null=True, verbose_name='Container memory limit', blank=True),
         ),
         migrations.AddField(
             model_name='project',

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -147,6 +147,12 @@ class Project(models.Model):
                     "This may slow down your page loads."))
     container_image = models.CharField(
         _('Alternative container image'), max_length=64, null=True, blank=True)
+    container_mem_limit = models.CharField(
+        _('Container memory limit in MB'), max_length=10, null=True, blank=True)
+    container_time_limit = models.CharField(
+        _('Container time limit'), max_length=10, null=True, blank=True)
+    build_queue = models.CharField(
+        _('Alternate build queue id'), max_length=32, null=True, blank=True)
 
     # Sphinx specific build options.
     enable_epub_build = models.BooleanField(

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -148,7 +148,9 @@ class Project(models.Model):
     container_image = models.CharField(
         _('Alternative container image'), max_length=64, null=True, blank=True)
     container_mem_limit = models.CharField(
-        _('Container memory limit in MB'), max_length=10, null=True, blank=True)
+        _('Container memory limit'), max_length=10, null=True, blank=True,
+        help_text=_("Memory limit in Docker format "
+                    "-- example: <code>512m</code> or <code>1g</code>"))
     container_time_limit = models.CharField(
         _('Container time limit'), max_length=10, null=True, blank=True)
     build_queue = models.CharField(

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -20,7 +20,7 @@ class GitLabWebHookTest(TestCase):
         def mock(*args, **kwargs):
             log.info("Mocking for great profit and speed.")
         tasks.update_docs = mock
-        tasks.update_docs.delay = mock
+        tasks.update_docs.apply_async = mock
 
         self.client.login(username='eric', password='test')
         self.payload = {
@@ -111,7 +111,7 @@ class PostCommitTest(TestCase):
             pass
 
         tasks.UpdateDocsTask.run = mock
-        tasks.UpdateDocsTask.delay = mock
+        tasks.UpdateDocsTask.apply_async = mock
 
         self.client.login(username='eric', password='test')
         self.payload = {


### PR DESCRIPTION
This allows for setting different limits on projects in docker containers, as
well as project level build queues for future use.