### PR TITLE
Add session configuration to API clients

### DIFF
--- a/readthedocs/api/client.py
+++ b/readthedocs/api/client.py
@@ -1,17 +1,31 @@
-import slumber
 import logging
 
+from slumber import API, serialize
+from requests import Session
 from django.conf import settings
+
 
 log = logging.getLogger(__name__)
 
+PRODUCTION_DOMAIN = getattr(settings, 'PRODUCTION_DOMAIN', 'readthedocs.org')
 USER = getattr(settings, 'SLUMBER_USERNAME', None)
 PASS = getattr(settings, 'SLUMBER_PASSWORD', None)
 API_HOST = getattr(settings, 'SLUMBER_API_HOST', 'https://readthedocs.org')
 
-if USER and PASS:
-    log.debug("Using slumber with user %s, pointed at %s" % (USER, API_HOST))
-    api = slumber.API(base_url='%s/api/v1/' % API_HOST, auth=(USER, PASS))
-else:
-    log.warning("SLUMBER_USERNAME/PASSWORD settings are not set")
-    api = slumber.API(base_url='%s/api/v1/' % API_HOST)
+
+def setup_api():
+    session = Session()
+    session.headers.update({'Host': PRODUCTION_DOMAIN})
+    api_config = {
+        'base_url': '%s/api/v1/' % API_HOST,
+        'session': session,
+    }
+    if USER and PASS:
+        log.debug("Using slumber with user %s, pointed at %s" % (USER, API_HOST))
+        session.auth = (USER, PASS)
+    else:
+        log.warning("SLUMBER_USERNAME/PASSWORD settings are not set")
+    return API(**api_config)
+
+
+api = setup_api()


### PR DESCRIPTION
This also cleans up the api v1 client to match the implementation by api v2.
A session is added to the Slumber API to handle an explicit hostname on the
request. This is useful for local development and staging, where the API
host name might not match the host name the web server or application instance
is designated to listen for. For example, when requests for API should go to
http://localhost, but the application expects http://readthedocs.org