### PR TITLE
Add a per-project advertising opt-out, and form page for preference

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,7 @@ var sources = {
         'js/tools.js': {},
         'js/import.js': {},
         'css/import.less': {},
+        'css/admin.less': {},
     },
     gold: {'js/gold.js': {}},
     donate: {'js/donate.js': {}}

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -511,3 +511,16 @@ class DomainForm(forms.ModelForm):
         ).exclude(domain=self.cleaned_data['domain']).exists():
             raise forms.ValidationError(_(u'Only 1 Domain can be canonical at a time.'))
         return canonical
+
+
+class ProjectAdvertisingForm(forms.ModelForm):
+
+    """Project promotion opt-out form"""
+
+    class Meta:
+        model = Project
+        fields = ['allow_promos']
+
+    def __init__(self, *args, **kwargs):
+        self.project = kwargs.pop('project', None)
+        super(ProjectAdvertisingForm, self).__init__(*args, **kwargs)

--- a/readthedocs/projects/migrations/0014_add_project_allow_promos.py
+++ b/readthedocs/projects/migrations/0014_add_project_allow_promos.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0013_add-container-limits'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='allow_promos',
+            field=models.BooleanField(default=True, help_text='Allow sponsor advertisements on my project documentation', verbose_name='Sponsor advertisements'),
+        ),
+    ]

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -155,6 +155,9 @@ class Project(models.Model):
         _('Container time limit'), max_length=10, null=True, blank=True)
     build_queue = models.CharField(
         _('Alternate build queue id'), max_length=32, null=True, blank=True)
+    allow_promos = models.BooleanField(
+        _('Sponsor advertisements'), default=True, help_text=_(
+            "Allow sponsor advertisements on my project documentation"))
 
     # Sphinx specific build options.
     enable_epub_build = models.BooleanField(

--- a/readthedocs/projects/static-src/projects/css/admin.less
+++ b/readthedocs/projects/static-src/projects/css/admin.less
@@ -1,0 +1,18 @@
+#content .module ul.project-ads-guidelines {
+    list-style: initial;
+    margin-left: 1.5em;
+    margin-bottom: 1em;
+}
+
+#content .module ul.project-ads-support {
+    margin-bottom: 1em;
+
+    li > form {
+      text-align: right;
+
+      input {
+          display: inline-block;
+          margin: 1em 0em 0em 0em;
+      }
+    }
+}

--- a/readthedocs/projects/static/projects/css/admin.css
+++ b/readthedocs/projects/static/projects/css/admin.css
@@ -1,0 +1,15 @@
+#content .module ul.project-ads-guidelines {
+  list-style: initial;
+  margin-left: 1.5em;
+  margin-bottom: 1em;
+}
+#content .module ul.project-ads-support {
+  margin-bottom: 1em;
+}
+#content .module ul.project-ads-support li > form {
+  text-align: right;
+}
+#content .module ul.project-ads-support li > form input {
+  display: inline-block;
+  margin: 1em 0em 0em 0em;
+}

--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -5,7 +5,8 @@ from django.conf.urls import patterns, url
 from readthedocs.projects.views.private import (
     ProjectDashboard, ImportView,
     ProjectUpdate, ProjectAdvancedUpdate,
-    DomainList, DomainCreate, DomainDelete, DomainUpdate)
+    DomainList, DomainCreate, DomainDelete, DomainUpdate,
+    ProjectAdvertisingUpdate)
 from readthedocs.projects.backends.views import ImportWizardView, ImportDemoView
 
 
@@ -104,6 +105,10 @@ urlpatterns = patterns(
     url(r'^(?P<project_slug>[-\w]+)/redirects/delete/$',
         'readthedocs.projects.views.private.project_redirects_delete',
         name='projects_redirects_delete'),
+
+    url(r'^(?P<project_slug>[-\w]+)/advertising/$',
+        ProjectAdvertisingUpdate.as_view(),
+        name='projects_advertising'),
 )
 
 domain_urls = patterns(

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -31,7 +31,7 @@ from readthedocs.projects.forms import (
     ProjectBasicsForm, ProjectExtraForm,
     ProjectAdvancedForm, UpdateProjectForm, SubprojectForm,
     build_versions_form, UserForm, EmailHookForm, TranslationForm,
-    RedirectForm, WebHookForm, DomainForm)
+    RedirectForm, WebHookForm, DomainForm, ProjectAdvertisingForm)
 from readthedocs.projects.models import Project, EmailHook, WebHook, Domain
 from readthedocs.projects.views.base import ProjectAdminMixin, ProjectSpamMixin
 from readthedocs.projects import constants, tasks
@@ -674,3 +674,19 @@ class DomainUpdate(DomainMixin, UpdateView):
 
 class DomainDelete(DomainMixin, DeleteView):
     pass
+
+
+class ProjectAdvertisingUpdate(PrivateViewMixin, UpdateView):
+
+    model = Project
+    form_class = ProjectAdvertisingForm
+    success_message = _('Project has been opted out from advertisement support')
+    template_name = 'projects/project_advertising.html'
+    lookup_url_kwarg = 'project_slug'
+    lookup_field = 'slug'
+
+    def get_queryset(self):
+        return self.model.objects.for_admin_user(self.request.user)
+
+    def get_success_url(self):
+        return reverse('projects_advertising', args=[self.object.slug])

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -106,14 +106,14 @@ def footer_html(request):
                      .first())
 
         # Support showing a "Thank you" message for gold folks
-        if gold_user and promo_obj is None:
+        if gold_user:
             gold_promo = SupporterPromo.objects.filter(live=True,
                                                        name='gold-user')
             if gold_promo.exists():
                 promo_obj = gold_promo.first()
 
         # Default to showing project-level thanks if it exists
-        if gold_project and promo_obj is None:
+        if gold_project:
             gold_promo = SupporterPromo.objects.filter(live=True,
                                                        name='gold-project')
             if gold_promo.exists():

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -83,39 +83,44 @@ def footer_html(request):
     else:
         print_url = None
 
-    show_promo = getattr(settings, 'USE_PROMOS', True)
+    use_promo = getattr(settings, 'USE_PROMOS', True)
+    show_promo = project.allow_promos
     gold_user = gold_project = False
+    promo_obj = None
+
     # User is a gold user, no promos for them!
     if request.user.is_authenticated():
         if request.user.gold.count() or request.user.goldonce.count():
-            show_promo = False
             gold_user = True
-    # Explicit promo disabling
-    if project.slug in getattr(settings, 'DISABLE_PROMO_PROJECTS', []):
-        show_promo = False
     # A GoldUser has mapped this project
-
     if project.gold_owners.count():
-        show_promo = False
         gold_project = True
 
-    promo_obj = SupporterPromo.objects.filter(live=True, display_type='doc').order_by('?').first()
-    if not promo_obj:
+    if gold_user or gold_project:
         show_promo = False
 
-    # Support showing a "Thank you" message for gold folks
-    if gold_user:
-        gold_promo = SupporterPromo.objects.filter(live=True, name='gold-user')
-        if gold_promo.count():
-            promo_obj = gold_promo.first()
-            show_promo = True
+    if use_promo and show_promo:
+        promo_obj = (SupporterPromo.objects
+                     .filter(live=True, display_type='doc')
+                     .order_by('?')
+                     .first())
 
-    # Default to showing project-level thanks if it exists
-    if gold_project:
-        gold_promo = SupporterPromo.objects.filter(live=True, name='gold-project')
-        if gold_promo.count():
-            promo_obj = gold_promo.first()
-            show_promo = True
+        # Support showing a "Thank you" message for gold folks
+        if gold_user and promo_obj is None:
+            gold_promo = SupporterPromo.objects.filter(live=True,
+                                                       name='gold-user')
+            if gold_promo.exists():
+                promo_obj = gold_promo.first()
+
+        # Default to showing project-level thanks if it exists
+        if gold_project and promo_obj is None:
+            gold_promo = SupporterPromo.objects.filter(live=True,
+                                                       name='gold-project')
+            if gold_promo.exists():
+                promo_obj = gold_promo.first()
+
+        if not promo_obj:
+            show_promo = False
 
     version_compare_data = get_version_compare_data(project, version)
 

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -1,0 +1,135 @@
+{% extends "projects/project_edit_base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Documentation Advertising" %}{% endblock %}
+
+{% block extra_links %}
+  <link rel="stylesheet" type="text/css" href="{% static "projects/css/admin.css" %}" />
+{% endblock %}
+
+{% block project-ads-active %}active{% endblock %}
+{% block project_edit_content_header %}{% trans "Documentation Advertising" %}{% endblock %}
+
+{% block project_edit_content %}
+  <p>
+    {% blocktrans %}
+      Read the Docs is an open source project, maintained and operated by
+      full-time volunteers. In order to maintain service, we rely on both the
+      support of our users, and from sponsor support.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans %}
+      We will periodically run advertisements on built documentation pages for
+      sponsors, however we have strict guidelines on advertisements:
+    {% endblocktrans %}
+  </p>
+
+  <ul class="project-ads-guidelines">
+    <li>
+      {% blocktrans %}
+        We don't give sponsors access to user information
+      {% endblocktrans %}
+    </li>
+    <li>
+      {% blocktrans %}
+        We only report the number of impressions and number of ad clicks
+      {% endblocktrans %}
+    </li>
+    <li>
+      {% blocktrans %}
+        We only allow and image and text, no Javascript besides our existing
+        tracking
+      {% endblocktrans %}
+    </li>
+  </ul>
+
+  <p>
+    {% blocktrans %}
+      For more information on our stance on sponsor advertisements, we wrote
+      more about our stance
+      <a href="https://blog.readthedocs.com/ads-on-read-the-docs/">on our blog</a>.
+    {% endblocktrans %}
+  </p>
+
+  <h4>{% trans "Opting out" %}</h4>
+
+  <p>
+    {% blocktrans %}
+      If you do not wish to support Read the Docs with use of this ad space,
+      we ask that you help support Read the Docs in one of following ways:
+    {% endblocktrans %}
+  </p>
+
+  <ul class="module-list project-ads-support">
+    <li class="module-item">
+      {% blocktrans %}
+        If you have an open source project, and can contribute financially,
+        consider a gold subscription. Gold subscribers can disable ads for
+        projects they author.
+      {% endblocktrans %}
+
+      <form method="get" action="{% url "gold_subscription" %}">
+        <input type="submit" value="{% trans "I can contribute financially" %}" />
+      </form>
+    </li>
+
+    <li class="module-item">
+      {% blocktrans %}
+        If your project is an open source project, you most certainly also
+        lack funding.  If you can't contribute financially to Read the Docs,
+        consider donating your time. We can always use help with support
+        requests, documentation updates, and of course feature development.
+      {% endblocktrans %}
+
+      <form method="get" action="http://docs.readthedocs.org/en/latest/contribute.html">
+        <input type="submit" value="{% trans "I can contribute my time" %}" />
+      </form>
+    </li>
+
+    <li class="module-item">
+      {% blocktrans %}
+        If you are part of a company that uses Read the Docs to host
+        documentation for a commercial product, we offer paid plans that
+        offer email support, additional build resources, and features like
+        CDN support and private documentation.
+      {% endblocktrans %}
+
+      <form method="get" action="https://readthedocs.com/pricing/">
+        <input type="submit" value="{% trans "Learn more about a paid plan" %}" />
+      </form>
+    </li>
+  </ul>
+
+  <h4>{% trans "Still can't help?" %}</h4>
+
+  <p>
+    {% blocktrans %}
+      If you can't contribute your support for your open source project, but
+      are conflicted by allowing support through advertising, we still would
+      like to give you the option to disable showing promotions inside your
+      documentation. We might be in contact in the future to see if you would
+      reconsider offering your support.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans %}
+      If you are a company hosting commercial documentation on our community
+      site, but can't offer support for Read the Docs, we do not allow
+      removing sponsor advertisements on your documentation. This goes
+      against the spirit of supporting the open source community, please find
+      a way to offer your support.
+    {% endblocktrans %}
+  </p>
+
+  <form method="post" action=".">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <p>
+      <input style="display: inline;" type="submit" value="{% trans "Update advertisement preference" %}">
+    </p>
+  </form>
+{% endblock %}

--- a/readthedocs/templates/projects/project_edit_base.html
+++ b/readthedocs/templates/projects/project_edit_base.html
@@ -23,6 +23,7 @@
         <li class="{% block project-translations-active %}{% endblock %}"><a href="{% url "projects_translations" project.slug %}">{% trans "Translations" %}</a></li>
         <li class="{% block project-subprojects-active %}{% endblock %}"><a href="{% url "projects_subprojects" project.slug %}">{% trans "Subprojects" %}</a></li>
         <li class="{% block project-notifications-active %}{% endblock %}"><a href="{% url "projects_notifications" project.slug %}">{% trans "Notifications" %}</a></li>
+        <li class="{% block project-ads-active %}{% endblock %}"><a href="{% url "projects_advertising" project.slug %}">{% trans "Advertising" %} </a></li>
         {% if project.allow_comments %}
             <li class="{% block project-comments-active %}{% endblock %}"><a href="{% url "projects_comments" project.slug %}">{% trans "Comments" %}</a></li>
         {% endif %}


### PR DESCRIPTION
This adds a per-project advertising opt-out form, with some guidance on supporting
Read the Docs if you oppose advertising. It links to several pages explaining more
about the advertising spot, how to opt-out of ads, and a backup option to just
remove ads altogether if you don't want to support the project.