### PR TITLE
use mkdocs builtin search.html

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/mkdocs.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/mkdocs.js
@@ -27,7 +27,9 @@ function init() {
           value: 'file'
       }).appendTo('#rtd-search-form');
 
-      $("#rtd-search-form").prop("action", rtd.api_host + "/search/");
+      var search_url = window.location.protocol + "//" + window.location.hostname +
+                       "/" + rtd.language + "/" + rtd.version + "/search.html";
+      $("#rtd-search-form").prop("action", search_url);
 
       // Apply stickynav to mkdocs builds
       var nav_bar = $('nav.wy-nav-side:first'),

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -124,8 +124,13 @@ class BaseMkdocs(BaseBuilder):
         data_file = open(os.path.join(self.root_path, docs_dir, 'readthedocs-data.js'), 'w+')
         data_file.write(data_string)
         data_file.write('''
-READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
-    0, mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix));
+//mkdocs doesn't expose this var for non-content-bearing pages (such as search.html)
+if(typeof mkdocs_page_input_path !== "undefined")
+{
+    READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
+        0, mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix));
+}
+//else, ["page"] will be null
 ''')
         data_file.close()
 


### PR DESCRIPTION
Currently, mkdocs projects have a search-box action of `https://readthedocs.org/search/`, which has been reported as inoperative in #1088 (and others). This PR changes this action to use the mkdocs builtin `search.html` page.

Also, in the process of making this patch, I found that mkdocs doesn't expose the `mkdocs_page_input_path` variable on non-content-bearing pages (such as `search.html`). Thus, I have placed a guard around it, to prevent it from `ReferenceError`ing while searching.
