### PR TITLE
Drop implied prefix on project build queue name

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -102,7 +102,7 @@ def trigger_build(project, version=None, record=True, force=False, basic=False):
 
     options = {}
     if project.build_queue:
-        options['queue'] = 'build-{0}'.format(project.build_queue)
+        options['queue'] = project.build_queue
 
     update_docs.apply_async(kwargs=kwargs, **options)
 

--- a/readthedocs/projects/migrations/0016_build-queue-name.py
+++ b/readthedocs/projects/migrations/0016_build-queue-name.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def update_build_queue(apps, schema):
+    """Update project build queue to include the previously implied build- prefix"""
+    Project = apps.get_model("projects", "Project")
+    for project in Project.objects.all():
+        if project.build_queue is not None:
+            if not project.build_queue.startswith('build-'):
+                project.build_queue = 'build-{0}'.format(project.build_queue)
+                project.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0015_add_project_allow_promos'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_build_queue),
+    ]


### PR DESCRIPTION
We shouldn't be as clever about build queue names. I got tripped up wondering
why builds weren't triggering on the build queue I specified. This migrates
projects to drop the build- prefix, updating projects that expect an implied
prefix.