### PR TITLE
Add private symlink structure.

### DIFF
--- a/readthedocs/core/symlink.py
+++ b/readthedocs/core/symlink.py
@@ -319,7 +319,7 @@ class PrivateSymlink(Symlink):
     PROJECT_CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'private_cname_project')
 
     def run_sanity_check(self):
-        return self.project.privacy_level in [constants.PRIVATE]
+        return self.project.privacy_level == constants.PRIVATE
 
     def get_version_queryset(self):
         return (self.project.versions.private(only_active=False).filter(built=True) |
@@ -334,7 +334,7 @@ class PrivateSymlink(Symlink):
     def get_default_version(self):
         default_version = self.project.get_default_version()
         if self.project.versions.private().filter(
-            slug=default_version
-        ).exists():
+                    slug=default_version
+                ).exists():
             return default_version
         return None

--- a/readthedocs/core/symlink.py
+++ b/readthedocs/core/symlink.py
@@ -333,8 +333,7 @@ class PrivateSymlink(Symlink):
 
     def get_default_version(self):
         default_version = self.project.get_default_version()
-        if self.project.versions.private().filter(
-                    slug=default_version
-                ).exists():
+        version_qs = self.project.versions.private().filter(slug=default_version)
+        if version_qs.exists():
             return default_version
         return None

--- a/readthedocs/core/symlink.py
+++ b/readthedocs/core/symlink.py
@@ -243,7 +243,6 @@ class Symlink(object):
         """
         default_version = self.get_default_version()
         if default_version is None:
-            self._log("Default version wrong privacy level.")
             return
 
         self._log("Symlinking single_version")
@@ -303,9 +302,7 @@ class PublicSymlink(Symlink):
 
     def get_default_version(self):
         default_version = self.project.get_default_version()
-        if self.project.versions.protected().filter(
-            slug=default_version
-        ).exists():
+        if self.project.versions.protected().filter(slug=default_version).exists():
             return default_version
         return None
 

--- a/readthedocs/core/symlink.py
+++ b/readthedocs/core/symlink.py
@@ -94,6 +94,8 @@ class Symlink(object):
 
         This will leave it in the proper state for the single_project setting.
         """
+        if not self.run_sanity_check():
+            return
         if os.path.islink(self.project_root) and not self.project.single_version:
             self._log("Removing single version symlink")
             os.unlink(self.project_root)
@@ -307,11 +309,17 @@ class PublicSymlink(Symlink):
             return default_version
         return None
 
+    def run_sanity_check(self):
+        return self.project.privacy_level in [constants.PUBLIC, constants.PROTECTED]
+
 
 class PrivateSymlink(Symlink):
     CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'private_cname_root')
     WEB_ROOT = os.path.join(settings.SITE_ROOT, 'private_web_root')
     PROJECT_CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'private_cname_project')
+
+    def run_sanity_check(self):
+        return self.project.privacy_level in [constants.PRIVATE]
 
     def get_version_queryset(self):
         return (self.project.versions.private(only_active=False).filter(built=True) |

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -176,8 +176,8 @@ class RelatedProjectManager(models.Manager):
 
     This shouldn't be used as a subclass.
     """
-
     use_for_related_fields = True
+    project_field = 'project'
 
     def _add_user_repos(self, queryset, user=None):
         # Hack around get_objects_for_user not supporting global perms
@@ -187,11 +187,35 @@ class RelatedProjectManager(models.Manager):
             # Add in possible user-specific views
             project_qs = get_objects_for_user(user, 'projects.view_project')
             pks = [p.pk for p in project_qs]
-            queryset = self.get_queryset().filter(project__pk__in=pks) | queryset
+            kwargs = {'%s__pk__in' % self.project_field: pks}
+            queryset = self.get_queryset().filter(**kwargs) | queryset
         return queryset.distinct()
 
     def public(self, user=None, project=None):
-        queryset = self.filter(project__privacy_level=constants.PUBLIC)
+        kwargs = {'%s__privacy_level' % self.project_field: constants.PUBLIC}
+        queryset = self.filter(**kwargs)
+        if user:
+            queryset = self._add_user_repos(queryset, user)
+        if project:
+            queryset = queryset.filter(project=project)
+        return queryset
+
+    def protected(self, user=None, project=None):
+        kwargs = {
+            '%s__privacy_level__in' % self.project_field: [constants.PUBLIC, constants.PROTECTED]
+        }
+        queryset = self.filter(**kwargs)
+        if user:
+            queryset = self._add_user_repos(queryset, user)
+        if project:
+            queryset = queryset.filter(project=project)
+        return queryset
+
+    def private(self, user=None, project=None):
+        kwargs = {
+            '%s__privacy_level' % self.project_field: constants.PRIVATE,
+        }
+        queryset = self.filter(**kwargs)
         if user:
             queryset = self._add_user_repos(queryset, user)
         if project:
@@ -200,6 +224,16 @@ class RelatedProjectManager(models.Manager):
 
     def api(self, user=None):
         return self.public(user)
+
+
+class ParentRelatedProjectManager(RelatedProjectManager):
+    project_field = 'parent'
+    use_for_related_fields = True
+
+
+class ChildRelatedProjectManager(RelatedProjectManager):
+    project_field = 'child'
+    use_for_related_fields = True
 
 
 class RelatedBuildManager(models.Manager):

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -57,6 +57,13 @@ class ProjectManager(models.Manager):
         else:
             return queryset
 
+    def private(self, user=None):
+        queryset = self.filter(privacy_level=constants.PRIVATE)
+        if user:
+            return self._add_user_repos(queryset, user)
+        else:
+            return queryset
+
     # Aliases
 
     def dashboard(self, user=None):

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -98,6 +98,16 @@ class VersionManager(models.Manager):
             queryset = queryset.filter(active=True)
         return queryset
 
+    def private(self, user=None, project=None, only_active=True):
+        queryset = self.filter(privacy_level__in=[constants.PRIVATE])
+        if user:
+            queryset = self._add_user_repos(queryset, user)
+        if project:
+            queryset = queryset.filter(project=project)
+        if only_active:
+            queryset = queryset.filter(active=True)
+        return queryset
+
     def api(self, user=None):
         return self.public(user, only_active=False)
 

--- a/readthedocs/privacy/loader.py
+++ b/readthedocs/privacy/loader.py
@@ -21,6 +21,9 @@ RelatedBuildManager = import_by_path(
 RelatedUserManager = import_by_path(
     getattr(settings, 'RELATED_USER_MANAGER',
             'readthedocs.privacy.backend.RelatedUserManager'))
+ParentRelatedProjectManager = import_by_path(
+    getattr(settings, 'PARENT_RELATED_PROJECT_MANAGER',
+            'readthedocs.privacy.backend.ParentRelatedProjectManager'))
 
 # Permissions
 AdminPermission = import_by_path(

--- a/readthedocs/privacy/loader.py
+++ b/readthedocs/privacy/loader.py
@@ -21,9 +21,9 @@ RelatedBuildManager = import_by_path(
 RelatedUserManager = import_by_path(
     getattr(settings, 'RELATED_USER_MANAGER',
             'readthedocs.privacy.backend.RelatedUserManager'))
-ParentRelatedProjectManager = import_by_path(
-    getattr(settings, 'PARENT_RELATED_PROJECT_MANAGER',
-            'readthedocs.privacy.backend.ParentRelatedProjectManager'))
+ChildRelatedProjectManager = import_by_path(
+    getattr(settings, 'CHILD_RELATED_PROJECT_MANAGER',
+            'readthedocs.privacy.backend.ChildRelatedProjectManager'))
 
 # Permissions
 AdminPermission = import_by_path(

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -22,6 +22,7 @@ from readthedocs.core.resolver import resolve_domain
 from readthedocs.restapi.client import api as apiv2
 from readthedocs.builds.constants import LATEST, LATEST_VERBOSE_NAME, STABLE
 from readthedocs.privacy.loader import RelatedProjectManager, ProjectManager
+from readthedocs.privacy.backend import ChildRelatedProjectManager, ParentRelatedProjectManager
 from readthedocs.projects import constants
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
@@ -57,6 +58,8 @@ class ProjectRelationship(models.Model):
     child = models.ForeignKey('Project', verbose_name=_('Child'),
                               related_name='superprojects')
     alias = models.CharField(_('Alias'), max_length=255, null=True, blank=True)
+
+    objects = ChildRelatedProjectManager()
 
     def __unicode__(self):
         return "%s -> %s" % (self.parent, self.child)

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -18,11 +18,10 @@ from taggit.managers import TaggableManager
 
 from readthedocs.api.client import api
 from readthedocs.core.utils import broadcast
-from readthedocs.core.resolver import resolve_domain
 from readthedocs.restapi.client import api as apiv2
 from readthedocs.builds.constants import LATEST, LATEST_VERBOSE_NAME, STABLE
-from readthedocs.privacy.loader import RelatedProjectManager, ProjectManager
-from readthedocs.privacy.backend import ChildRelatedProjectManager, ParentRelatedProjectManager
+from readthedocs.privacy.loader import (RelatedProjectManager, ProjectManager,
+                                        ChildRelatedProjectManager)
 from readthedocs.projects import constants
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -25,7 +25,7 @@ from readthedocs.builds.constants import (LATEST,
                                           BUILD_STATE_BUILDING)
 from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import send_email, run_on_app_servers, broadcast
-from readthedocs.core.symlink import get_symlink
+from readthedocs.core.symlink import PublicSymlink, PrivateSymlink
 from readthedocs.cdn.purge import purge
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.doc_builder.config import load_yaml_config
@@ -624,27 +624,29 @@ def update_search(version_pk, commit, delete_non_commit_files=True):
 @task(queue='web')
 def symlink_project(project_pk):
     project = Project.objects.get(pk=project_pk)
-    sym = get_symlink(project=project)
-    sym.run()
+    for symlink in [PublicSymlink, PrivateSymlink]:
+        sym = symlink(project=project)
+        sym.run()
 
 
 @task(queue='web')
 def symlink_domain(project_pk, domain_pk, delete=False):
     project = Project.objects.get(pk=project_pk)
     domain = Domain.objects.get(pk=domain_pk)
-    sym = get_symlink(project=project)
-    if delete:
-        sym.remove_symlink_cname(domain)
-    else:
-        sym.symlink_cnames(domain)
+    for symlink in [PublicSymlink, PrivateSymlink]:
+        sym = symlink(project=project)
+        if delete:
+            sym.remove_symlink_cname(domain)
+        else:
+            sym.symlink_cnames(domain)
 
 
 @task(queue='web')
 def symlink_subproject(project_pk):
     project = Project.objects.get(pk=project_pk)
-    sym = get_symlink(project=project)
-    sym.symlink_subprojects()
-    sym.symlink_subprojects()
+    for symlink in [PublicSymlink, PrivateSymlink]:
+        sym = symlink(project=project)
+        sym.symlink_subprojects()
 
 
 @task(queue='web')

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -25,7 +25,7 @@ from readthedocs.builds.constants import (LATEST,
                                           BUILD_STATE_BUILDING)
 from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import send_email, run_on_app_servers, broadcast
-from readthedocs.core.symlink import Symlink
+from readthedocs.core.symlink import get_symlink
 from readthedocs.cdn.purge import purge
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.doc_builder.config import load_yaml_config
@@ -624,7 +624,7 @@ def update_search(version_pk, commit, delete_non_commit_files=True):
 @task(queue='web')
 def symlink_project(project_pk):
     project = Project.objects.get(pk=project_pk)
-    sym = Symlink(project=project)
+    sym = get_symlink(project=project)
     sym.run()
 
 
@@ -632,7 +632,7 @@ def symlink_project(project_pk):
 def symlink_domain(project_pk, domain_pk, delete=False):
     project = Project.objects.get(pk=project_pk)
     domain = Domain.objects.get(pk=domain_pk)
-    sym = Symlink(project=project)
+    sym = get_symlink(project=project)
     if delete:
         sym.remove_symlink_cname(domain)
     else:
@@ -642,7 +642,8 @@ def symlink_domain(project_pk, domain_pk, delete=False):
 @task(queue='web')
 def symlink_subproject(project_pk):
     project = Project.objects.get(pk=project_pk)
-    sym = Symlink(project=project)
+    sym = get_symlink(project=project)
+    sym.symlink_subprojects()
     sym.symlink_subprojects()
 
 

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -9,7 +9,7 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project, Domain
-from readthedocs.core.symlink import Symlink
+from readthedocs.core.symlink import Publicsymlink
 
 
 def patched(fn):
@@ -31,7 +31,7 @@ class TestSubprojects(TestCase):
     def setUp(self):
         self.project = get(Project, slug='kong')
         self.subproject = get(Project, slug='sub')
-        self.symlink = Symlink(self.project)
+        self.symlink = Publicsymlink(self.project)
         self.args = {
             'web_root': self.symlink.WEB_ROOT,
             'subproject_root': self.symlink.subproject_root,
@@ -76,12 +76,12 @@ class TestSubprojects(TestCase):
         self.assertTrue(not os.path.lexists(subproject_link))
 
 
-class TestSymlinkCnames(TestCase):
+class TestPublicsymlinkCnames(TestCase):
 
     def setUp(self):
         self.project = get(Project, slug='kong')
         self.version = get(Version, verbose_name='latest', active=True, project=self.project)
-        self.symlink = Symlink(self.project)
+        self.symlink = Publicsymlink(self.project)
         self.args = {
             'cname_root': self.symlink.CNAME_ROOT,
             'project_root': self.symlink.project_root,
@@ -101,7 +101,7 @@ class TestSymlinkCnames(TestCase):
             self.assertEqual(self.commands[index], command.format(**self.args))
 
 
-class TestSymlinkTranslations(TestCase):
+class TestPublicsymlinkTranslations(TestCase):
 
     commands = []
 
@@ -113,7 +113,7 @@ class TestSymlinkTranslations(TestCase):
         self.project.translations.add(self.translation)
         self.translation.save()
         self.project.save()
-        self.symlink = Symlink(self.project)
+        self.symlink = Publicsymlink(self.project)
         get(Version, verbose_name='master', active=True, project=self.project)
         get(Version, verbose_name='master', active=True, project=self.translation)
         self.args = {
@@ -184,25 +184,25 @@ class TestSymlinkTranslations(TestCase):
                     self.commands.index(command.format(**self.args))
                 ))
 
-
     def test_remove_language(self):
         self.symlink.symlink_translations()
         trans_link = os.path.join(
             self.symlink.project_root, self.translation.language
         )
         self.assertTrue(os.path.lexists(trans_link))
-        
+
         trans = self.project.translations.first()
         self.project.translations.remove(trans)
         self.symlink.symlink_translations()
         self.assertTrue(not os.path.lexists(trans_link))
 
-class TestSymlinkSingleVersion(TestCase):
+
+class TestPublicsymlinkSingleVersion(TestCase):
 
     def setUp(self):
         self.project = get(Project, slug='kong')
         self.version = get(Version, verbose_name='latest', active=True, project=self.project)
-        self.symlink = Symlink(self.project)
+        self.symlink = Publicsymlink(self.project)
         self.args = {
             'project_root': self.symlink.project_root,
             'doc_path': self.project.rtd_build_path(),
@@ -220,12 +220,13 @@ class TestSymlinkSingleVersion(TestCase):
             self.assertEqual(self.commands[index], command.format(**self.args))
 
 
-class TestSymlinkVersions(TestCase):
+class TestPublicsymlinkVersions(TestCase):
 
     def setUp(self):
         self.project = get(Project, slug='kong')
-        self.stable = get(Version, slug='stable', verbose_name='stable', active=True, project=self.project)
-        self.symlink = Symlink(self.project)
+        self.stable = get(
+            Version, slug='stable', verbose_name='stable', active=True, project=self.project)
+        self.symlink = Publicsymlink(self.project)
         self.args = {
             'project_root': self.symlink.project_root,
             'latest_path': self.project.rtd_build_path('latest'),
@@ -268,12 +269,14 @@ class TestSymlinkVersions(TestCase):
         self.assertTrue(not os.path.lexists(version_link))
 
 
-class TestSymlinkUnicode(TestCase):
+class TestPublicsymlinkUnicode(TestCase):
 
     def setUp(self):
         self.project = get(Project, slug='kong', name=u'foo-∫')
-        self.stable = get(Version, slug='stable', verbose_name=u'foo-∂', active=True, project=self.project)
-        self.symlink = Symlink(self.project)
+        self.stable = get(
+            Version, slug='stable', verbose_name=u'foo-∂', active=True, project=self.project
+        )
+        self.symlink = Publicsymlink(self.project)
         self.args = {
             'project_root': self.symlink.project_root,
             'latest_path': self.project.rtd_build_path('latest'),


### PR DESCRIPTION
This builds out a separate `private_*` symlink structure for all private projects. This runs both Public & Private symlinks for each project, as it might have versions that have both privacy levels. 