### PR TITLE
Don't download when building the base virtualenv

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -84,7 +84,6 @@ class Virtualenv(PythonEnvironment):
 
     def setup_base(self):
         site_packages = '--no-site-packages'
-        no_download = '--no-download'
         if self.config.use_system_site_packages:
             site_packages = '--system-site-packages'
         env_path = self.venv_path()
@@ -92,7 +91,7 @@ class Virtualenv(PythonEnvironment):
             self.config.python_interpreter,
             '-mvirtualenv',
             site_packages,
-            no_download,
+            '--no-download',
             env_path,
             bin_path=None,  # Don't use virtualenv bin that doesn't exist yet
         )

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -84,6 +84,7 @@ class Virtualenv(PythonEnvironment):
 
     def setup_base(self):
         site_packages = '--no-site-packages'
+        no_download = '--no-download'
         if self.config.use_system_site_packages:
             site_packages = '--system-site-packages'
         env_path = self.venv_path()
@@ -91,6 +92,7 @@ class Virtualenv(PythonEnvironment):
             self.config.python_interpreter,
             '-mvirtualenv',
             site_packages,
+            no_download,
             env_path,
             bin_path=None,  # Don't use virtualenv bin that doesn't exist yet
         )


### PR DESCRIPTION
Currently, when building the virtualenv base for a project, virtualenv
will always try to download the latest packages (pip, setuptools..),
this may cause problem if the building requires a specific version of
package like pip==8.1.1, and the installed version may be > 8.1.1.

This patch adds an option --no-download in the virtualenv base build
command.