### PR TITLE
Redirect .../index.html links from Sphinx HTMLDir

### DIFF
--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -129,14 +129,15 @@ class Redirect(models.Model):
                 return cut_path
 
     def redirect_sphinx_html(self, path, language=None, version_slug=None):
-        if path.endswith('/'):
-            log.debug('Redirecting %s' % self)
-            path = path[1:]  # Strip leading slash.
-            to = re.sub('/$', '.html', path)
-            return self.get_full_path(
-                filename=to,
-                language=language,
-                version_slug=version_slug)
+        for ending in ['/', '/index.html']:
+            if path.endswith(ending):
+                log.debug('Redirecting %s' % self)
+                path = path[1:]  # Strip leading slash.
+                to = re.sub(ending + '$', '.html', path)
+                return self.get_full_path(
+                    filename=to,
+                    language=language,
+                    version_slug=version_slug)
 
     def redirect_sphinx_htmldir(self, path, language=None, version_slug=None):
         if path.endswith('.html'):

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -197,6 +197,15 @@ class RedirectAppTests(TestCase):
             r['Location'], 'http://pip.readthedocs.org/en/latest/faq.html')
 
     @override_settings(USE_SUBDOMAIN=True, PYTHON_MEDIA=True)
+    def test_redirect_html_index(self):
+        Redirect.objects.create(
+            project=self.pip, redirect_type='sphinx_html')
+        r = self.client.get('/en/latest/faq/index.html', HTTP_HOST='pip.readthedocs.org')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'http://pip.readthedocs.org/en/latest/faq.html')
+
+    @override_settings(USE_SUBDOMAIN=True, PYTHON_MEDIA=True)
     def test_redirect_htmldir(self):
         Redirect.objects.create(
             project=self.pip, redirect_type='sphinx_htmldir')


### PR DESCRIPTION
We recently switched from a Sphinx HTMLDir-style layout to Sphinx HTML. The redirect we have in place handles links of the form http://clearwater.readthedocs.io/en/stable/Clearwater_SNMP_Statistics/, but not http://clearwater.readthedocs.io/en/stable/Clearwater_SNMP_Statistics/index.html (which used to work, and we have a lot of now-broken links in that format).

This PR makes the latter style of link redirect correctly. I was worried that it would affect links like http://clearwater.readthedocs.io/en/stable/index.html (redirecting to http://clearwater.readthedocs.io/en/stable.html), but I checked and get_redirect_response is only called from the 404 handler at https://github.com/rtfd/readthedocs.org/blob/a3e5cf3134c5db089d30451fdd89f77a2ad354a1/readthedocs/core/views/__init__.py#L123, so it won't spuriously redirect pages that otherwise work.