### PR TITLE
Update pip and venv

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,6 +1,6 @@
 # Base packages
-pip==8.0.2
-virtualenv==14.0.5
+pip==8.1.1
+virtualenv==15.0.1
 docutils==0.11
 Sphinx==1.3.5
 Pygments==2.0.2


### PR DESCRIPTION
I'm seeing some problems with pip 8.0.2 where pip explodes spectacularly with nested requirements.txt files. Pip complains that there is a double definition of a requirement:

```
Double requirement given: coverage==3.7.1 (from -r requirements/tests.txt (line 4)) (already in coverage==3.7.1 (from -r requirements/tests.txt (line 4)), name='coverage')
```

This is fixed in later versions of Pip. Thus, I'm proposing this pull request to update pip and the related virtualenv requirements.

Substantially similar to #1979.