### PR TITLE
This fixes a bug where we weren't locking the Python env.

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -297,11 +297,15 @@ class UpdateDocsTask(Task):
         """
         self.build_env.update_build(state=BUILD_STATE_INSTALLING)
 
-        self.python_env.delete_existing_build_dir()
-        self.python_env.setup_base()
-        self.python_env.install_core_requirements()
-        self.python_env.install_user_requirements()
-        self.python_env.install_package()
+        with self.project.repo_nonblockinglock(
+                version=self.version,
+                max_lock_age=getattr(settings, 'REPO_LOCK_SECONDS', 30)):
+
+            self.python_env.delete_existing_build_dir()
+            self.python_env.setup_base()
+            self.python_env.install_core_requirements()
+            self.python_env.install_user_requirements()
+            self.python_env.install_package()
 
     def build_docs(self):
         """Wrapper to all build functions


### PR DESCRIPTION
This lead to the `Text File Busy` errors,
because we were trying to create the virtualenv while another process was running.
Instead of this throwing a "version locked" error and retrying,
it was just failing because it was never checking for a lock properly.

Fixes #2229 