### PR TITLE
Build out proper querysets for managers.

### DIFF
--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -18,6 +18,8 @@ class ProjectManager(models.Manager):
     Projects take into account their own privacy_level setting.
     """
 
+    use_for_related_fields = True
+
     def _add_user_repos(self, queryset, user):
         if user.has_perm('projects.view_project'):
             return self.get_queryset().all().distinct()
@@ -69,6 +71,8 @@ class VersionManager(models.Manager):
     """
     Versions take into account their own privacy_level setting.
     """
+
+    use_for_related_fields = True
 
     def _add_user_repos(self, queryset, user):
         if user.has_perm('builds.view_version'):
@@ -132,6 +136,8 @@ class BuildManager(models.Manager):
     Build objects take into account the privacy of the Version they relate to.
     """
 
+    use_for_related_fields = True
+
     def _add_user_repos(self, queryset, user=None):
         if user.has_perm('builds.view_version'):
             return self.get_queryset().all().distinct()
@@ -161,6 +167,8 @@ class RelatedProjectManager(models.Manager):
     This shouldn't be used as a subclass.
     """
 
+    use_for_related_fields = True
+
     def _add_user_repos(self, queryset, user=None):
         # Hack around get_objects_for_user not supporting global perms
         if user.has_perm('projects.view_project'):
@@ -187,6 +195,8 @@ class RelatedProjectManager(models.Manager):
 class RelatedBuildManager(models.Manager):
 
     '''For models with association to a project through :py:cls:`Build`'''
+
+    use_for_related_fields = True
 
     def _add_user_repos(self, queryset, user=None):
         if user.has_perm('builds.view_version'):

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -102,6 +102,16 @@ class VersionManager(models.Manager):
             queryset = queryset.filter(active=True)
         return queryset
 
+    def private(self, user=None, project=None, only_active=True):
+        queryset = self.filter(privacy_level__in=[constants.PRIVATE])
+        if user:
+            queryset = self._add_user_repos(queryset, user)
+        if project:
+            queryset = queryset.filter(project=project)
+        if only_active:
+            queryset = queryset.filter(active=True)
+        return queryset
+
     def api(self, user=None):
         return self.public(user, only_active=False)
 

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -347,3 +347,13 @@ class PrivacyTests(TestCase):
         self.client.login(username='tester', password='test')
         r = self.client.get('/projects/django-kong/builds/')
         self.assertTrue('test-slug' not in r.content)
+
+    def test_queryset_chaining(self):
+        """
+        Test that manager methods get set on related querysets.
+        """
+        kong = self._create_kong('public', 'private')
+        self.assertEqual(
+            kong.versions.private().get(slug='latest').slug,
+            'latest'
+        )


### PR DESCRIPTION
This allows them to be chained,
vastly simplifying out query structure in many places