### PR TITLE
Bump setuptools to latest

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -99,7 +99,7 @@ class Virtualenv(PythonEnvironment):
         requirements = [
             'sphinx==1.3.4',
             'Pygments==2.0.2',
-            'setuptools==18.6.1',
+            'setuptools==20.1.1',
             'docutils==0.12',
             'mkdocs==0.15.0',
             'mock==1.0.1',


### PR DESCRIPTION
This refs #1843, where the setuptools version is not handling `setup.cfg`
options gracefully.

I don't believe this should cause any problems, but haven't tested this
thoroughly yet.