### PR TITLE
Honor MkDocs configured theme, while keeping 'readthedocs' as the default

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -27,6 +27,7 @@ class BaseMkdocs(BaseBuilder):
             self.version.project.checkout_path(self.version.slug),
             self.build_dir)
         self.root_path = self.version.project.checkout_path(self.version.slug)
+        self.theme = 'readthedocs'
 
     def append_conf(self, **kwargs):
         """
@@ -88,6 +89,9 @@ class BaseMkdocs(BaseBuilder):
         if 'theme_dir' not in user_config and self.use_theme:
             user_config['theme_dir'] = TEMPLATE_DIR
 
+        if 'theme' in user_config:
+            self.theme = user_config['theme']
+
         yaml.dump(
             user_config,
             open(os.path.join(self.root_path, 'mkdocs.yml'), 'w')
@@ -101,7 +105,7 @@ class BaseMkdocs(BaseBuilder):
             'version': self.version.slug,
             'language': self.version.project.language,
             'page': None,
-            'theme': "readthedocs",
+            'theme': self.theme,
             'builder': "mkdocs",
             'docroot': docs_dir,
             'source_suffix': ".md",
@@ -153,7 +157,7 @@ READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
             '--site-dir', self.build_dir,
         ]
         if self.use_theme:
-            build_command.extend(['--theme', 'readthedocs'])
+            build_command.extend(['--theme', self.theme])
         cmd_ret = self.run(
             *build_command,
             cwd=checkout_path,


### PR DESCRIPTION
This is meant to solve #978, i.e. honoring a MkDocs theme set in `mkdocs.yml` while keeping `readthedocs` as default theme if none is specified.

Let me know if there's any obvious concerns I didn't address, and also whether there's any tests I need to write (I couldn't find any regarding themes).
