### PR TITLE
#2015 Fix ReadTheDocs footer not loading for mkdocs

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -98,7 +98,7 @@ class BaseMkdocs(BaseBuilder):
         # Will be available in the JavaScript as READTHEDOCS_DATA.
         readthedocs_data = {
             'project': self.version.project.slug,
-            'version': self.version.verbose_name,
+            'version': self.version.slug,
             'language': self.version.project.language,
             'page': None,
             'theme': "readthedocs",


### PR DESCRIPTION
* Fix for https://github.com/rtfd/readthedocs.org/issues/2015
* Changes `'version': self.version.verbose_name`, to `'version': self.version.slug,` in `readthedocs/doc_builder/backends/mkdocs.py`