### PR TITLE
Add basic tests for BitBucket

### DIFF
--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -21,7 +21,10 @@ your docs whenever you push updates:
 * Check "Active"
 * Click "Add service"
 
-**Note:** The GitHub URL in your Read the Docs project must match the URL on GitHub. The URL is case-sensitive.
+.. note:: The GitHub URL in your Read the Docs project must match the URL on GitHub. The URL is case-sensitive.
+
+If you ever need to manually set the webhook on GitHub,
+you can point it at ``https://readthedocs.org/github``.
 
 Bitbucket
 -----------
@@ -33,6 +36,9 @@ your docs whenever you push updates:
 * Click "Services"
 * In the available service hooks, select "Read the Docs"
 * Click "Add service"
+
+If you ever need to manually set the webhook on Bitbucket,
+you can point it at ``https://readthedocs.org/bitbucket``.
 
 Others
 ------

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -727,13 +727,6 @@ class Project(models.Model):
                     identifier=new_stable.identifier)
                 return new_stable
 
-    def version_from_branch_name(self, branch):
-        versions = self.versions_from_branch_name(branch)
-        try:
-            return versions[0]
-        except IndexError:
-            return None
-
     def versions_from_branch_name(self, branch):
         return (
             self.versions.filter(identifier=branch) |

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 import json
 import logging
 
+from django_dynamic_fixture import get
+
 from readthedocs.projects.models import Project
 from readthedocs.projects import tasks
 
@@ -39,7 +41,7 @@ class GitLabWebHookTest(TestCase):
                 "homepage": "http://github.com/rtfd/readthedocs.org",
                 "git_http_url": "http://github.com/rtfd/readthedocs.org.git",
                 "git_ssh_url": "git@github.com:rtfd/readthedocs.org.git",
-                "visibility_level":0
+                "visibility_level": 0
             },
             "commits": [
                 {
@@ -74,11 +76,13 @@ class GitLabWebHookTest(TestCase):
         """
         r = self.client.post('/gitlab/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [awesome]')
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [awesome]')
         self.payload['ref'] = 'refs/heads/not_ok'
         r = self.client.post('/gitlab/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Not Building: github.com/rtfd/readthedocs.org [not_ok]')
+        self.assertEqual(
+            r.content, '(URL Build) Not Building: github.com/rtfd/readthedocs.org [not_ok]')
         self.payload['ref'] = 'refs/heads/unknown'
         r = self.client.post('/gitlab/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
@@ -97,7 +101,8 @@ class GitLabWebHookTest(TestCase):
 
         r = self.client.post('/gitlab/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [latest]')
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [latest]')
 
         rtd.default_branch = old_default
         rtd.save()
@@ -181,7 +186,8 @@ class GitHubPostCommitTest(TestCase):
         payload['repository']['url'] = payload['repository']['url'].upper()
         r = self.client.post('/github/', {'payload': json.dumps(payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Build Started: HTTPS://GITHUB.COM/RTFD/READTHEDOCS.ORG [awesome]')
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: HTTPS://GITHUB.COM/RTFD/READTHEDOCS.ORG [awesome]')
         self.payload['ref'] = 'refs/heads/not_ok'
 
     def test_400_on_no_ref(self):
@@ -203,11 +209,13 @@ class GitHubPostCommitTest(TestCase):
         """
         r = self.client.post('/github/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [awesome]')
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [awesome]')
         self.payload['ref'] = 'refs/heads/not_ok'
         r = self.client.post('/github/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Not Building: github.com/rtfd/readthedocs.org [not_ok]')
+        self.assertEqual(
+            r.content, '(URL Build) Not Building: github.com/rtfd/readthedocs.org [not_ok]')
         self.payload['ref'] = 'refs/heads/unknown'
         r = self.client.post('/github/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
@@ -226,7 +234,8 @@ class GitHubPostCommitTest(TestCase):
 
         r = self.client.post('/github/', {'payload': json.dumps(self.payload)})
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [latest]')
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: github.com/rtfd/readthedocs.org [latest]')
 
         rtd.default_branch = old_default
         rtd.save()
@@ -237,7 +246,8 @@ class GitHubPostCommitTest(TestCase):
         rtd.save()
         r = self.client.post('/build/%s' % rtd.pk, {'version_slug': 'master'})
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/projects/read-the-docs/builds/')
+        self.assertEqual(
+            r._headers['location'][1], 'http://testserver/projects/read-the-docs/builds/')
 
     def test_hook_state_tracking(self):
         rtd = Project.objects.get(slug='read-the-docs')
@@ -245,3 +255,105 @@ class GitHubPostCommitTest(TestCase):
         self.client.post('/build/%s' % rtd.pk, {'version_slug': 'latest'})
         # Need to re-query to get updated DB entry
         self.assertEqual(Project.objects.get(slug='read-the-docs').has_valid_webhook, True)
+
+
+class BitBucketHookTests(TestCase):
+
+    def setUp(self):
+        def mock(*args, **kwargs):
+            pass
+
+        self.pip = get(Project, repo='https://bitbucket.org/pip/pip', repo_type='hg')
+        self.sphinx = get(Project, repo='https://bitbucket.org/sphinx/sphinx', repo_type='git')
+
+        tasks.UpdateDocsTask.run = mock
+        tasks.UpdateDocsTask.apply_async = mock
+
+        self.client.login(username='eric', password='test')
+
+        self.hg_payload = {
+            "canon_url": "https://bitbucket.org",
+            "commits": [
+                {
+                    "author": "marcus",
+                    "branch": "default",
+                    "files": [
+                        {
+                            "file": "somefile.py",
+                            "type": "modified"
+                        }
+                    ],
+                    "message": "Added some featureA things",
+                    "node": "d14d26a93fd2",
+                    "parents": [
+                            "1b458191f31a"
+                    ],
+                    "raw_author": "Marcus Bertrand <marcus@somedomain.com>",
+                    "raw_node": "d14d26a93fd28d3166fa81c0cd3b6f339bb95bfe",
+                    "revision": 3,
+                    "size": -1,
+                    "timestamp": "2012-05-30 06:07:03",
+                    "utctimestamp": "2012-05-30 04:07:03+00:00"
+                }
+            ],
+            "repository": {
+                "absolute_url": "/pip/pip/",
+                "fork": False,
+                "is_private": True,
+                "name": "Project X",
+                "owner": "marcus",
+                "scm": "hg",
+                "slug": "project-x",
+                "website": ""
+            },
+            "user": "marcus"
+        }
+
+        self.git_payload = {
+            "canon_url": "https://bitbucket.org",
+            "commits": [
+                {
+                    "author": "marcus",
+                    "branch": "master",
+                    "files": [
+                        {
+                            "file": "somefile.py",
+                            "type": "modified"
+                        }
+                    ],
+                    "message": "Added some more things to somefile.py\n",
+                    "node": "620ade18607a",
+                    "parents": [
+                            "702c70160afc"
+                    ],
+                    "raw_author": "Marcus Bertrand <marcus@somedomain.com>",
+                    "raw_node": "620ade18607ac42d872b568bb92acaa9a28620e9",
+                    "revision": None,
+                    "size": -1,
+                    "timestamp": "2012-05-30 05:58:56",
+                    "utctimestamp": "2012-05-30 03:58:56+00:00"
+                }
+            ],
+            "repository": {
+                "absolute_url": "/sphinx/sphinx/",
+                "fork": False,
+                "is_private": True,
+                "name": "Project X",
+                "owner": "marcus",
+                "scm": "git",
+                "slug": "project-x",
+                "website": "https://atlassian.com/"
+            },
+            "user": "marcus"
+        }
+
+    def test_bitbucket_post_commit(self):
+        r = self.client.post('/bitbucket/', {'payload': json.dumps(self.hg_payload)})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: bitbucket.org/pip/pip [latest]')
+
+        r = self.client.post('/bitbucket/', {'payload': json.dumps(self.git_payload)})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: bitbucket.org/sphinx/sphinx [latest]')

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -393,3 +393,23 @@ class BitBucketHookTests(BasePostCommitTest):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
             r.content, '(URL Build) Not Building: bitbucket.org/pip/pip []')
+
+    def test_bitbucket_default_branch(self):
+        self.test_project = get(
+            Project, repo='HTTPS://bitbucket.org/test/project', slug='test-project',
+            default_branch='integration', repo_type='git',
+        )
+
+        self.git_payload['commits'] = [{
+            "branch": "integration",
+        }]
+        self.git_payload['repository'] = {
+            'absolute_url': '/test/project/'
+        }
+
+        r = self.client.post('/bitbucket/', {'payload': json.dumps(self.git_payload)})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.content, '(URL Build) Build Started: bitbucket.org/test/project [latest]')
+
+

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -370,7 +370,7 @@ class BitBucketHookTests(BasePostCommitTest):
 
     def test_bitbucket_post_commit_hook_builds_branch_docs_if_it_should(self):
         """
-        Test the github post commit hook to see if it will only build
+        Test the bitbucket post commit hook to see if it will only build
         versions that are set to be built if the branch they refer to
         is updated. Otherwise it is no op.
         """


### PR DESCRIPTION
We didn't have these before. Fixes #2090 

This also cleans up the use of fixture data in these tests, instead of relying on a fixture.