### PR TITLE
Remove domain autocreation.

### DIFF
--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -79,21 +79,6 @@ class SubdomainMiddleware(object):
                     log.debug(LOG_TEMPLATE.format(
                         msg='CNAME detetected: %s' % request.slug,
                         **log_kwargs))
-                    try:
-                        proj = Project.objects.get(slug=slug)
-                        domain, created = Domain.objects.get_or_create(
-                            project=proj,
-                            domain=host,
-                        )
-                        if created:
-                            domain.machine = True
-                            domain.cname = True
-                        domain.count = domain.count + 1
-                        domain.save()
-                    except (ObjectDoesNotExist, MultipleObjectsReturned):
-                        log.debug(LOG_TEMPLATE.format(
-                            msg='Project CNAME does not exist: %s' % slug,
-                            **log_kwargs))
                 except:
                     # Some crazy person is CNAMEing to us. 404.
                     log.exception(LOG_TEMPLATE.format(msg='CNAME 404', **log_kwargs))

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -23,14 +23,13 @@ class MiddlewareTests(TestCase):
         cache.get = self.old_cache_get
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
-    def test_cname_creation(self):
+    def test_no_cname_creation(self):
         self.assertEqual(Domain.objects.count(), 0)
         self.project = get(Project, slug='my_slug')
         cache.get = lambda x: 'my_slug'
         request = self.factory.get(self.url, HTTP_HOST='my.valid.hostname')
         self.middleware.process_request(request)
-        self.assertEqual(Domain.objects.count(), 1)
-        self.assertEqual(Domain.objects.first().domain, 'my.valid.hostname')
+        self.assertEqual(Domain.objects.count(), 0)
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
     def test_no_readthedocs_domain(self):
@@ -40,22 +39,6 @@ class MiddlewareTests(TestCase):
         request = self.factory.get(self.url, HTTP_HOST='pip.readthedocs.org')
         self.middleware.process_request(request)
         self.assertEqual(Domain.objects.count(), 0)
-
-    @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
-    def test_cname_count(self):
-        self.assertEqual(Domain.objects.count(), 0)
-        self.project = get(Project, slug='my_slug')
-        cache.get = lambda x: 'my_slug'
-        request = self.factory.get(self.url, HTTP_HOST='my.valid.hostname')
-
-        self.middleware.process_request(request)
-        self.assertEqual(Domain.objects.count(), 1)
-        self.assertEqual(Domain.objects.first().domain, 'my.valid.hostname')
-        self.assertEqual(Domain.objects.first().count, 1)
-
-        self.middleware.process_request(request)
-        self.assertEqual(Domain.objects.count(), 1)
-        self.assertEqual(Domain.objects.first().count, 2)
 
 
 class ModelTests(TestCase):


### PR DESCRIPTION
We were previously automatically creating Domain objects when you pointed a domain at us.
This was a backwards compat feature to catch domains that were configured using the old DNS method.
We have had this long enough to catch any major user,
so we should remove this and only have them be explicitly created.