### PR TITLE
Add field for domain https

### DIFF
--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -1,13 +1,14 @@
 """Django administration interface for `projects.models`"""
 
-from readthedocs.builds.models import Version
 from django.contrib import admin
-from readthedocs.redirects.models import Redirect
-from .models import (Project, ImportedFile,
-                     ProjectRelationship, EmailHook, WebHook, Domain)
 from guardian.admin import GuardedModelAdmin
 
+from readthedocs.builds.models import Version
+from readthedocs.redirects.models import Redirect
 from readthedocs.donate.models import ProjectImpressions
+
+from .models import (Project, ImportedFile,
+                     ProjectRelationship, EmailHook, WebHook, Domain)
 
 
 class ProjectRelationshipInline(admin.TabularInline):
@@ -74,11 +75,12 @@ class ImportedFileAdmin(admin.ModelAdmin):
 
 
 class DomainAdmin(admin.ModelAdmin):
-    list_display = ('domain', 'project', 'count')
+    list_display = ('domain', 'project', 'https', 'count')
     search_fields = ('domain', 'project__slug')
     raw_id_fields = ('project',)
     list_filter = ('canonical',)
     model = Domain
+
 
 admin.site.register(Project, ProjectAdmin)
 admin.site.register(ImportedFile, ImportedFileAdmin)

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -488,7 +488,7 @@ class DomainForm(forms.ModelForm):
 
     class Meta:
         model = Domain
-        exclude = ['machine', 'cname', 'count']
+        exclude = ['machine', 'cname', 'count', 'https']
 
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop('project', None)

--- a/readthedocs/projects/migrations/0017_add_domain_https.py
+++ b/readthedocs/projects/migrations/0017_add_domain_https.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='domain',
             name='https',
-            field=models.BooleanField(default=False, help_text='Use HTTPS', verbose_name='HTTPS', editable=False),
+            field=models.BooleanField(default=False, help_text='SSL is enabled for this domain', verbose_name='Use HTTPS'),
         ),
     ]

--- a/readthedocs/projects/migrations/0017_add_domain_https.py
+++ b/readthedocs/projects/migrations/0017_add_domain_https.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0016_build-queue-name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='domain',
+            name='https',
+            field=models.BooleanField(default=False, help_text='Use HTTPS', verbose_name='HTTPS', editable=False),
+        ),
+    ]

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -891,6 +891,8 @@ class Domain(models.Model):
         help_text=_('This Domain is the primary one where the documentation is served from.')
     )
     count = models.IntegerField(default=0, help_text=_('Number of times this domain has been hit.'))
+    https = models.BooleanField(_('HTTPS'), default=False, editable=False,
+                                help_text=_('Use HTTPS'))
 
     objects = RelatedProjectManager()
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -890,9 +890,12 @@ class Domain(models.Model):
         default=False,
         help_text=_('This Domain is the primary one where the documentation is served from.')
     )
+    https = models.BooleanField(
+        _('Use HTTPS'),
+        default=False,
+        help_text=_('SSL is enabled for this domain')
+    )
     count = models.IntegerField(default=0, help_text=_('Number of times this domain has been hit.'))
-    https = models.BooleanField(_('HTTPS'), default=False, editable=False,
-                                help_text=_('Use HTTPS'))
 
     objects = RelatedProjectManager()
 


### PR DESCRIPTION
This is an admin only option to designate a domain that has a custom SSL
certificate installed on the production stack.