### PR TITLE
Add proper privacy filtering to subproject queries

### DIFF
--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -118,8 +118,8 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
                 # doesn't pass along to ProjectRelationships
                 project_slugs.extend(s.slug for s
                                      in Project.objects.public(
-                                        request.user).filter(
-                                        superprojects__parent__slug=project.slug))
+                                         request.user).filter(
+                                         superprojects__parent__slug=project.slug))
                 final_filter['and'].append({"terms": {"project": project_slugs}})
 
                 # Add routing to optimize search by hitting the right shard.

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -114,8 +114,13 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
                            .api(request.user)
                            .get(slug=project_slug))
                 project_slugs = [project.slug]
-                project_slugs.extend(s.child.slug for s
-                                     in project.subprojects.public(request.user))
+                # We need to use the obtuse syntax here because the manager
+                # doesn't pass along to ProjectRelationships
+                project_slugs.extend(s.slug for s
+                                     in Project.objects.public(
+                                        request.user).filter(
+                                        superprojects__parent__slug=project.slug))
+                import ipdb; ipdb.set_trace()
                 final_filter['and'].append({"terms": {"project": project_slugs}})
 
                 # Add routing to optimize search by hitting the right shard.

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -120,7 +120,6 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
                                      in Project.objects.public(
                                         request.user).filter(
                                         superprojects__parent__slug=project.slug))
-                import ipdb; ipdb.set_trace()
                 final_filter['and'].append({"terms": {"project": project_slugs}})
 
                 # Add routing to optimize search by hitting the right shard.

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -115,7 +115,7 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
                            .get(slug=project_slug))
                 project_slugs = [project.slug]
                 project_slugs.extend(s.child.slug for s
-                                     in project.subprojects.all())
+                                     in project.subprojects.public(request.user))
                 final_filter['and'].append({"terms": {"project": project_slugs}})
 
                 # Add routing to optimize search by hitting the right shard.


### PR DESCRIPTION
This uses an annoying pattern because the project relationship manager doesn't know about privacy levels. We should look into cascading the managers onto querysets as with https://docs.djangoproject.com/en/1.9/topics/db/managers/#create-manager-with-queryset-methods