### PR TITLE
Specify project id when get version in serve_docs

### DIFF
--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -138,7 +138,8 @@ def serve_docs(request, project, subproject,
     if not version_slug:
         version_slug = project.get_default_version()
     try:
-        version = project.versions.public(request.user).get(slug=version_slug)
+        version = project.versions.public(request.user).get(
+            slug=version_slug, project_id=project.id)
     except Version.DoesNotExist:
         # Properly raise a 404 if the version doesn't exist & a 401 if it does
         if project.versions.filter(slug=version_slug).exists():


### PR DESCRIPTION
In some cases(I didn't find the exact reason yet :<), the version get method in serve_docs
will raise MultipleObjectsReturned exception. Make the version query precise and return
the right result by specifying project id.

The exact exception log below:
Internal Server Error: /docs/test/en/latest/
Traceback (most recent call last):
  File "/docs/rtd/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/docs/rtd/checkouts/readthedocs.org/readthedocs/core/views/serve.py", line 84, in inner_view
    return view_func(request, project=project, *args, **kwargs)
  File "/docs/rtd/checkouts/readthedocs.org/readthedocs/core/views/serve.py", line 63, in inner_view
    return view_func(request, subproject=subproject, *args, **kwargs)
  File "/docs/rtd/checkouts/readthedocs.org/readthedocs/core/views/serve.py", line 143, in serve_docs
    version = project.versions.public(request.user).get(slug=version_slug)
  File "/docs/rtd/lib/python2.7/site-packages/django/db/models/query.py", line 338, in get
    (self.model._meta.object_name, num)
MultipleObjectsReturned: get() returned more than one Version -- it returned 2!