### PR TITLE
Fixed typo in fallbacks url

### DIFF
--- a/readthedocs/core/urls.py
+++ b/readthedocs/core/urls.py
@@ -49,7 +49,7 @@ docs_urls = patterns(
          r'(?P<version_slug>{version_slug})/'
          r'(?P<filename>{filename_slug})$'.format(**pattern_opts)),
         'readthedocs.core.views.server_helpful_404',
-        name='user_buils_fallback'),
+        name='user_builds_fallback'),
     url((r'^user_builds/(?P<project_slug>{project_slug})/translations/'
          r'(?P<lang_slug>{lang_slug})/(?P<version_slug>{version_slug})/'
          r'(?P<filename>{filename_slug})$'.format(**pattern_opts)),


### PR DESCRIPTION
Hi,
It's a small detail, but I came across a misspelled variable name (user_buils_fallback) in the urls.py file and I thought it would be worth fixing before it became a problem for someone else.