### PR TITLE
Use iendswith for repo lookups on hooks

### DIFF
--- a/readthedocs/core/views.py
+++ b/readthedocs/core/views.py
@@ -171,8 +171,8 @@ def _build_branches(project, branch_list):
 def _build_url(url, branches):
     try:
         projects = (
-            Project.objects.filter(repo__endswith=url) |
-            Project.objects.filter(repo__endswith=url + '.git'))
+            Project.objects.filter(repo__iendswith=url) |
+            Project.objects.filter(repo__iendswith=url + '.git'))
         if not projects.count():
             raise NoProjectException()
         for project in projects:

--- a/readthedocs/oauth/models.py
+++ b/readthedocs/oauth/models.py
@@ -139,8 +139,8 @@ class RemoteRepository(models.Model):
                     .objects
                     .public(user)
                     .filter(Q(repo=self.clone_url) |
-                            Q(repo__endswith=fuzzy_url) |
-                            Q(repo__endswith=fuzzy_url + '.git')))
+                            Q(repo__iendswith=fuzzy_url) |
+                            Q(repo__iendswith=fuzzy_url + '.git')))
         return [{'id': project.slug,
                  'url': reverse('projects_detail',
                                 kwargs={'project_slug': project.slug})}

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -171,6 +171,19 @@ class PostCommitTest(TestCase):
             }
         }
 
+    def test_github_upper_case_repo(self):
+        """
+        Test the github post commit hook will build properly with upper case
+        repository.
+        This allows for capitization differences in post-commit hook URL's.
+        """
+        payload = self.payload.copy()
+        payload['repository']['url'] = payload['repository']['url'].toUpper()
+        r = self.client.post('/github/', {'payload': json.dumps(payload)})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [awesome]')
+        self.payload['ref'] = 'refs/heads/not_ok'
+
     def test_github_post_commit_hook_builds_branch_docs_if_it_should(self):
         """
         Test the github post commit hook to see if it will only build

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -178,10 +178,10 @@ class PostCommitTest(TestCase):
         This allows for capitization differences in post-commit hook URL's.
         """
         payload = self.payload.copy()
-        payload['repository']['url'] = payload['repository']['url'].toUpper()
+        payload['repository']['url'] = payload['repository']['url'].upper()
         r = self.client.post('/github/', {'payload': json.dumps(payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [awesome]')
+        self.assertEqual(r.content, '(URL Build) Build Started: HTTPS://GITHUB.COM/RTFD/READTHEDOCS.ORG [awesome]')
         self.payload['ref'] = 'refs/heads/not_ok'
 
     def test_github_post_commit_hook_builds_branch_docs_if_it_should(self):


### PR DESCRIPTION
This allows us to catch capitalization differences in what the post-commit hook is sending, and what the user entered as the repo URL.