### PR TITLE
WIP: Add basic badge support.

### DIFF
--- a/readthedocs/templates/badges/badge.svg
+++ b/readthedocs/templates/badges/badge.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="{{ full_width }}" height="20">
+  <g shape-rendering="crispEdges">
+    <rect width="{{ project_length }}" height="20" fill="{{ fill }}"/>
+    <rect x="{{ project_length }}" width="{{ version_length }}" height="20" fill="{{ fill }}"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="{{ project_fill }}" y="14">{{ project }}</text>
+    <text x="{{ version_fill }}" y="14">{{ version }}</text>
+  </g>
+</svg>


### PR DESCRIPTION
This moves to hosting badges internally to Read the Docs.

This is a WIP, as the SVG code needs to be fixed. I don't know SVG super well, but we basically just need to fix the template so that it will properly render with variable width text (eg. varying project name length).
