### PR TITLE
Fix mkdocs.py

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -59,7 +59,7 @@ class BaseMkdocs(BaseBuilder):
         # Mkdocs needs a full domain here because it tries to link to local media files
         if not media_url.startswith('http'):
             domain = getattr(settings, 'PRODUCTION_DOMAIN')
-            media_url = 'http://{}/{}'.format(domain, media_url)
+            media_url = 'http://{}{}'.format(domain, media_url) # media_url has already a prefix slash
 
         if 'extra_javascript' in user_config:
             user_config['extra_javascript'].append('readthedocs-data.js')

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -72,7 +72,7 @@ class BaseMkdocs(BaseBuilder):
             user_config['extra_javascript'] = [
                 'readthedocs-data.js',
                 'readthedocs-dynamic-include.js',
-                '%static/core/js/readthedocs-doc-embed.js' % media_url,
+                '%sstatic/core/js/readthedocs-doc-embed.js' % media_url,
             ]
 
         if 'extra_css' in user_config:

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -66,12 +66,12 @@ class BaseMkdocs(BaseBuilder):
             user_config['extra_javascript'].append(
                 'readthedocs-dynamic-include.js')
             user_config['extra_javascript'].append(
-                '%sjavascript/readthedocs-doc-embed.js' % media_url)
+                '%sstatic/core/js/readthedocs-doc-embed.js' % media_url)
         else:
             user_config['extra_javascript'] = [
                 'readthedocs-data.js',
                 'readthedocs-dynamic-include.js',
-                '%sjavascript/readthedocs-doc-embed.js' % media_url,
+                '%static/core/js/readthedocs-doc-embed.js' % media_url,
             ]
 
         if 'extra_css' in user_config:

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -54,12 +54,13 @@ class BaseMkdocs(BaseBuilder):
 
         # Set mkdocs config values
 
-        media_url = getattr(settings, 'MEDIA_URL', 'https://media.readthedocs.org')
+        media_url = getattr(settings, 'MEDIA_URL', '')
 
         # Mkdocs needs a full domain here because it tries to link to local media files
         if not media_url.startswith('http'):
             domain = getattr(settings, 'PRODUCTION_DOMAIN')
-            media_url = 'http://{}{}'.format(domain, media_url) # media_url has already a prefix slash
+            # media_url has already a prefix slash
+            media_url = 'http://{}{}'.format(domain, media_url)
 
         if 'extra_javascript' in user_config:
             user_config['extra_javascript'].append('readthedocs-data.js')
@@ -122,7 +123,8 @@ class BaseMkdocs(BaseBuilder):
             'doc_builder/data.js.tmpl'
         ).render(data_ctx)
 
-        data_file = open(os.path.join(self.root_path, docs_dir, 'readthedocs-data.js'), 'w+')
+        data_file = open(os.path.join(
+            self.root_path, docs_dir, 'readthedocs-data.js'), 'w+')
         data_file.write(data_string)
         data_file.write('''
 READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
@@ -138,7 +140,8 @@ READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
             'doc_builder/include.js.tmpl'
         ).render(include_ctx)
         include_file = open(
-            os.path.join(self.root_path, docs_dir, 'readthedocs-dynamic-include.js'),
+            os.path.join(self.root_path, docs_dir,
+                         'readthedocs-dynamic-include.js'),
             'w+'
         )
         include_file.write(include_string)


### PR DESCRIPTION
RE: https://github.com/rtfd/readthedocs.org/issues/2210

RE: https://github.com/rtfd/readthedocs.org/commit/f81c62c2cbb42507330a66746da2b8f4df8cf4fd

>  Move readthedocs-doc-embed to static path for collection
>
> This also adds a symlink from the existing media path to the statically
> collected file to avoid breaking the existing rtd-sphinx-ext includes.