### PR TITLE
Add a mixin class for dashboard views on models with project relations

### DIFF
--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -1,0 +1,47 @@
+"""Mixin classes for project views"""
+
+from django.shortcuts import get_object_or_404
+
+from readthedocs.projects.models import Project
+
+
+class ProjectRelationMixin(object):
+
+    """Mixin class for constructing model views for project dashboard
+
+    This mixin class is used for model views on models that have a relation
+    to the :py:cls:`Project` model.
+
+    :cvar project_lookup_url_kwarg: URL kwarg to use in project lookup
+    :cvar project_lookup_field: Query field for project relation
+    :cvar project_context_object_name: Context object name for project
+    """
+
+    project_lookup_url_kwarg = 'project_slug'
+    project_lookup_field = 'project'
+    project_context_object_name = 'project'
+
+    def get_project_queryset(self):
+        return Project.objects.for_admin_user(user=self.request.user)
+
+    def get_project(self):
+        if self.project_lookup_url_kwarg not in self.kwargs:
+            return None
+        return get_object_or_404(
+            self.get_project_queryset(),
+            slug=self.kwargs[self.project_lookup_url_kwarg]
+        )
+
+    def get_queryset(self):
+        return self.model.objects.filter(
+            **{self.project_lookup_field: self.get_project()}
+        )
+
+    def get_context_data(self, **kwargs):
+        context = {}
+        try:
+            context = super(ProjectRelationMixin, self).get_context_data(**kwargs)
+        except AttributeError:
+            pass
+        context[self.project_context_object_name] = self.get_project()
+        return context

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -38,10 +38,6 @@ class ProjectRelationMixin(object):
         )
 
     def get_context_data(self, **kwargs):
-        context = {}
-        try:
-            context = super(ProjectRelationMixin, self).get_context_data(**kwargs)
-        except AttributeError:
-            pass
+        context = super(ProjectRelationMixin, self).get_context_data(**kwargs)
         context[self.project_context_object_name] = self.get_project()
         return context

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -4,6 +4,7 @@ from mock import patch
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.contrib.messages import constants as message_const
+from django.views.generic.base import ContextMixin
 from django_dynamic_fixture import get
 from django_dynamic_fixture import new
 
@@ -342,16 +343,15 @@ class TestPrivateMixins(MockBuildTestCase):
     def test_project_relation(self):
         """Class using project relation mixin class"""
 
-        class FoobarView(ProjectRelationMixin):
+        class FoobarView(ProjectRelationMixin, ContextMixin):
             model = Domain
 
             def get_project_queryset(self):
                 # Don't test this as a view with a request.user
                 return Project.objects.all()
 
-
         view = FoobarView()
         view.kwargs = {'project_slug': 'kong'}
         self.assertEqual(view.get_project(), self.project)
         self.assertEqual(view.get_queryset().first(), self.domain)
-        self.assertEqual(view.get_context_data(), {'project': self.project})
+        self.assertEqual(view.get_context_data()['project'], self.project)


### PR DESCRIPTION
As we overhaul the project admin dashboard, a good amount of code can be cleaned
up by using a CBV rather than repeating the view code like is currently used. I
had a need for this outside this code base, but implemented it here instead.

Views would look like:

    class DomainMixin(ProjectRelationMixin):
        model = Domain
        lookup_url_kwarg = 'pk'

    class ListDomainView(DomainMixin, ListView):
        pass

    class DetailDomainView(DomainMixin, DetailView):
        pass

Views would then have access to a `project` and `domains` in template context
data.