### PR TITLE
Fix AttributeError error at /api/v1/file/search/

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,8 +8,8 @@ mkdocs==0.14.0
 readthedocs-build==2.0.5
 django==1.8.3
 
-git+https://github.com/django-tastypie/django-tastypie.git@1e1aff3dd4dcd21669e9c68bd7681253b286b856#egg=django-tastypie
-django-haystack==2.1.0
+django-tastypie==0.12.2
+django-haystack==2.5.0
 celery-haystack==0.7.2
 django-guardian==1.3.0
 django-extensions==1.3.8


### PR DESCRIPTION
Currently, /api/v1/file/search/ is not working because
of https://github.com/django-haystack/django-haystack/issues/908

See https://github.com/rtfd/readthedocs.org/issues/2264 for a
complaint about the broken endpoint.

The problem has already been fixed in https://github.com/django-haystack/django-haystack/commit/49564861e432ec3c4b8d13d3d4ce8eda763d1308

I have just upgraded django-haystack and django-tastypie
dependencies to fix the problem.