### PR TITLE
Add build complete signal

### DIFF
--- a/readthedocs/builds/signals.py
+++ b/readthedocs/builds/signals.py
@@ -1,0 +1,6 @@
+"""Build signals"""
+
+import django.dispatch
+
+
+build_complete = django.dispatch.Signal(providing_args=['build'])

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -25,6 +25,7 @@ from readthedocs.builds.constants import (LATEST,
                                           BUILD_STATE_BUILDING,
                                           BUILD_STATE_FINISHED)
 from readthedocs.builds.models import Build, Version
+from readthedocs.builds.signals import build_complete
 from readthedocs.core.utils import send_email, run_on_app_servers, broadcast
 from readthedocs.core.symlink import PublicSymlink, PrivateSymlink
 from readthedocs.cdn.purge import purge
@@ -184,6 +185,7 @@ class UpdateDocsTask(Task):
 
         if self.build_env.failed:
             self.send_notifications()
+        build_complete.send(sender=Build, build=self.build_env.build)
 
     @staticmethod
     def get_project(project_pk):


### PR DESCRIPTION
This will be used to accumulate stats on finished build state. There is already
a projects.signals.after_build, but I'm not 100% it isn't being used, and passing
the version, as the signal expects, doesn't make sense if we are inspecting builds