### PR TITLE
Add python.pip_install option

### DIFF
--- a/docs/yaml-config.rst
+++ b/docs/yaml-config.rst
@@ -93,12 +93,25 @@ python.setup_py_install
 * Default: `False`
 * Type: Boolean
 
-When true, install your project into the Virtualenv when building documentation.
+When true, install your project into the Virtualenv with ``python setup.py install`` when building documentation.
 
 .. code-block:: yaml
 
 	python:
 	   setup_py_install: true
+
+python.pip_install
+``````````````````
+
+* Default: `False`
+* Type: Boolean
+
+When true, install your project into the Virtualenv with pip when building documentation.
+
+.. code-block:: yaml
+
+    python:
+       pip_install: true
 
 .. To implement..
 

--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -24,7 +24,16 @@ class ConfigWrapper(object):
         self._yaml_config = yaml_config
 
     @property
+    def pip_install(self):
+        if 'pip_install' in self._yaml_config.get('python', {}):
+            return self._yaml_config['python']['pip_install']
+        else:
+            return False
+
+    @property
     def install_project(self):
+        if self.pip_install:
+            return True
         if 'setup_py_install' in self._yaml_config.get('python', {}):
             return self._yaml_config['python']['setup_py_install']
         else:

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -43,7 +43,7 @@ class PythonEnvironment(object):
     def install_package(self):
         setup_path = os.path.join(self.checkout_path, 'setup.py')
         if os.path.isfile(setup_path) and self.config.install_project:
-            if getattr(settings, 'USE_PIP_INSTALL', False):
+            if self.config.pip_install or getattr(settings, 'USE_PIP_INSTALL', False):
                 self.build_env.run(
                     'python',
                     self.venv_bin(filename='pip'),


### PR DESCRIPTION
Allows users to specify that `pip install .` should be used instead of `setup.py install`.

closes #2011

Feel free to close if this should be moved to the new readthedocs-build.