### PR TITLE
Bump Sphinx to 1.4.6, or 1.4.1 in conda.

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -98,7 +98,7 @@ class Virtualenv(PythonEnvironment):
 
     def install_core_requirements(self):
         requirements = [
-            'sphinx==1.3.5',
+            'sphinx==1.4.6',
             'Pygments==2.1.3',
             'setuptools==20.1.1',
             'docutils==0.12',
@@ -189,7 +189,7 @@ class Conda(PythonEnvironment):
 
         # Use conda for requirements it packages
         requirements = [
-            'sphinx==1.3.5',
+            'sphinx==1.4.1',
             'Pygments==2.1.1',
             'docutils==0.12',
             'mock',

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -2,7 +2,7 @@
 pip==8.1.1
 virtualenv==15.0.1
 docutils==0.11
-Sphinx==1.3.5
+Sphinx==1.4.1
 Pygments==2.0.2
 mkdocs==0.14.0
 readthedocs-build==2.0.5


### PR DESCRIPTION
Sphinx is 1.4.6 in PyPI now, and 1.4.1 in Anaconda:

https://docs.continuum.io/anaconda/pkg-docs
