### PR TITLE
Fix the 'edit on github' link for stable versions of a projet

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -713,7 +713,7 @@ class Project(models.Model):
                         "Update stable version: {project}:{version}".format(
                             project=self.slug,
                             version=new_stable.identifier))
-                    current_stable.identifier = new_stable.identifier
+                    current_stable.identifier = new_stable.verbose_name
                     current_stable.save()
                     return new_stable
             else:
@@ -723,7 +723,7 @@ class Project(models.Model):
                         version=new_stable.identifier))
                 current_stable = self.versions.create_stable(
                     type=new_stable.type,
-                    identifier=new_stable.identifier)
+                    identifier=new_stable.verbose_name)
                 return new_stable
 
     def versions_from_branch_name(self, branch):


### PR DESCRIPTION
Fixes #1820

This is a naive approach, and might break things, for example for other VCS
than GitHub. Feedback welcome!

The rationale here is that the `identifier` of the `stable` build is the hash
of the tag, and not of a commit. It thus leads to a 404 when building the link
to edit on GitHub (see the [comment in the original
issue](https://github.com/rtfd/readthedocs.org/issues/1820#issuecomment-250147088)).
If instead of storing the tag hash in the `identifier` we stored the
`verbose_name` of the original branch (its name), it would be used to build the
link (just the same way we use the verbose name for tags, and not commit
hashes).
