### PR TITLE
Add admin action for sending user emails

### DIFF
--- a/readthedocs/core/admin.py
+++ b/readthedocs/core/admin.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin
 
+from readthedocs.core.views import SendEmailView
 from readthedocs.core.models import UserProfile
 from readthedocs.projects.models import Project
 
@@ -19,7 +20,7 @@ class UserProjectInline(admin.TabularInline):
 class UserAdminExtra(UserAdmin):
     list_display = ('username', 'email', 'first_name',
                     'last_name', 'is_staff', 'is_banned')
-    actions = ['ban_user']
+    actions = ['ban_user', 'send_email']
     inlines = [UserProjectInline]
 
     def is_banned(self, obj):
@@ -36,6 +37,12 @@ class UserAdminExtra(UserAdmin):
         self.message_user(request, 'Banned users: %s' % ', '.join(users))
 
     ban_user.short_description = 'Ban user'
+
+    def send_email(self, request, queryset):
+        view = SendEmailView.as_view()
+        return view(request, queryset=queryset)
+
+    send_email.short_description = 'Email user'
 
 
 class UserProfileAdmin(admin.ModelAdmin):

--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -99,3 +99,28 @@ class FacetedSearchForm(SearchForm):
             sqs = sqs.narrow(facet)
         self.searchqueryset = sqs
         return sqs
+
+
+class SendEmailForm(forms.Form):
+
+    """Send email form
+
+    Used for building an email notifiction to a list of users from admin pages
+
+    Fields:
+
+        _selected_action
+            This is required for the admin intermediate form to submit
+
+        subject
+            Email subject
+
+        body
+            Email body
+    """
+
+    _selected_action = forms.CharField(widget=forms.MultipleHiddenInput)
+
+    subject = forms.CharField(label=_('Email subject'), required=True)
+    body = forms.CharField(label=_('Email body'), widget=forms.Textarea,
+                           required=True)

--- a/readthedocs/core/tasks.py
+++ b/readthedocs/core/tasks.py
@@ -1,0 +1,47 @@
+"""Basic tasks"""
+
+import logging
+
+from celery import task
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import get_template
+
+
+log = logging.getLogger(__name__)
+
+
+@task(queue='web')
+def send_email_task(recipient, subject, template, template_html, context=None):
+    """
+    Send multipart email
+
+    recipient
+        Email recipient address
+
+    subject
+        Email subject header
+
+    template
+        Plain text template to send
+
+    template_html
+        HTML template to send as new message part
+
+    context
+        A dictionary to pass into the template calls
+
+    request
+        Request object for determining absolute URL
+    """
+    ctx = {}
+    ctx.update(context)
+    msg = EmailMultiAlternatives(
+        subject,
+        get_template(template).render(ctx),
+        settings.DEFAULT_FROM_EMAIL,
+        [recipient]
+    )
+    msg.attach_alternative(get_template(template_html).render(ctx), 'text/html')
+    msg.send()
+    log.info('Sent email to recipient: %s', recipient)

--- a/readthedocs/core/tasks.py
+++ b/readthedocs/core/tasks.py
@@ -13,8 +13,7 @@ log = logging.getLogger(__name__)
 
 @task(queue='web')
 def send_email_task(recipient, subject, template, template_html, context=None):
-    """
-    Send multipart email
+    """Send multipart email
 
     recipient
         Email recipient address
@@ -30,18 +29,13 @@ def send_email_task(recipient, subject, template, template_html, context=None):
 
     context
         A dictionary to pass into the template calls
-
-    request
-        Request object for determining absolute URL
     """
-    ctx = {}
-    ctx.update(context)
     msg = EmailMultiAlternatives(
         subject,
-        get_template(template).render(ctx),
+        get_template(template).render(context),
         settings.DEFAULT_FROM_EMAIL,
         [recipient]
     )
-    msg.attach_alternative(get_template(template_html).render(ctx), 'text/html')
+    msg.attach_alternative(get_template(template_html).render(context), 'text/html')
     msg.send()
     log.info('Sent email to recipient: %s', recipient)

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -111,7 +111,15 @@ def trigger_build(project, version=None, record=True, force=False, basic=False):
 
 def send_email(recipient, subject, template, template_html, context=None,
                request=None):
-    """Pass email send command to task"""
+    """Alter context passed in and call email send task
+
+    .. seealso::
+
+        Task :py:func:`readthedocs.core.tasks.send_email_task`
+            Task that handles templating and sending email message
+    """
+    if context is None:
+        context = {}
     if request:
         scheme = 'https' if request.is_secure() else 'http'
         context['uri'] = '{scheme}://{host}'.format(scheme=scheme,

--- a/readthedocs/core/views.py
+++ b/readthedocs/core/views.py
@@ -862,7 +862,7 @@ class SendEmailView(FormView):
         if count == 0:
             self.message_user("No receipients to send to", level=messages.ERROR)
         else:
-            self.message_user("Messages sent!")
+            self.message_user("Queued {0} messages".format(count))
         return HttpResponseRedirect(self.request.get_full_path())
 
     def get_queryset(self):

--- a/readthedocs/core/views.py
+++ b/readthedocs/core/views.py
@@ -3,6 +3,7 @@ documentation and header rendering, and server errors.
 
 """
 
+from django.contrib import admin, messages
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect, Http404, HttpResponseNotFound
@@ -10,15 +11,15 @@ from django.shortcuts import render_to_response, get_object_or_404, redirect
 from django.template import RequestContext
 from django.views.decorators.csrf import csrf_exempt
 from django.views.static import serve
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, FormView
 
 from haystack.query import EmptySearchQuerySet
 from haystack.query import SearchQuerySet
 
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
-from readthedocs.core.forms import FacetedSearchForm
-from readthedocs.core.utils import trigger_build, broadcast
+from readthedocs.core.forms import FacetedSearchForm, SendEmailForm
+from readthedocs.core.utils import trigger_build, broadcast, send_email
 from readthedocs.donate.mixins import DonateProgressMixin
 from readthedocs.builds.constants import LATEST
 from readthedocs.projects import constants
@@ -811,3 +812,75 @@ class SearchView(TemplateView):
         Fetches the results via the form.
         """
         return self.form.search()
+
+
+class SendEmailView(FormView):
+
+    """Form view for sending emails to users from admin pages
+
+    Accepts the following additional parameters:
+
+    queryset
+        The queryset to use to determine the users to send emails to
+    """
+
+    form_class = SendEmailForm
+    template_name = 'core/send_email_form.html'
+
+    def get_form_kwargs(self):
+        """Override form kwargs based on input fields
+
+        The admin posts to this view initially, so detect the send button on
+        form post variables. Drop additional fields if we see the send button.
+        """
+        kwargs = super(SendEmailView, self).get_form_kwargs()
+        if 'send' not in self.request.POST:
+            kwargs.pop('data', None)
+            kwargs.pop('files', None)
+        return kwargs
+
+    def get_initial(self):
+        """Add selected ids to initial form data"""
+        initial = super(SendEmailView, self).get_initial()
+        initial['_selected_action'] = self.request.POST.getlist(
+            admin.ACTION_CHECKBOX_NAME)
+        return initial
+
+    def form_valid(self, form):
+        """If form is valid, send emails to selected users"""
+        count = 0
+        for user in self.get_queryset().all():
+            send_email(
+                user.email,
+                subject=form.cleaned_data['subject'],
+                template='core/email/common.txt',
+                template_html='core/email/common.html',
+                context={'user': user, 'content': form.cleaned_data['body']},
+                request=self.request,
+            )
+            count += 1
+        if count == 0:
+            self.message_user("No receipients to send to", level=messages.ERROR)
+        else:
+            self.message_user("Messages sent!")
+        return HttpResponseRedirect(self.request.get_full_path())
+
+    def get_queryset(self):
+        return self.kwargs.get('queryset')
+
+    def get_context_data(self, **kwargs):
+        """Return queryset in context"""
+        context = super(SendEmailView, self).get_context_data(**kwargs)
+        context['users'] = self.get_queryset().all()
+        return context
+
+    def message_user(self, message, level=messages.INFO, extra_tags='',
+                     fail_silently=False):
+        """Implementation of :py:meth:`django.contrib.admin.options.ModelAdmin.message_user`
+
+        Send message through messages framework
+        """
+        # TODO generalize this or check if implementation in ModelAdmin is
+        # useable here
+        messages.add_message(self.request, level, message, extra_tags=extra_tags,
+                             fail_silently=fail_silently)

--- a/readthedocs/templates/core/email/common.html
+++ b/readthedocs/templates/core/email/common.html
@@ -1,1 +1,3 @@
 {% extends 'core/email/base.html' %}
+
+{% block content %}<p>{{ content|safe }}</p>{% endblock %}

--- a/readthedocs/templates/core/email/common.html
+++ b/readthedocs/templates/core/email/common.html
@@ -1,3 +1,3 @@
 {% extends 'core/email/base.html' %}
 
-{% block content %}<p>{{ content|safe }}</p>{% endblock %}
+{% block content %}{{ content|safe }}{% endblock %}

--- a/readthedocs/templates/core/email/common.txt
+++ b/readthedocs/templates/core/email/common.txt
@@ -1,1 +1,3 @@
 {% extends 'core/email/base.txt' %}
+
+{% block content %}{{ content|safe }}{% endblock %}

--- a/readthedocs/templates/core/email/common.txt
+++ b/readthedocs/templates/core/email/common.txt
@@ -1,3 +1,3 @@
 {% extends 'core/email/base.txt' %}
 
-{% block content %}{{ content|safe }}{% endblock %}
+{% block content %}{{ content|striptags }}{% endblock %}

--- a/readthedocs/templates/core/send_email_form.html
+++ b/readthedocs/templates/core/send_email_form.html
@@ -12,9 +12,18 @@
   </p>
 
   <ul>
-    {% for user in users %}
+    {% for user in users|slice:":20" %}
       <li>{{ user.email }} ({{ user }})</li>
     {% endfor %}
+    {% with extra_users=users|slice:"20:" %}
+      {% if extra_users|length > 0 %}
+        <li>
+          {% blocktrans with count=extra_users|length %}
+            And {{ count }} other users...
+          {% endblocktrans %}
+        </li>
+      {% endif %}
+    {% endwith %}
   </ul>
 
   <p>

--- a/readthedocs/templates/core/send_email_form.html
+++ b/readthedocs/templates/core/send_email_form.html
@@ -1,0 +1,32 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+
+  <h3>{% trans 'Send Email' %}</h3>
+
+  <p>
+    {% blocktrans %}
+      An email message will be sent to the following email addresses:
+    {% endblocktrans %}
+  </p>
+
+  <ul>
+    {% for user in users %}
+      <li>{{ user.email }} ({{ user }})</li>
+    {% endfor %}
+  </ul>
+
+  <p>
+    {% blocktrans %}
+      Specify the email content you wish to send:
+    {% endblocktrans %}
+  </p>
+
+  <form method="post" action="">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="hidden" name="action" value="send_email" />
+    <input type="submit" name="send" value="{% trans 'Send Messages' %}" />
+  </form>
+{% endblock %}


### PR DESCRIPTION
This adds a generic option for sending emails to users. The form view will
accept a queryset returning users and will display an email form asking for
subject and body input. Currently, nothing is templated, it is only passed
in to the base email template as a string.

This also breaks out sending email into a task, as more than a 100 outbound
emails could timeout the send request.

Note: this has already been hotfix applied to the `rel` and 'relcorp` branches.

Refs #2148