### PR TITLE
Remove deprecated usages of URL features

### DIFF
--- a/readthedocs/bookmarks/urls.py
+++ b/readthedocs/bookmarks/urls.py
@@ -1,11 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from readthedocs.bookmarks.views import BookmarkListView
 from readthedocs.bookmarks.views import BookmarkAddView, BookmarkRemoveView
 from readthedocs.bookmarks.views import BookmarkExistsView
 
-urlpatterns = patterns(
-    # base view, flake8 complains if it is on the previous line.
-    'readthedocs.bookmarks.views',
+urlpatterns = [
     url(r'^$',
         BookmarkListView.as_view(),
         name='bookmark_list'),
@@ -25,4 +23,4 @@ urlpatterns = patterns(
     url(r'^exists/$',
         BookmarkExistsView.as_view(),
         name='bookmark_exists'),
-)
+]

--- a/readthedocs/builds/urls.py
+++ b/readthedocs/builds/urls.py
@@ -1,16 +1,16 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-from .views import BuildList, BuildDetail
+from .views import (
+    BuildList, BuildDetail, builds_redirect_detail, builds_redirect_list,
+)
 
 
-urlpatterns = patterns(
-    # base view, flake8 complains if it is on the previous line.
-    'readthedocs.builds.views',
+urlpatterns = [
     url(r'^(?P<project_slug>[-\w]+)/(?P<pk>\d+)/$',
-        'builds_redirect_detail',
+        builds_redirect_detail,
         name='old_builds_detail'),
 
     url(r'^(?P<project_slug>[-\w]+)/$',
-        'builds_redirect_list',
+        builds_redirect_list,
         name='old_builds_project_list'),
-)
+]

--- a/readthedocs/comments/urls.py
+++ b/readthedocs/comments/urls.py
@@ -1,30 +1,14 @@
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 
-urlpatterns = patterns(
-    # base view, flake8 complains if it is on the previous line.
-    '',
-    url(r'build',
-        'readthedocs.comments.views.build',
-        name='build'),
-    url(r'_has_node',
-        'readthedocs.comments.views.has_node',
-        name='has_node'),
-    url(r'_add_node',
-        'readthedocs.comments.views.add_node',
-        name='add_node'),
-    url(r'_update_node',
-        'readthedocs.comments.views.update_node',
-        name='update_node'),
-    url(r'_attach_comment',
-        'readthedocs.comments.views.attach_comment',
-        name='attach_comment'),
-    url(r'_get_metadata',
-        'readthedocs.comments.views.get_metadata',
-        name='get_metadata'),
-    url(r'_get_options',
-        'readthedocs.comments.views.get_options',
-        name='get_options'),
-    url(r'(?P<file>.*)',
-        'readthedocs.comments.views.serve_file',
-        name='serve_file'),
-)
+from readthedocs.comments import views
+
+urlpatterns = [
+    url(r'build', views.build, name='build'),
+    url(r'_has_node', views.has_node, name='has_node'),
+    url(r'_add_node', views.add_node, name='add_node'),
+    url(r'_update_node', views.update_node, name='update_node'),
+    url(r'_attach_comment', views.attach_comment, name='attach_comment'),
+    url(r'_get_metadata', views.get_metadata, name='get_metadata'),
+    url(r'_get_options', views.get_options, name='get_options'),
+    url(r'(?P<file>.*)', views.serve_file, name='serve_file'),
+]

--- a/readthedocs/core/urls/__init__.py
+++ b/readthedocs/core/urls/__init__.py
@@ -1,22 +1,24 @@
-from django.conf.urls import url, patterns
+from django.conf.urls import url
+
+from django_filters import views as django_filters_views
 
 from readthedocs.constants import pattern_opts
+from readthedocs.core import views
+from readthedocs.core.views import hooks, serve
 from readthedocs.builds.filters import VersionFilter
 from readthedocs.projects.feeds import LatestProjectsFeed, NewProjectsFeed
 from readthedocs.projects.filters import ProjectFilter
 
 
-docs_urls = patterns(
-    '',
-
+docs_urls = [
     url((r'^docs/(?P<project_slug>{project_slug})/page/'
          r'(?P<filename>{filename_slug})$'.format(**pattern_opts)),
-        'readthedocs.core.views.serve.redirect_page_with_filename',
+        serve.redirect_page_with_filename,
         name='docs_detail'),
 
     url((r'^docs/(?P<project_slug>{project_slug})/'
         r'(?:|projects/(?P<subproject_slug>{project_slug})/)$'.format(**pattern_opts)),
-        'readthedocs.core.views.serve.redirect_project_slug',
+        serve.redirect_project_slug,
         name='docs_detail'),
 
     url((r'^docs/(?P<project_slug>{project_slug})/'
@@ -24,41 +26,39 @@ docs_urls = patterns(
          r'(?P<lang_slug>{lang_slug})/'
          r'(?P<version_slug>{version_slug})/'
          r'(?P<filename>{filename_slug})'.format(**pattern_opts)),
-        'readthedocs.core.views.serve.serve_docs',
+        serve.serve_docs,
         name='docs_detail'),
-)
+]
 
 
-core_urls = patterns(
-    '',
+core_urls = [
     # Hooks
-    url(r'^github', 'readthedocs.core.views.hooks.github_build', name='github_build'),
-    url(r'^gitlab', 'readthedocs.core.views.hooks.gitlab_build', name='gitlab_build'),
-    url(r'^bitbucket', 'readthedocs.core.views.hooks.bitbucket_build', name='bitbucket_build'),
+    url(r'^github', hooks.github_build, name='github_build'),
+    url(r'^gitlab', hooks.gitlab_build, name='gitlab_build'),
+    url(r'^bitbucket', hooks.bitbucket_build, name='bitbucket_build'),
     url((r'^build/'
          r'(?P<project_id_or_slug>{project_slug})'.format(**pattern_opts)),
-        'readthedocs.core.views.hooks.generic_build',
+        hooks.generic_build,
         name='generic_build'),
     # Random other stuff
     url(r'^random/(?P<project_slug>{project_slug})'.format(**pattern_opts),
-        'readthedocs.core.views.random_page',
+        views.random_page,
         name='random_page'),
-    url(r'^random/$', 'readthedocs.core.views.random_page', name='random_page'),
-    url(r'^500/$', 'readthedocs.core.views.divide_by_zero', name='divide_by_zero'),
+    url(r'^random/$', views.random_page, name='random_page'),
+    url(r'^500/$', views.divide_by_zero, name='divide_by_zero'),
     url((r'^wipe/(?P<project_slug>{project_slug})/'
          r'(?P<version_slug>{version_slug})/$'.format(**pattern_opts)),
-        'readthedocs.core.views.wipe_version',
+        views.wipe_version,
         name='wipe_version'),
-)
+]
 
-deprecated_urls = patterns(
-    '',
+deprecated_urls = [
     url(r'^filter/version/$',
-        'django_filters.views.object_filter',
+        django_filters_views.object_filter,
         {'filter_class': VersionFilter, 'template_name': 'filter.html'},
         name='filter_version'),
     url(r'^filter/project/$',
-        'django_filters.views.object_filter',
+        django_filters_views.object_filter,
         {'filter_class': ProjectFilter, 'template_name': 'filter.html'},
         name='filter_project'),
 
@@ -68,4 +68,4 @@ deprecated_urls = patterns(
     url(r'^feeds/latest/$',
         LatestProjectsFeed(),
         name="latest_feed"),
-)
+]

--- a/readthedocs/core/urls/single_version.py
+++ b/readthedocs/core/urls/single_version.py
@@ -1,27 +1,26 @@
 from operator import add
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from django.conf.urls.static import static
 
 from readthedocs.constants import pattern_opts
+from readthedocs.core.views import serve
 
 handler500 = 'readthedocs.core.views.server_error'
 handler404 = 'readthedocs.core.views.server_error_404'
 
-single_version_urls = patterns(
-    '',  # base view, flake8 complains if it is on the previous line.
-
+single_version_urls = [
     url(r'^(?:|projects/(?P<subproject_slug>{project_slug})/)'
         r'page/(?P<filename>.*)$'.format(**pattern_opts),
-        'readthedocs.core.views.serve.redirect_page_with_filename',
+        serve.redirect_page_with_filename,
         name='docs_detail'),
 
     url((r'^(?:|projects/(?P<subproject_slug>{project_slug})/)'
          r'(?P<filename>{filename_slug})$'.format(**pattern_opts)),
-        'readthedocs.core.views.serve.serve_docs',
+        serve.serve_docs,
         name='docs_detail'),
-)
+]
 
 groups = [single_version_urls]
 
@@ -31,14 +30,13 @@ if getattr(settings, 'DEBUG', False):
 
 # Allow `/docs/<foo>` URL's when not using subdomains or during local dev
 if not getattr(settings, 'USE_SUBDOMAIN', False) or settings.DEBUG:
-    docs_url = patterns(
-        '',
+    docs_url = [
         url((r'^docs/(?P<project_slug>[-\w]+)/'
              r'(?:|projects/(?P<subproject_slug>{project_slug})/)'
              r'(?P<filename>{filename_slug})$'.format(**pattern_opts)),
-            'readthedocs.core.views.serve.serve_docs',
+            serve.serve_docs,
             name='docs_detail')
-    )
+    ]
     groups.insert(1, docs_url)
 
 

--- a/readthedocs/donate/urls.py
+++ b/readthedocs/donate/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 
 from .views import DonateCreateView
 from .views import DonateListView
@@ -6,11 +6,10 @@ from .views import DonateSuccessView
 from .views import click_proxy, view_proxy
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', DonateListView.as_view(), name='donate'),
     url(r'^contribute/$', DonateCreateView.as_view(), name='donate_add'),
     url(r'^contribute/thanks$', DonateSuccessView.as_view(), name='donate_success'),
     url(r'^view/(?P<promo_id>\d+)/(?P<hash>.+)/$', view_proxy, name='donate_view_proxy'),
     url(r'^click/(?P<promo_id>\d+)/(?P<hash>.+)/$', click_proxy, name='donate_click_proxy'),
-)
+]

--- a/readthedocs/gold/urls.py
+++ b/readthedocs/gold/urls.py
@@ -1,13 +1,12 @@
 """Gold subscription URLs"""
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 from readthedocs.gold import views
 from readthedocs.projects.constants import PROJECT_SLUG_REGEX
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', views.DetailGoldSubscription.as_view(), name='gold_detail'),
     url(r'^subscription/$', views.UpdateGoldSubscription.as_view(),
         name='gold_subscription'),
@@ -17,4 +16,4 @@ urlpatterns = patterns(
          .format(project_slug=PROJECT_SLUG_REGEX)),
         views.projects_remove,
         name='gold_projects_remove'),
-)
+]

--- a/readthedocs/profiles/urls/private.py
+++ b/readthedocs/profiles/urls/private.py
@@ -1,17 +1,18 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from readthedocs.core.forms import UserProfileForm
+from readthedocs.profiles import views
 
-urlpatterns = patterns('',
-                       url(r'^create/', 'readthedocs.profiles.views.create_profile',
-                           {
-                               'form_class': UserProfileForm,
-                           },
-                           name='profiles_profile_create'),
-                       url(r'^edit/', 'readthedocs.profiles.views.edit_profile',
-                           {
-                               'form_class': UserProfileForm,
-                               'template_name': 'profiles/private/edit_profile.html',
-                           },
-                           name='profiles_profile_edit'),
-                       )
+urlpatterns = [
+    url(r'^create/', views.create_profile,
+        {
+            'form_class': UserProfileForm,
+        },
+        name='profiles_profile_create'),
+    url(r'^edit/', views.edit_profile,
+        {
+            'form_class': UserProfileForm,
+            'template_name': 'profiles/private/edit_profile.html',
+        },
+        name='profiles_profile_edit'),
+]

--- a/readthedocs/profiles/urls/public.py
+++ b/readthedocs/profiles/urls/public.py
@@ -1,11 +1,11 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from readthedocs.profiles import views
 
 
-urlpatterns = patterns('',
-                       url(r'^(?P<username>[\w@.-]+)/$',
-                           views.profile_detail,
-                           {'template_name': 'profiles/public/profile_detail.html'},
-                           name='profiles_profile_detail'),
-                       )
+urlpatterns = [
+    url(r'^(?P<username>[\w@.-]+)/$',
+        views.profile_detail,
+        {'template_name': 'profiles/public/profile_detail.html'},
+        name='profiles_profile_detail'),
+]

--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -1,7 +1,8 @@
 """Project URLs for authenticated users"""
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
+from readthedocs.projects.views import private
 from readthedocs.projects.views.private import (
     ProjectDashboard, ImportView,
     ProjectUpdate, ProjectAdvancedUpdate,
@@ -10,9 +11,7 @@ from readthedocs.projects.views.private import (
 from readthedocs.projects.backends.views import ImportWizardView, ImportDemoView
 
 
-urlpatterns = patterns(
-    # base view, flake8 complains if it is on the previous line.
-    '',
+urlpatterns = [
     url(r'^$',
         ProjectDashboard.as_view(),
         name='projects_dashboard'),
@@ -31,11 +30,11 @@ urlpatterns = patterns(
         name='projects_import_demo'),
 
     url(r'^(?P<project_slug>[-\w]+)/$',
-        'readthedocs.projects.views.private.project_manage',
+        private.project_manage,
         name='projects_manage'),
 
     url(r'^(?P<project_slug>[-\w]+)/comments_moderation/$',
-        'readthedocs.projects.views.private.project_comments_moderation',
+        private.project_comments_moderation,
         name='projects_comments_moderation'),
 
     url(r'^(?P<project_slug>[-\w]+)/edit/$',
@@ -47,76 +46,75 @@ urlpatterns = patterns(
         name='projects_advanced'),
 
     url(r'^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/delete_html/$',
-        'readthedocs.projects.views.private.project_version_delete_html',
+        private.project_version_delete_html,
         name='project_version_delete_html'),
 
     url(r'^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/$',
-        'readthedocs.projects.views.private.project_version_detail',
+        private.project_version_detail,
         name='project_version_detail'),
 
     url(r'^(?P<project_slug>[-\w]+)/versions/$',
-        'readthedocs.projects.views.private.project_versions',
+        private.project_versions,
         name='projects_versions'),
 
     url(r'^(?P<project_slug>[-\w]+)/delete/$',
-        'readthedocs.projects.views.private.project_delete',
+        private.project_delete,
         name='projects_delete'),
 
     url(r'^(?P<project_slug>[-\w]+)/subprojects/delete/(?P<child_slug>[-\w]+)/$',  # noqa
-        'readthedocs.projects.views.private.project_subprojects_delete',
+        private.project_subprojects_delete,
         name='projects_subprojects_delete'),
 
     url(r'^(?P<project_slug>[-\w]+)/subprojects/$',
-        'readthedocs.projects.views.private.project_subprojects',
+        private.project_subprojects,
         name='projects_subprojects'),
 
     url(r'^(?P<project_slug>[-\w]+)/users/$',
-        'readthedocs.projects.views.private.project_users',
+        private.project_users,
         name='projects_users'),
 
     url(r'^(?P<project_slug>[-\w]+)/users/delete/$',
-        'readthedocs.projects.views.private.project_users_delete',
+        private.project_users_delete,
         name='projects_users_delete'),
 
     url(r'^(?P<project_slug>[-\w]+)/notifications/$',
-        'readthedocs.projects.views.private.project_notifications',
+        private.project_notifications,
         name='projects_notifications'),
 
     url(r'^(?P<project_slug>[-\w]+)/comments/$',
-        'readthedocs.projects.views.private.project_comments_settings',
+        private.project_comments_settings,
         name='projects_comments'),
 
     url(r'^(?P<project_slug>[-\w]+)/notifications/delete/$',
-        'readthedocs.projects.views.private.project_notifications_delete',
+        private.project_notifications_delete,
         name='projects_notification_delete'),
 
     url(r'^(?P<project_slug>[-\w]+)/translations/$',
-        'readthedocs.projects.views.private.project_translations',
+        private.project_translations,
         name='projects_translations'),
 
     url(r'^(?P<project_slug>[-\w]+)/translations/delete/(?P<child_slug>[-\w]+)/$',  # noqa
-        'readthedocs.projects.views.private.project_translations_delete',
+        private.project_translations_delete,
         name='projects_translations_delete'),
 
     url(r'^(?P<project_slug>[-\w]+)/redirects/$',
-        'readthedocs.projects.views.private.project_redirects',
+        private.project_redirects,
         name='projects_redirects'),
 
     url(r'^(?P<project_slug>[-\w]+)/redirects/delete/$',
-        'readthedocs.projects.views.private.project_redirects_delete',
+        private.project_redirects_delete,
         name='projects_redirects_delete'),
 
     url(r'^(?P<project_slug>[-\w]+)/resync_webhook/$',
-        'readthedocs.projects.views.private.project_resync_webhook',
+        private.project_resync_webhook,
         name='projects_resync_webhook'),
 
     url(r'^(?P<project_slug>[-\w]+)/advertising/$',
         ProjectAdvertisingUpdate.as_view(),
         name='projects_advertising'),
-)
+]
 
-domain_urls = patterns(
-    '',
+domain_urls = [
     url(r'^(?P<project_slug>[-\w]+)/domains/$',
         DomainList.as_view(),
         name='projects_domains'),
@@ -129,6 +127,6 @@ domain_urls = patterns(
     url(r'^(?P<project_slug>[-\w]+)/domains/(?P<domain_pk>[-\w]+)/delete/$',
         DomainDelete.as_view(),
         name='projects_domains_delete'),
-)
+]
 
 urlpatterns += domain_urls

--- a/readthedocs/projects/urls/public.py
+++ b/readthedocs/projects/urls/public.py
@@ -1,26 +1,25 @@
 """Project URLS for public users"""
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
+from readthedocs.projects.views import public
 from readthedocs.projects.views.public import ProjectIndex, ProjectDetailView
 
 from readthedocs.builds import views as build_views
 from readthedocs.constants import pattern_opts
 
 
-urlpatterns = patterns(
-    # base view, flake8 complains if it is on the previous line.
-    '',
+urlpatterns = [
     url(r'^$',
         ProjectIndex.as_view(),
         name='projects_list'),
 
     url(r'^search/autocomplete/$',
-        'readthedocs.projects.views.public.search_autocomplete',
+        public.search_autocomplete,
         name='search_autocomplete'),
 
     url(r'^autocomplete/version/(?P<project_slug>[-\w]+)/$',
-        'readthedocs.projects.views.public.version_autocomplete',
+        public.version_autocomplete,
         name='version_autocomplete'),
 
     url(r'^(?P<project_slug>{project_slug})/$'.format(**pattern_opts),
@@ -28,25 +27,25 @@ urlpatterns = patterns(
         name='projects_detail'),
 
     url(r'^(?P<project_slug>{project_slug})/downloads/$'.format(**pattern_opts),
-        'readthedocs.projects.views.public.project_downloads',
+        public.project_downloads,
         name='project_downloads'),
 
     url((r'^(?P<project_slug>{project_slug})/downloads/(?P<type_>[-\w]+)/'
          r'(?P<version_slug>{version_slug})/$'.format(**pattern_opts)),
-        'readthedocs.projects.views.public.project_download_media',
+        public.project_download_media,
         name='project_download_media'),
 
     url(r'^(?P<project_slug>{project_slug})/badge/$'.format(**pattern_opts),
-        'readthedocs.projects.views.public.project_badge',
+        public.project_badge,
         name='project_badge'),
 
     url((r'^(?P<project_slug>{project_slug})/tools/embed/$'
          .format(**pattern_opts)),
-        'readthedocs.projects.views.public.project_embed',
+        public.project_embed,
         name='project_embed'),
 
     url(r'^(?P<project_slug>{project_slug})/search/$'.format(**pattern_opts),
-        'readthedocs.projects.views.public.elastic_project_search',
+        public.elastic_project_search,
         name='elastic_project_search'),
 
     url((r'^(?P<project_slug>{project_slug})/builds/(?P<build_pk>\d+)/$'
@@ -61,15 +60,14 @@ urlpatterns = patterns(
 
     url((r'^(?P<project_slug>{project_slug})/autocomplete/file/$'
          .format(**pattern_opts)),
-        'readthedocs.projects.views.public.file_autocomplete',
+        public.file_autocomplete,
         name='file_autocomplete'),
 
     url(r'^(?P<project_slug>{project_slug})/versions/$'.format(**pattern_opts),
-        'readthedocs.projects.views.public.project_versions',
+        public.project_versions,
         name='project_version_list'),
 
     url(r'^tags/(?P<tag>[-\w]+)/$',
         ProjectIndex.as_view(),
         name='projects_tag_detail'),
-
-)
+]

--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 
 from rest_framework import routers
 
@@ -8,6 +8,10 @@ from .views.model_views import (BuildViewSet, BuildCommandViewSet,
                                 RemoteOrganizationViewSet,
                                 RemoteRepositoryViewSet)
 from readthedocs.comments.views import CommentViewSet
+from readthedocs.restapi import views
+from readthedocs.restapi.views import (
+    core_views, footer_views, search_views, task_views,
+)
 
 router = routers.DefaultRouter()
 router.register(r'build', BuildViewSet)
@@ -20,43 +24,38 @@ router.register(r'remote/org', RemoteOrganizationViewSet)
 router.register(r'remote/repo', RemoteRepositoryViewSet)
 router.register(r'comments', CommentViewSet, base_name="comments")
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^', include(router.urls)),
-)
+]
 
-function_urls = patterns(
-    '',
-    url(r'embed/', 'readthedocs.restapi.views.core_views.embed', name='embed'),
-    url(r'docurl/', 'readthedocs.restapi.views.core_views.docurl', name='docurl'),
-    url(r'cname/', 'readthedocs.restapi.views.core_views.cname', name='cname'),
-    url(r'footer_html/', 'readthedocs.restapi.views.footer_views.footer_html', name='footer_html'),
-)
+function_urls = [
+    url(r'embed/', core_views.embed, name='embed'),
+    url(r'docurl/', core_views.docurl, name='docurl'),
+    url(r'cname/', core_views.cname, name='cname'),
+    url(r'footer_html/', footer_views.footer_html, name='footer_html'),
+]
 
-search_urls = patterns(
-    '',
+search_urls = [
     url(r'index_search/',
-        'readthedocs.restapi.views.search_views.index_search',
+        search_views.index_search,
         name='index_search'),
-    url(r'search/$', 'readthedocs.restapi.views.search_views.search', name='api_search'),
+    url(r'search/$', views.search_views.search, name='api_search'),
     url(r'search/project/$',
-        'readthedocs.restapi.views.search_views.project_search',
+        search_views.project_search,
         name='api_project_search'),
     url(r'search/section/$',
-        'readthedocs.restapi.views.search_views.section_search',
+        search_views.section_search,
         name='api_section_search'),
-)
+]
 
-task_urls = patterns(
-    '',
+task_urls = [
     url(r'jobs/status/(?P<task_id>[^/]+)/',
-        'readthedocs.restapi.views.task_views.job_status',
+        task_views.job_status,
         name='api_job_status'),
     url(r'jobs/sync-remote-repositories/',
-        'readthedocs.restapi.views.task_views.sync_remote_repositories',
+        task_views.sync_remote_repositories,
         name='api_sync_remote_repositories'),
-)
-
+]
 
 urlpatterns += function_urls
 urlpatterns += search_urls

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -2,7 +2,7 @@
 
 from operator import add
 
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
@@ -14,6 +14,7 @@ from readthedocs.api.base import (ProjectResource, UserResource,
                                   VersionResource, FileResource)
 from readthedocs.core.urls import docs_urls, core_urls, deprecated_urls
 from readthedocs.core.views import HomepageView, SupportView
+from readthedocs.search import views as search_views
 
 
 v1_api = Api(api_name='v1')
@@ -27,60 +28,52 @@ admin.autodiscover()
 handler500 = 'readthedocs.core.views.server_error'
 handler404 = 'readthedocs.core.views.server_error_404'
 
-basic_urls = patterns(
-    '',  # base view, flake8 complains if it is on the previous line.
+basic_urls = [
     url(r'^$', HomepageView.as_view(), name='homepage'),
     url(r'^support/', SupportView.as_view(), name='support'),
     url(r'^security/', TemplateView.as_view(template_name='security.html')),
-)
+]
 
-rtd_urls = patterns(
-    '',
+rtd_urls = [
     url(r'^bookmarks/', include('readthedocs.bookmarks.urls')),
-    url(r'^search/$', 'readthedocs.search.views.elastic_search', name='search'),
+    url(r'^search/$', search_views.elastic_search, name='search'),
     url(r'^dashboard/', include('readthedocs.projects.urls.private')),
     url(r'^profiles/', include('readthedocs.profiles.urls.public')),
     url(r'^accounts/', include('readthedocs.profiles.urls.private')),
     url(r'^accounts/', include('allauth.urls')),
     # For redirects
     url(r'^builds/', include('readthedocs.builds.urls')),
-)
+]
 
-project_urls = patterns(
-    '',
+project_urls = [
     url(r'^projects/', include('readthedocs.projects.urls.public')),
-)
+]
 
-api_urls = patterns(
-    '',
+api_urls = [
     url(r'^api/', include(v1_api.urls)),
     url(r'^api/v2/', include('readthedocs.restapi.urls')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^websupport/', include('readthedocs.comments.urls')),
-)
+]
 
-i18n_urls = patterns(
-    '',
+i18n_urls = [
     url(r'^i18n/', include('django.conf.urls.i18n')),
-)
+]
 
-admin_urls = patterns(
-    '',
+admin_urls = [
     url(r'^admin/', include(admin.site.urls)),
-)
+]
 
-money_urls = patterns(
-    '',
+money_urls = [
     url(r'^sustainability/', include('readthedocs.donate.urls')),
     url(r'^accounts/gold/', include('readthedocs.gold.urls')),
-)
+]
 
 debug_urls = add(
-    patterns(
-        '',  # base view, flake8 complains if it is on the previous line.
+    [
         url('style-catalog/$',
             TemplateView.as_view(template_name='style_catalog.html')),
-    ),
+    ],
     static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 )
 


### PR DESCRIPTION
* patterns() has been deprecated
* Passing 'path.to.view.function' to url() has also
  been deprecated