### PR TITLE
Remove our injection of recommonmark into builds.

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -69,17 +69,6 @@ else:
         html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     using_rtd_theme = True
 
-# Force theme on setting
-if globals().get('RTD_NEW_THEME', False):
-    html_theme = 'sphinx_rtd_theme'
-    html_style = None
-    html_theme_options = {}
-    using_rtd_theme = True
-
-if globals().get('RTD_OLD_THEME', False):
-    html_style = 'rtd.css'
-    html_theme = 'default'
-
 if globals().get('websupport2_base_url', False):
     websupport2_base_url = '{{ api_host }}/websupport'
     if 'http' not in settings.MEDIA_URL:

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -20,28 +20,6 @@ from six import string_types
 
 from sphinx import version_info
 
-from recommonmark.parser import CommonMarkParser
-
-# Only Sphinx 1.3+
-if version_info[0] == 1 and version_info[1] > 2:
-
-    # Markdown Support
-    if 'source_suffix' in globals():
-        if isinstance(source_suffix, string_types) and source_suffix != '.md':
-            source_suffix = [source_suffix, '.md']
-        elif '.md' not in source_suffix:
-            source_suffix.append('.md')
-    else:
-        source_suffix = ['.rst', '.md']
-
-    if 'source_parsers' in globals():
-        if '.md' not in source_parsers:
-            source_parsers['.md'] = CommonMarkParser
-    else:
-        source_parsers = {
-            '.md': CommonMarkParser,
-        }
-
 if globals().get('source_suffix', False):
     if isinstance(source_suffix, string_types):
         SUFFIX = source_suffix

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -20,6 +20,9 @@ from six import string_types
 
 from sphinx import version_info
 
+# Get suffix for proper linking to GitHub
+# This is deprecated in Sphinx 1.3+,
+# as each page can have its own suffix
 if globals().get('source_suffix', False):
     if isinstance(source_suffix, string_types):
         SUFFIX = source_suffix
@@ -28,7 +31,7 @@ if globals().get('source_suffix', False):
 else:
     SUFFIX = '.rst'
 
-#Add RTD Template Path.
+# Add RTD Template Path.
 if 'templates_path' in globals():
     templates_path.insert(0, '{{ template_path }}')
 else:

--- a/readthedocs/templates/sphinx/conf.py.conf
+++ b/readthedocs/templates/sphinx/conf.py.conf
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 
-import sys, os
+from recommonmark.parser import CommonMarkParser
+
 extensions = []
 templates_path = ['{{ template_dir }}', 'templates', '_templates', '.templates']
-source_suffix = '{{ project.suffix }}'
+source_suffix = ['.rst', '.md']		
+source_parsers = {		
+            '.md': CommonMarkParser,		
+        }
 master_doc = 'index'
 project = u'{{ project.name }}'
-copyright = u'{{ project.copyright }}'
+copyright = u'2016'
 version = '{{ version.verbose_name }}'
 release = '{{ version.verbose_name }}'
 exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 htmlhelp_basename = '{{ project.slug }}'
+html_theme = 'sphinx_rtd_theme'
 file_insertion_enabled = False
 latex_documents = [
   ('index', '{{ project.slug }}.tex', u'{{ project.name }} Documentation',


### PR DESCRIPTION
This was done to make it easier to support random projects with MD files being built on RTD.
This isn't a good priority,
and should only be included in the conf.py file we generate for those projects,
not the build file for all projects.