### PR TITLE
Add support for Pip's extra dependencies in YAML config.

### DIFF
--- a/docs/yaml-config.rst
+++ b/docs/yaml-config.rst
@@ -144,6 +144,56 @@ documentation.
 
 		conf_file: project2/docs/conf.py
 
+python.extra_requirements
+`````````````````````````
+
+* Default: ``[]``
+* Type: List
+
+List of `extra requirements`_ sections to install, additionnaly to the
+`package default dependencies`_. Only works if ``python.pip_install`` option
+above is set to ``True``.
+
+Let's say your Python package has a ``setup.py`` which looks like this:
+
+.. code-block:: python
+
+    from setuptools import setup
+
+    setup(
+        name="my_package",
+        # (...)
+        install_requires=[
+            'requests',
+            'simplejson'],
+        extras_require={
+            'tests': [
+                'nose',
+                'pycodestyle >= 2.1.0'],
+            'docs': [
+                'sphinx >= 1.4',
+                'sphinx_rtd_theme']}
+    )
+
+Then to have all dependencies from the ``tests`` and ``docs`` sections
+installed in addition to the default ``requests`` and ``simplejson``, use the
+``extra_requirements`` as such:
+
+.. code-block:: yaml
+
+    python:
+        extra_requirements:
+            - tests
+            - docs
+
+Behind the scene the following Pip command will be run:
+
+.. code-block:: shell
+
+    $ pip install -e .[tests,docs]
+
 
 .. _issue: https://github.com/rtfd/readthedocs.org/issues
 .. _environment file: http://conda.pydata.org/docs/using/envs.html#share-an-environment
+.. _extra requirements: http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
+.. _package default dependencies: http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies

--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -40,6 +40,14 @@ class ConfigWrapper(object):
             return self._project.install_project
 
     @property
+    def extra_requirements(self):
+        if self.pip_install and 'extra_requirements' in self._yaml_config.get(
+                'python', {}):
+            return self._yaml_config['python']['extra_requirements']
+        else:
+            return []
+
+    @property
     def python_interpreter(self):
         if 'version' in self._yaml_config.get('python', {}):
             ver = self._yaml_config['python']['version']

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -44,6 +44,10 @@ class PythonEnvironment(object):
         setup_path = os.path.join(self.checkout_path, 'setup.py')
         if os.path.isfile(setup_path) and self.config.install_project:
             if self.config.pip_install or getattr(settings, 'USE_PIP_INSTALL', False):
+                extra_req_param = ''
+                if self.config.extra_requirements:
+                    extra_req_param = '[{0}]'.format(
+                        ','.join(self.config.extra_requirements))
                 self.build_env.run(
                     'python',
                     self.venv_bin(filename='pip'),
@@ -51,7 +55,7 @@ class PythonEnvironment(object):
                     '--ignore-installed',
                     '--cache-dir',
                     self.project.pip_cache_path,
-                    '.',
+                    '.{0}'.format(extra_req_param),
                     cwd=self.checkout_path,
                     bin_path=self.venv_bin()
                 )

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -55,6 +55,28 @@ class ConfigWrapperTests(TestCase):
         config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
         self.assertEqual(config.install_project, False)
 
+    def test_extra_requirements(self):
+        yaml_config = get_build_config({'python': {
+            'pip_install': True,
+            'extra_requirements': ['tests', 'docs']}})
+        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        self.assertEqual(config.extra_requirements, ['tests', 'docs'])
+
+        yaml_config = get_build_config({'python': {
+            'extra_requirements': ['tests', 'docs']}})
+        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        self.assertEqual(config.extra_requirements, [])
+
+        yaml_config = get_build_config({})
+        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        self.assertEqual(config.extra_requirements, [])
+
+        yaml_config = get_build_config({'python': {
+            'setup_py_install': True,
+            'extra_requirements': ['tests', 'docs']}})
+        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        self.assertEqual(config.extra_requirements, [])
+
     def test_conda(self):
         to_find = 'urls.py'
         yaml_config = get_build_config({'conda': {'file': to_find}})

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -5,7 +5,7 @@ docutils==0.11
 Sphinx==1.3.5
 Pygments==2.0.2
 mkdocs==0.14.0
-readthedocs-build==2.0.5
+git+https://github.com/rtfd/readthedocs-build.git@ef2d91962aeb5391f21245d1e3c311e33785649d#egg=readthedocs-build-2.0.6.dev
 django==1.8.3
 
 django-tastypie==0.12.2


### PR DESCRIPTION
Depends on: https://github.com/rtfd/readthedocs-build/pull/16.

Also closes #173.