### PR TITLE
Reference PRODUCTION_DOMAIN for uri passed to email templates

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -120,8 +120,6 @@ def send_email(recipient, subject, template, template_html, context=None,
     """
     if context is None:
         context = {}
-    if request:
-        scheme = 'https' if request.is_secure() else 'http'
-        context['uri'] = '{scheme}://{host}'.format(scheme=scheme,
-                                                    host=request.get_host())
+    context['uri'] = '{scheme}://{host}'.format(
+        scheme='https', host=settings.PRODUCTION_DOMAIN)
     send_email_task.delay(recipient, subject, template, template_html, context)


### PR DESCRIPTION
I don't believe there was a good reason for using `request.get_host`. This drops
that for `PRODUCTION_DOMAIN` settings, forcing https as well.