### PR TITLE
Add a signal in the footer that gets info about footer response.

### DIFF
--- a/readthedocs/donate/__init__.py
+++ b/readthedocs/donate/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'readthedocs.donate.apps.DonateAppConfig'

--- a/readthedocs/donate/apps.py
+++ b/readthedocs/donate/apps.py
@@ -1,0 +1,18 @@
+"""Gold application config for establishing signals"""
+
+import logging
+
+from django.apps import AppConfig
+
+log = logging.getLogger(__name__)
+
+
+class DonateAppConfig(AppConfig):
+    name = 'readthedocs.donate'
+    verbose_name = 'Donate'
+
+    def ready(self):
+        if hasattr(self, 'already_run'):
+            return
+        self.already_run = True
+        import readthedocs.donate.signals  # noqa

--- a/readthedocs/donate/apps.py
+++ b/readthedocs/donate/apps.py
@@ -1,4 +1,4 @@
-"""Gold application config for establishing signals"""
+"""Donate app config for establishing signals"""
 
 import logging
 

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -1,0 +1,70 @@
+from django.dispatch import receiver
+from django.conf import settings
+from django.core.cache import cache
+
+from readthedocs.restapi.signals import footer_response
+from readthedocs.donate.models import SupporterPromo, VIEWS, CLICKS
+
+
+@receiver(footer_response)
+def attach_promo_data(sender, **kwargs):
+    request = kwargs['request']
+    context = kwargs['context']
+    resp_data = kwargs['resp_data']
+
+    project = context['project']
+
+    use_promo = getattr(settings, 'USE_PROMOS', True)
+    show_promo = project.allow_promos
+
+    gold_user = gold_project = False
+    promo_obj = None
+
+    # User is a gold user, no promos for them!
+    if request.user.is_authenticated():
+        if request.user.gold.count() or request.user.goldonce.count():
+            gold_user = True
+
+    # A GoldUser has mapped this project
+    if project.gold_owners.count():
+        gold_project = True
+
+    # Try to get a promo if we should be using one.
+    if use_promo and show_promo:
+        promo_obj = (SupporterPromo.objects
+                     .filter(live=True, display_type='doc')
+                     .order_by('?')
+                     .first())
+
+        # Support showing a "Thank you" message for gold folks
+        if gold_user:
+            gold_promo = SupporterPromo.objects.filter(live=True,
+                                                       name='gold-user')
+            if gold_promo.exists():
+                promo_obj = gold_promo.first()
+
+        # Default to showing project-level thanks if it exists
+        if gold_project:
+            gold_promo = SupporterPromo.objects.filter(live=True,
+                                                       name='gold-project')
+            if gold_promo.exists():
+                promo_obj = gold_promo.first()
+
+    # All the cases we don't show promos for
+    if gold_user or gold_project or not promo_obj or not use_promo:
+        show_promo = False
+
+    if show_promo and promo_obj:
+        promo_dict = promo_obj.as_dict()
+        resp_data['promo_data'] = promo_dict
+        promo_obj.incr('offers')
+        # Set validation cache
+        for type in [VIEWS, CLICKS]:
+            cache.set(
+                promo_obj.cache_key(type=type, hash=promo_dict['hash']),
+                0,  # Number of times used. Make this an int so we can detect multiple uses
+                60 * 60  # hour
+            )
+
+    # Set promo object on return JSON
+    resp_data['promo'] = show_promo

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -34,7 +34,8 @@ def attach_promo_data(sender, **kwargs):
     if project.gold_owners.count():
         gold_project = True
 
-    # Don't show gold users promos. This will get overridden if we have specific promos for them below.
+    # Don't show gold users promos.
+    # This will get overridden if we have specific promos for them below.
     if gold_user or gold_project:
         show_promo = False
 

--- a/readthedocs/donate/tests.py
+++ b/readthedocs/donate/tests.py
@@ -67,7 +67,7 @@ class FooterTests(TestCase):
                          display_type='doc',
                          link='http://example.com',
                          image='http://media.example.com/img.png')
-        self.pip = get(Project, slug='pip')
+        self.pip = get(Project, slug='pip', allow_promos=True)
 
     def test_footer(self):
         r = self.client.get(
@@ -131,6 +131,16 @@ class FooterTests(TestCase):
     def test_footer_no_obj(self):
         """Test that the promo doesn't get set with no SupporterPromo objects"""
         self.promo.delete()
+        r = self.client.get(
+            '/api/v2/footer_html/?project=pip&version=latest&page=index'
+        )
+        resp = json.loads(r.content)
+        self.assertEqual(resp['promo'], False)
+
+    def test_project_disabling(self):
+        """Test that the promo doesn't show when the project has it disabled"""
+        self.pip.allow_promos = False
+        self.pip.save()
         r = self.client.get(
             '/api/v2/footer_html/?project=pip&version=latest&page=index'
         )

--- a/readthedocs/donate/tests.py
+++ b/readthedocs/donate/tests.py
@@ -118,3 +118,21 @@ class FooterTests(TestCase):
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 1)
         self.assertEqual(impression.clicks, 1)
+
+    def test_footer_setting(self):
+        """Test that the promo doesn't show with USE_PROMOS is False"""
+        with self.settings(USE_PROMOS=False):
+            r = self.client.get(
+                '/api/v2/footer_html/?project=pip&version=latest&page=index'
+            )
+            resp = json.loads(r.content)
+            self.assertEqual(resp['promo'], False)
+
+    def test_footer_no_obj(self):
+        """Test that the promo doesn't get set with no SupporterPromo objects"""
+        self.promo.delete()
+        r = self.client.get(
+            '/api/v2/footer_html/?project=pip&version=latest&page=index'
+        )
+        resp = json.loads(r.content)
+        self.assertEqual(resp['promo'], False)

--- a/readthedocs/gold/apps.py
+++ b/readthedocs/gold/apps.py
@@ -1,4 +1,4 @@
-"""Gold application config for establishing signals"""
+"""Donate application config for establishing signals"""
 
 import logging
 

--- a/readthedocs/gold/apps.py
+++ b/readthedocs/gold/apps.py
@@ -1,4 +1,4 @@
-"""Donate application config for establishing signals"""
+"""Gold application config for establishing signals"""
 
 import logging
 

--- a/readthedocs/restapi/signals.py
+++ b/readthedocs/restapi/signals.py
@@ -1,0 +1,3 @@
+import django.dispatch
+
+footer_response = django.dispatch.Signal(providing_args=["context", "response_data"])

--- a/readthedocs/restapi/signals.py
+++ b/readthedocs/restapi/signals.py
@@ -1,3 +1,5 @@
 import django.dispatch
 
-footer_response = django.dispatch.Signal(providing_args=["context", "response_data"])
+footer_response = django.dispatch.Signal(
+    providing_args=["request", "context", "response_data"]
+)

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -13,6 +13,7 @@ from readthedocs.donate.models import SupporterPromo
 from readthedocs.projects.models import Project
 from readthedocs.projects.version_handling import highest_version
 from readthedocs.projects.version_handling import parse_version_failsafe
+from readthedocs.restapi.signals import footer_response
 
 
 def get_version_compare_data(project, base_version=None):
@@ -155,4 +156,8 @@ def footer_html(request):
     }
     if show_promo and promo_obj:
         resp_data['promo_data'] = promo_obj.as_dict()
+
+    # Allow folks to hook onto the footer response for various information usage.
+    footer_response.send(sender=None, context=context, resp_data=resp_data)
+
     return Response(resp_data)


### PR DESCRIPTION
With the new signal, we can move the messy logic around Promo insertion into a signal handler. This keeps the footer views nicely container, and allows us to hook into the footer in other places if we want.

Also added a few tests to make sure the logic is correct. 