### PR TITLE
Mercurial no longer needed

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -31,7 +31,6 @@ git+https://github.com/pennersr/django-allauth.git@d869aff9#egg=django-allauth
 dnspython==1.11.0
 
 # VCS
-mercurial==2.6.3
 httplib2==0.7.7
 
 # Search


### PR DESCRIPTION
Inclusion broke install on Windows 10. Tested after removal.