### PR TITLE
Properly check for a cloning failure and report error.

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -262,7 +262,6 @@ class BuildEnvironment(object):
     :param build: Build instance
     :param record: Record status of build object
     :param environment: shell environment variables
-    :param report_build_success: update build if successful
     """
 
     def __init__(self, project=None, version=None, build=None, record=True,

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -266,13 +266,12 @@ class BuildEnvironment(object):
     """
 
     def __init__(self, project=None, version=None, build=None, record=True,
-                 environment=None, report_build_success=True):
+                 environment=None):
         self.project = project
         self.version = version
         self.build = build
         self.record = record
         self.environment = environment or {}
-        self.report_build_success = report_build_success
 
         self.commands = []
         self.failure = None
@@ -384,8 +383,7 @@ class BuildEnvironment(object):
         want to record successful builds yet (if we are running setup commands
         for the build)
         """
-        if not self.record or (state == BUILD_STATE_FINISHED and
-                               not self.report_build_success):
+        if not self.record:
             return None
 
         self.build['project'] = self.project.pk

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -527,9 +527,7 @@ class DockerEnvironment(BuildEnvironment):
                           version=self.version.slug,
                           msg="Couldn't remove container"),
                       exc_info=True)
-
         self.container = None
-        self.update_build(state=BUILD_STATE_FINISHED)
         log.info(LOG_TEMPLATE
                  .format(project=self.project.slug,
                          version=self.version.slug,

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -373,7 +373,7 @@ class BuildEnvironment(object):
     def done(self):
         '''Is build in finished state'''
         return (self.build is not None and
-                self.build.get('state') == BUILD_STATE_FINISHED)
+                self.build['state'] == BUILD_STATE_FINISHED)
 
     def update_build(self, state=None):
         """Record a build by hitting the API
@@ -528,6 +528,7 @@ class DockerEnvironment(BuildEnvironment):
                           msg="Couldn't remove container"),
                       exc_info=True)
         self.container = None
+        self.build['state'] = BUILD_STATE_FINISHED
         log.info(LOG_TEMPLATE
                  .format(project=self.project.slug,
                          version=self.version.slug,

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -373,7 +373,7 @@ class BuildEnvironment(object):
     def done(self):
         '''Is build in finished state'''
         return (self.build is not None and
-                self.build['state'] == BUILD_STATE_FINISHED)
+                self.build.get('state') == BUILD_STATE_FINISHED)
 
     def update_build(self, state=None):
         """Record a build by hitting the API

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -241,7 +241,7 @@ class UpdateDocsTask(Task):
                                     msg=str(e)),
                 exc_info=True,
             )
-            raise BuildEnvironmentError('Failed to import project: %s' % str(e),
+            raise BuildEnvironmentError('Failed to import project: %s' % e,
                                         status_code=404)
 
     def get_env_vars(self):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -116,8 +116,7 @@ class UpdateDocsTask(Task):
 
         env_cls = LocalEnvironment
         self.setup_env = env_cls(project=self.project, version=self.version,
-                                 build=self.build, record=record,
-                                 report_build_success=False)
+                                 build=self.build, record=record)
 
         # Environment used for code checkout & initial configuration reading
         with self.setup_env:
@@ -135,7 +134,7 @@ class UpdateDocsTask(Task):
 
             self.config = load_yaml_config(version=self.version)
 
-        if self.setup_env.failed or self.config is None:
+        if self.setup_env.failure or self.config is None:
             self.send_notifications()
             self.setup_env.update_build(state=BUILD_STATE_FINISHED)
             return None
@@ -242,7 +241,7 @@ class UpdateDocsTask(Task):
                                     msg=str(e)),
                 exc_info=True,
             )
-            raise BuildEnvironmentError('Failed to import project',
+            raise BuildEnvironmentError('Failed to import project: %s' % str(e),
                                         status_code=404)
 
     def get_env_vars(self):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -186,6 +186,8 @@ class UpdateDocsTask(Task):
             self.send_notifications()
         build_complete.send(sender=Build, build=self.build_env.build)
 
+        self.build_env.update_build(state=BUILD_STATE_FINISHED)
+
     @staticmethod
     def get_project(project_pk):
         """Get project from API"""


### PR DESCRIPTION
This also adds the proper import failure to the exception that gets shown to the user.
This also removes the ``report_build_success``, which seems redundant and not necessary. 