### PR TITLE
Fix 'readthedocs-embed.js'

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -66,12 +66,12 @@ class BaseMkdocs(BaseBuilder):
             user_config['extra_javascript'].append(
                 'readthedocs-dynamic-include.js')
             user_config['extra_javascript'].append(
-                '%sjavascript/readthedocs-doc-embed.js' % media_url)
+                '%sstatic/core/js/readthedocs-doc-embed.js' % media_url)
         else:
             user_config['extra_javascript'] = [
                 'readthedocs-data.js',
                 'readthedocs-dynamic-include.js',
-                '%sjavascript/readthedocs-doc-embed.js' % media_url,
+                '%sstatic/core/js/readthedocs-doc-embed.js' % media_url,
             ]
 
         if 'extra_css' in user_config:


### PR DESCRIPTION
RE: https://github.com/rtfd/readthedocs.org/commit/f81c62c2cbb42507330a66746da2b8f4df8cf4fd

>  Move readthedocs-doc-embed to static path for collection
>
> This also adds a symlink from the existing media path to the statically
> collected file to avoid breaking the existing rtd-sphinx-ext includes.

RE: #2369 