### PR TITLE
Add missing createsuperuser in local VM instructions

### DIFF
--- a/docs/custom_installs/local_rtd_vm.rst
+++ b/docs/custom_installs/local_rtd_vm.rst
@@ -56,6 +56,7 @@ Possible Error and Resolution
 1. Run the following commands. ::
 
     $ ./manage.py migrate
+    $ ./manage.py createsuperuser
 
 2. This will prompt you to create a superuser account for Django. Enter appropriate details. For example: ::
 


### PR DESCRIPTION
This is correctly present in the developer installation instructions.