### PR TITLE
Delete djangodocs extension

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -1,6 +1,0 @@
-def setup(app):
-    app.add_crossref_type(
-        directivename="setting",
-        rolename="setting",
-        indextemplate="pair: %s; setting",
-    )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,21 +5,10 @@ import sys
 
 from recommonmark.parser import CommonMarkParser
 
-sys.path.insert(0, os.path.abspath('..'))
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "readthedocs.settings.dev")
-
-from django.conf import settings
-
-import django
-django.setup()
-
-
-sys.path.append(os.path.abspath('_ext'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.httpdomain',
-    'djangodocs',
 ]
 templates_path = ['_templates']
 

--- a/docs/custom_installs/customization.rst
+++ b/docs/custom_installs/customization.rst
@@ -12,7 +12,7 @@ If you put a file named ``local_settings.py`` in the ``readthedocs/settings`` di
 Adding your own title to pages
 ------------------------------
 
-This requires 2 parts of setup. First, you need to add a custom :setting:`TEMPLATE_DIRS` setting that points at your template overrides. Then, in those template overrides you have to insert your logo where the normal RTD logo goes.
+This requires 2 parts of setup. First, you need to add a custom ``TEMPLATE_DIRS`` setting that points at your template overrides. Then, in those template overrides you have to insert your logo where the normal RTD logo goes.
 
 .. note:: This works for any setting you wish to change.
 


### PR DESCRIPTION
It was added in d8fea873ca6f1a5197a02fed092e2434a139e6b7
but:

* only used in one place in the whole documentation:
  https://docs.readthedocs.io/en/latest/custom_installs/customization.html
* and it doesn't work

It would be nice to remove it to make conf.py simpler.