### PR TITLE
Break Impression modeling up into seperate models

### DIFF
--- a/readthedocs/donate/admin.py
+++ b/readthedocs/donate/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Supporter, SupporterPromo, SupporterImpressions
+from .models import Supporter, SupporterPromo, PromoImpressions
 
 
 class SupporterAdmin(admin.ModelAdmin):
@@ -10,7 +10,7 @@ class SupporterAdmin(admin.ModelAdmin):
 
 
 class ImpressionInline(admin.TabularInline):
-    model = SupporterImpressions
+    model = PromoImpressions
     readonly_fields = ('date', 'offers', 'views', 'clicks', 'view_ratio', 'click_ratio')
     extra = 0
     can_delete = False

--- a/readthedocs/donate/migrations/0004_rebase-impressions-on-base.py
+++ b/readthedocs/donate/migrations/0004_rebase-impressions-on-base.py
@@ -7,8 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('projects', '0016_rebase-impressions-on-base'),
-        ('donate', '0003_add-impressions'),
+        ('donate', '0003_add-impressions')
     ]
 
     operations = [

--- a/readthedocs/donate/migrations/0004_rebase-impressions-on-base.py
+++ b/readthedocs/donate/migrations/0004_rebase-impressions-on-base.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0016_rebase-impressions-on-base'),
+        ('donate', '0003_add-impressions'),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            'SupporterImpressions',
+            'PromoImpressions',
+        ),
+        migrations.CreateModel(
+            name='ProjectImpressions',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('date', models.DateField(verbose_name='Date')),
+                ('offers', models.IntegerField(default=0, verbose_name='Offer')),
+                ('views', models.IntegerField(default=0, verbose_name='View')),
+                ('clicks', models.IntegerField(default=0, verbose_name='Clicks')),
+                ('project', models.ForeignKey(related_name='impressions', blank=True, to='projects.Project', null=True)),
+                ('promo', models.ForeignKey(related_name='project_impressions', blank=True, to='donate.SupporterPromo', null=True)),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='projectimpressions',
+            unique_together=set([('project', 'promo', 'date')]),
+        ),
+    ]

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -92,7 +92,7 @@ class SupporterPromo(models.Model):
 
     def cache_key(self, type, hash):
         assert type in IMPRESSION_TYPES + ('project',)
-        return 'promo:{id}:{type}:{hash}'.format(id=self.analytics_id, hash=hash, type=type)
+        return 'promo:{id}:{hash}:{type}'.format(id=self.analytics_id, hash=hash, type=type)
 
     def incr(self, type):
         """Add to the number of times this action has been performed, stored in the DB"""

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -142,12 +142,12 @@ class BaseImpression(models.Model):
         return float(self.clicks) / float(self.views)
 
 
-class SupporterImpressions(BaseImpression):
+class PromoImpressions(BaseImpression):
     """Track stats around how successful this promo has been.
 
     Indexed one per promo per day."""
 
-    promo = models.ForeignKey(SupporterPromo, related_name='promo_impressions',
+    promo = models.ForeignKey(SupporterPromo, related_name='impressions',
                               blank=True, null=True)
 
 

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -94,24 +94,20 @@ class SupporterPromo(models.Model):
         assert type in IMPRESSION_TYPES + ('project',)
         return 'promo:{id}:{hash}:{type}'.format(id=self.analytics_id, hash=hash, type=type)
 
-    def incr(self, type):
+    def incr(self, type, project=None):
         """Add to the number of times this action has been performed, stored in the DB"""
         assert type in IMPRESSION_TYPES
         day = get_ad_day()
-        impression, _ = self.impressions.get_or_create(date=day)
+        if project:
+            impression, _ = self.impressions.get_or_create(date=day, project=project)
+        else:
+            impression, _ = self.impressions.get_or_create(date=day)
+
         setattr(impression, type, models.F(type) + 1)
         impression.save()
 
         # TODO: Support redis, more info on this PR
         # github.com/rtfd/readthedocs.org/pull/2105/files/1b5f8568ae0a7760f7247149bcff481efc000f32#r58253051
-
-    def incr_project(self, type, project):
-        """Add to the number of times this action has been performed, stored in the DB"""
-        assert type in IMPRESSION_TYPES
-        day = get_ad_day()
-        impression, _ = self.project_impressions.get_or_create(date=day, project=project)
-        setattr(impression, type, models.F(type) + 1)
-        impression.save()
 
     def view_ratio(self, day=None):
         if not day:

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -91,8 +91,8 @@ class SupporterPromo(models.Model):
         }
 
     def cache_key(self, type, hash):
-        assert type in IMPRESSION_TYPES
-        return 'promo:{id}:{hash}:{type}'.format(id=self.analytics_id, hash=hash, type=type)
+        assert type in IMPRESSION_TYPES + ('project',)
+        return 'promo:{id}:{type}:{hash}'.format(id=self.analytics_id, hash=hash, type=type)
 
     def incr(self, type):
         """Add to the number of times this action has been performed, stored in the DB"""
@@ -104,6 +104,14 @@ class SupporterPromo(models.Model):
 
         # TODO: Support redis, more info on this PR
         # github.com/rtfd/readthedocs.org/pull/2105/files/1b5f8568ae0a7760f7247149bcff481efc000f32#r58253051
+
+    def incr_project(self, type, project):
+        """Add to the number of times this action has been performed, stored in the DB"""
+        assert type in IMPRESSION_TYPES
+        day = get_ad_day()
+        impression, _ = self.project_impressions.get_or_create(date=day, project=project)
+        setattr(impression, type, models.F(type) + 1)
+        impression.save()
 
     def view_ratio(self, day=None):
         if not day:

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core.cache import cache
 
 from readthedocs.restapi.signals import footer_response
-from readthedocs.donate.models import SupporterPromo, VIEWS, CLICKS
+from readthedocs.donate.models import SupporterPromo, VIEWS, CLICKS, OFFERS
 
 
 @receiver(footer_response)
@@ -67,12 +67,18 @@ def attach_promo_data(sender, **kwargs):
     if show_promo:
         promo_dict = promo_obj.as_dict()
         resp_data['promo_data'] = promo_dict
-        promo_obj.incr('offers')
+        promo_obj.incr(OFFERS)
+        promo_obj.incr_project(OFFERS, project)
         # Set validation cache
         for type in [VIEWS, CLICKS]:
             cache.set(
                 promo_obj.cache_key(type=type, hash=promo_dict['hash']),
                 0,  # Number of times used. Make this an int so we can detect multiple uses
+                60 * 60  # hour
+            )
+            cache.set(
+                promo_obj.cache_key(type='project', hash=promo_dict['hash']),
+                project.slug,
                 60 * 60  # hour
             )
 

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -68,7 +68,7 @@ def attach_promo_data(sender, **kwargs):
         promo_dict = promo_obj.as_dict()
         resp_data['promo_data'] = promo_dict
         promo_obj.incr(OFFERS)
-        promo_obj.incr_project(OFFERS, project)
+        promo_obj.incr(OFFERS, project=project)
         # Set validation cache
         for type in [VIEWS, CLICKS]:
             cache.set(
@@ -76,6 +76,7 @@ def attach_promo_data(sender, **kwargs):
                 0,  # Number of times used. Make this an int so we can detect multiple uses
                 60 * 60  # hour
             )
+            # Set project for hash key, so we can count it later.
             cache.set(
                 promo_obj.cache_key(type='project', hash=promo_dict['hash']),
                 project.slug,

--- a/readthedocs/donate/tests.py
+++ b/readthedocs/donate/tests.py
@@ -97,8 +97,12 @@ class FooterTests(TestCase):
             '/api/v2/footer_html/?project=pip&version=latest&page=index'
         )
         resp = json.loads(r.content)
-        self.assertEqual(resp['promo_data'][
-                         'link'], '//readthedocs.org/sustainability/click/%s/%s/' % (self.promo.pk, resp['promo_data']['hash']))
+        self.assertEqual(
+            resp['promo_data']['link'],
+            '//readthedocs.org/sustainability/click/%s/%s/' % (
+                self.promo.pk, resp['promo_data']['hash']
+            )
+        )
         impression = self.promo.impressions.first()
         self.assertEqual(impression.offers, 1)
 

--- a/readthedocs/donate/tests.py
+++ b/readthedocs/donate/tests.py
@@ -17,10 +17,12 @@ class PromoTests(TestCase):
                          slug='promo-slug',
                          link='http://example.com',
                          image='http://media.example.com/img.png')
+        self.pip = get(Project, slug='pip', allow_promos=True)
 
     def test_clicks(self):
         cache.set(self.promo.cache_key(type=CLICKS, hash='random_hash'), 0)
-        resp = self.client.get('http://testserver/sustainability/click/%s/random_hash/' % self.promo.id)
+        resp = self.client.get(
+            'http://testserver/sustainability/click/%s/random_hash/' % self.promo.id)
         self.assertEqual(resp._headers['location'][1], 'http://example.com')
         promo = SupporterPromo.objects.get(pk=self.promo.pk)
         impression = promo.impressions.first()
@@ -28,11 +30,20 @@ class PromoTests(TestCase):
 
     def test_views(self):
         cache.set(self.promo.cache_key(type=VIEWS, hash='random_hash'), 0)
-        resp = self.client.get('http://testserver/sustainability/view/%s/random_hash/' % self.promo.id)
+        resp = self.client.get(
+            'http://testserver/sustainability/view/%s/random_hash/' % self.promo.id)
         self.assertEqual(resp._headers['location'][1], 'http://media.example.com/img.png')
         promo = SupporterPromo.objects.get(pk=self.promo.pk)
         impression = promo.impressions.first()
         self.assertEqual(impression.views, 1)
+
+    def test_project_clicks(self):
+        cache.set(self.promo.cache_key(type=CLICKS, hash='random_hash'), 0)
+        cache.set(self.promo.cache_key(type='project', hash='random_hash'), self.pip.slug)
+        self.client.get('http://testserver/sustainability/click/%s/random_hash/' % self.promo.id)
+        promo = SupporterPromo.objects.get(pk=self.promo.pk)
+        impression = promo.project_impressions.first()
+        self.assertEqual(impression.clicks, 1)
 
     def test_stats(self):
         for x in range(50):
@@ -57,6 +68,18 @@ class PromoTests(TestCase):
         impression = promo.impressions.first()
         self.assertEqual(impression.views, 1)
 
+    def test_invalid_id(self):
+        resp = self.client.get('http://testserver/sustainability/view/invalid/data/')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_invalid_hash(self):
+        cache.set(self.promo.cache_key(type=VIEWS, hash='valid_hash'), 0)
+        resp = self.client.get(
+            'http://testserver/sustainability/view/%s/invalid_hash/' % self.promo.id)
+        promo = SupporterPromo.objects.get(pk=self.promo.pk)
+        self.assertEqual(promo.impressions.count(), 0)
+        self.assertEqual(resp._headers['location'][1], 'http://media.example.com/img.png')
+
 
 class FooterTests(TestCase):
 
@@ -74,7 +97,8 @@ class FooterTests(TestCase):
             '/api/v2/footer_html/?project=pip&version=latest&page=index'
         )
         resp = json.loads(r.content)
-        self.assertEqual(resp['promo_data']['link'], '//readthedocs.org/sustainability/click/%s/%s/' % (self.promo.pk, resp['promo_data']['hash']))
+        self.assertEqual(resp['promo_data'][
+                         'link'], '//readthedocs.org/sustainability/click/%s/%s/' % (self.promo.pk, resp['promo_data']['hash']))
         impression = self.promo.impressions.first()
         self.assertEqual(impression.offers, 1)
 
@@ -86,7 +110,8 @@ class FooterTests(TestCase):
         resp = json.loads(r.content)
         self.assertEqual(
             resp['promo_data']['link'],
-            '//readthedocs.org/sustainability/click/%s/%s/' % (self.promo.pk, resp['promo_data']['hash'])
+            '//readthedocs.org/sustainability/click/%s/%s/' % (
+                self.promo.pk, resp['promo_data']['hash'])
         )
         impression = self.promo.impressions.first()
         self.assertEqual(impression.offers, 1)

--- a/readthedocs/donate/views.py
+++ b/readthedocs/donate/views.py
@@ -74,7 +74,7 @@ def click_proxy(request, promo_id, hash):
         )
         if project_slug:
             project = Project.objects.get(slug=project_slug)
-            promo.incr_project(CLICKS, project=project)
+            promo.incr(CLICKS, project=project)
     else:
         log.warning('Duplicate click logged. {count} total clicks tried.'.format(count=count))
         cache.incr(promo.cache_key(type=CLICKS, hash=hash))
@@ -95,7 +95,7 @@ def view_proxy(request, promo_id, hash):
         )
         if project_slug:
             project = Project.objects.get(slug=project_slug)
-            promo.incr_project(VIEWS, project=project)
+            promo.incr(VIEWS, project=project)
     else:
         log.warning('Duplicate view logged. {count} total clicks tried.'.format(count=count))
         cache.incr(promo.cache_key(type=VIEWS, hash=hash))

--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -7,6 +7,8 @@ from .models import (Project, ImportedFile,
                      ProjectRelationship, EmailHook, WebHook, Domain)
 from guardian.admin import GuardedModelAdmin
 
+from readthedocs.donate.models import ProjectImpressions
+
 
 class ProjectRelationshipInline(admin.TabularInline):
 
@@ -35,6 +37,20 @@ class DomainInline(admin.TabularInline):
     model = Domain
 
 
+class ImpressionInline(admin.TabularInline):
+    model = ProjectImpressions
+    readonly_fields = ('date', 'offers', 'views', 'clicks', 'view_ratio', 'click_ratio')
+    extra = 0
+    can_delete = False
+    max_num = 15
+
+    def view_ratio(self, instance):
+        return instance.view_ratio * 100
+
+    def click_ratio(self, instance):
+        return instance.click_ratio * 100
+
+
 class ProjectAdmin(GuardedModelAdmin):
 
     """Project model admin view"""
@@ -45,7 +61,8 @@ class ProjectAdmin(GuardedModelAdmin):
                    'documentation_type', 'programming_language')
     list_editable = ('featured',)
     search_fields = ('slug', 'repo')
-    inlines = [ProjectRelationshipInline, RedirectInline, VersionInline, DomainInline]
+    inlines = [ProjectRelationshipInline, RedirectInline,
+               VersionInline, DomainInline, ImpressionInline]
     raw_id_fields = ('users', 'main_language_project')
 
 


### PR DESCRIPTION
This allows us to keep track of independent attrs on impressions.
This initially tracks impresisons per-project,
as well as per-promo.