### PR TITLE
Refactor webhooks, add modern webhooks, and fix issues with Bitbucket

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -1,6 +1,7 @@
 import logging
 from urlparse import urlparse
 
+from django.dispatch import Signal
 from corsheaders import signals
 
 from readthedocs.projects.models import Project, Domain
@@ -8,6 +9,11 @@ from readthedocs.projects.models import Project, Domain
 log = logging.getLogger(__name__)
 
 WHITELIST_URLS = ['/api/v2/footer_html', '/api/v2/search', '/api/v2/docsearch']
+
+
+webhook_github = Signal(providing_args=['project', 'data', 'event'])
+webhook_gitlab = Signal(providing_args=['project', 'data', 'event'])
+webhook_bitbucket = Signal(providing_args=['project', 'data', 'event'])
 
 
 def decide_if_cors(sender, request, **kwargs):

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -5,6 +5,7 @@ import json
 import re
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from requests.exceptions import RequestException
 from allauth.socialaccount.providers.bitbucket_oauth2.views import (
     BitbucketOAuth2Adapter)
@@ -185,7 +186,13 @@ class BitbucketService(Service):
         owner, repo = build_utils.get_bitbucket_username_repo(url=project.repo)
         data = json.dumps({
             'description': 'Read the Docs ({domain})'.format(domain=settings.PRODUCTION_DOMAIN),
-            'url': 'https://{domain}/bitbucket'.format(domain=settings.PRODUCTION_DOMAIN),
+            'url': 'https://{domain}{path}'.format(
+                domain=settings.PRODUCTION_DOMAIN,
+                path=reverse(
+                    'api_webhook_bitbucket',
+                    kwargs={'project_slug': project.slug}
+                )
+            ),
             'active': True,
             'events': ['repo:push'],
         })

--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -2,16 +2,18 @@ from django.conf.urls import url, include
 
 from rest_framework import routers
 
+from readthedocs.constants import pattern_opts
+from readthedocs.comments.views import CommentViewSet
+from readthedocs.restapi import views
+from readthedocs.restapi.views import (
+    core_views, footer_views, search_views, task_views, integrations
+)
+
 from .views.model_views import (BuildViewSet, BuildCommandViewSet,
                                 ProjectViewSet, NotificationViewSet,
                                 VersionViewSet, DomainViewSet,
                                 RemoteOrganizationViewSet,
                                 RemoteRepositoryViewSet)
-from readthedocs.comments.views import CommentViewSet
-from readthedocs.restapi import views
-from readthedocs.restapi.views import (
-    core_views, footer_views, search_views, task_views,
-)
 
 router = routers.DefaultRouter()
 router.register(r'build', BuildViewSet)
@@ -57,10 +59,22 @@ task_urls = [
         name='api_sync_remote_repositories'),
 ]
 
+integration_urls = [
+    url(r'webhook/github/(?P<project_slug>{project_slug})/'.format(**pattern_opts),
+        integrations.GitHubWebhookView.as_view(),
+        name='api_webhook_github'),
+    url(r'webhook/gitlab/(?P<project_slug>{project_slug})/'.format(**pattern_opts),
+        integrations.GitLabWebhookView.as_view(),
+        name='api_webhook_gitlab'),
+    url(r'webhook/bitbucket/(?P<project_slug>{project_slug})/'.format(**pattern_opts),
+        integrations.BitbucketWebhookView.as_view(),
+        name='api_webhook_bitbucket'),
+]
 
 urlpatterns += function_urls
 urlpatterns += search_urls
 urlpatterns += task_urls
+urlpatterns += integration_urls
 
 try:
     from readthedocsext.search.docsearch import DocSearch

--- a/readthedocs/restapi/views/integrations.py
+++ b/readthedocs/restapi/views/integrations.py
@@ -1,0 +1,172 @@
+from rest_framework import permissions
+from rest_framework.views import APIView
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from rest_framework.exceptions import ParseError
+
+from django.shortcuts import get_object_or_404
+from django.http import Http404
+
+from readthedocs.core.views.hooks import build_branches
+from readthedocs.core.signals import (webhook_github, webhook_bitbucket,
+                                      webhook_gitlab)
+from readthedocs.projects.models import Project
+
+
+GITHUB_PUSH = 'push'
+GITLAB_PUSH = 'push'
+BITBUCKET_PUSH = 'repo:push'
+
+
+class WebhookMixin(object):
+
+    permission_classes = (permissions.AllowAny,)
+    renderer_classes = (JSONRenderer,)
+
+    def post(self, request, project_slug, format=None):
+        try:
+            project = Project.objects.get(slug=project_slug)
+            resp = self.handle_webhook(request, project, request.data)
+        except Project.DoesNotExist:
+            raise Http404('Project does not exist')
+        return Response(resp)
+
+    def handle_webhook(self, project, branch, event=GITHUB_PUSH, data=None):
+        """Handle webhook payload
+
+        If a build is triggered from this method, return a JSON response with
+        the following::
+
+            {
+                "build_triggered": true,
+                "project": "project_name",
+                "versions": [...]
+            }
+        """
+        raise NotImplemented
+
+
+class GitHubWebhookView(WebhookMixin, APIView):
+
+    """Webhook consumer for GitHub
+
+    Accepts webhook events from GitHub, 'push' events trigger builds. Expects the
+    webhook event type will be included in HTTP header ``X-GitHub-Event``, and
+    we will have a JSON payload.
+
+    Expects the following JSON::
+
+        {
+            "ref": "branch-name",
+            ...
+        }
+
+    If a build is triggered, this will return JSON with the following::
+
+        {
+            "build_triggered": true,
+            "project": "project_name",
+            "versions": [...]
+        }
+    """
+
+    def handle_webhook(self, request, project, data=None):
+        # Get event and trigger other webhook events
+        event = request.META.get('HTTP_X_GITHUB_EVENT', 'push')
+        webhook_github.send(Project, project=project, data=data, event=event)
+        # Handle push events and trigger builds
+        try:
+            branches = [request.data['ref'].replace('refs/heads/', '')]
+        except KeyError:
+            raise ParseError('Parameter "ref" is required')
+        if event == GITHUB_PUSH:
+            to_build, not_building = build_branches(project, branches)
+            triggered = True if to_build else False
+            return {'build_triggered': triggered,
+                    'project': project.slug,
+                    'versions': to_build}
+        return {'build_triggered': false}
+
+
+class GitLabWebhookView(WebhookMixin, APIView):
+
+    """Webhook consumer for GitLab
+
+    Accepts webhook events from GitLab, 'push' events trigger builds.
+
+    Expects the following JSON::
+
+        {
+            "object_kind": "push",
+            "ref": "branch-name",
+            ...
+        }
+
+    If a build is triggered, this will return JSON with the following::
+
+        {
+            "build_triggered": true,
+            "project": "project_name",
+            "versions": [...]
+        }
+    """
+
+    def handle_webhook(self, request, project, data=None):
+        # Get event and trigger other webhook events
+        event = data.get('object_kind', GITLAB_PUSH)
+        webhook_gitlab.send(Project, project=project, data=data, event=event)
+        # Handle push events and trigger builds
+        try:
+            branches = [request.data['ref'].replace('refs/heads/', '')]
+        except KeyError:
+            raise ParseError('Parameter "ref" is required')
+        if event == GITLAB_PUSH:
+            to_build, not_building = build_branches(project, branches)
+            triggered = True if to_build else False
+            return {'build_triggered': triggered,
+                    'project': project.slug,
+                    'versions': to_build}
+        return {'build_triggered': false}
+
+
+class BitbucketWebhookView(WebhookMixin, APIView):
+
+    """Webhook consumer for Bitbucket
+
+    Accepts webhook events from Bitbucket, 'repo:push' events trigger builds.
+
+    Expects the following JSON::
+
+        {
+            "push": {
+                "changes": [{
+                    "new": {
+                        "name": "branch-name",
+                        ...
+                    },
+                    ...
+                }],
+                ...
+            },
+            ...
+        }
+    """
+
+    def handle_webhook(self, request, project, data=None):
+        # Get event and trigger other webhook events
+        event = request.META.get('HTTP_X_EVENT_KEY', BITBUCKET_PUSH)
+        webhook_bitbucket.send(Project, project=project, data=data, event=event)
+        # Handle push events and trigger builds
+        if event == BITBUCKET_PUSH:
+            try:
+                changes = data['push']['changes']
+                branches = [change['new']['name']
+                            for change in changes]
+            except KeyError:
+                raise ParseError('Invalid request')
+            to_build, not_building = build_branches(project, branches)
+            triggered = True if to_build else False
+            return {'build_triggered': triggered,
+                    'project': project.slug,
+                    'versions': to_build}
+        return {'build_triggered': false}

--- a/readthedocs/restapi/views/integrations.py
+++ b/readthedocs/restapi/views/integrations.py
@@ -31,7 +31,7 @@ class WebhookMixin(object):
             raise Http404('Project does not exist')
         return Response(resp)
 
-    def handle_webhook(self, project, branch, event=GITHUB_PUSH, data=None):
+    def handle_webhook(self, request, project, data=None):
         """Handle webhook payload
 
         If a build is triggered from this method, return a JSON response with
@@ -43,7 +43,7 @@ class WebhookMixin(object):
                 "versions": [...]
             }
         """
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class GitHubWebhookView(WebhookMixin, APIView):
@@ -85,7 +85,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
             return {'build_triggered': triggered,
                     'project': project.slug,
                     'versions': to_build}
-        return {'build_triggered': false}
+        return {'build_triggered': False}
 
 
 class GitLabWebhookView(WebhookMixin, APIView):
@@ -126,7 +126,7 @@ class GitLabWebhookView(WebhookMixin, APIView):
             return {'build_triggered': triggered,
                     'project': project.slug,
                     'versions': to_build}
-        return {'build_triggered': false}
+        return {'build_triggered': False}
 
 
 class BitbucketWebhookView(WebhookMixin, APIView):
@@ -169,4 +169,4 @@ class BitbucketWebhookView(WebhookMixin, APIView):
             return {'build_triggered': triggered,
                     'project': project.slug,
                     'versions': to_build}
-        return {'build_triggered': false}
+        return {'build_triggered': False}

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -324,6 +324,18 @@ class IntegrationsTests(TestCase):
             mock.call(force=True, version=mock.ANY, project=self.project)
         ])
 
+    def test_github_invalid_webhook(self, trigger_build):
+        """GitHub webhook unhandled event"""
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/webhook/github/{0}/'.format(self.project.slug),
+            {'foo': 'bar'},
+            format='json',
+            HTTP_X_GITHUB_EVENT='pull_request',
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['detail'], 'Unhandled webhook event')
+
     def test_gitlab_webhook(self, trigger_build):
         """GitLab webhook API"""
         client = APIClient()
@@ -343,6 +355,17 @@ class IntegrationsTests(TestCase):
         trigger_build.assert_has_calls([
             mock.call(force=True, version=mock.ANY, project=self.project)
         ])
+
+    def test_gitlab_invalid_webhook(self, trigger_build):
+        """GitLab webhook unhandled event"""
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/webhook/gitlab/{0}/'.format(self.project.slug),
+            {'object_kind': 'pull_request'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['detail'], 'Unhandled webhook event')
 
     def test_bitbucket_webhook(self, trigger_build):
         """Bitbucket webhook API"""
@@ -379,3 +402,15 @@ class IntegrationsTests(TestCase):
         trigger_build.assert_has_calls([
             mock.call(force=True, version=mock.ANY, project=self.project)
         ])
+
+    def test_bitbucket_invalid_webhook(self, trigger_build):
+        """Bitbucket webhook unhandled event"""
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/webhook/bitbucket/{0}/'.format(self.project.slug),
+            {'foo': 'bar'},
+            format='json',
+            HTTP_X_EVENT_KEY='pull_request'
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['detail'], 'Unhandled webhook event')

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -1,9 +1,10 @@
-from django.test import TestCase
 import json
 import logging
-import mock
+from urllib import urlencode
 
+import mock
 from django_dynamic_fixture import get
+from django.test import TestCase
 
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
@@ -209,6 +210,17 @@ class GitHubPostCommitTest(BasePostCommitTest):
             }
         }
 
+    def test_post_types(self):
+        """Ensure various POST formats"""
+        r = self.client.post('/github/',
+                             data=json.dumps(self.payload),
+                             content_type='application/json')
+        self.assertEqual(r.status_code, 200)
+        r = self.client.post('/github/',
+                             data=urlencode({'payload': json.dumps(self.payload)}),
+                             content_type='application/x-www-form-urlencoded')
+        self.assertEqual(r.status_code, 200)
+
     def test_github_upper_case_repo(self):
         """
         Test the github post commit hook will build properly with upper case
@@ -403,6 +415,17 @@ class BitBucketHookTests(BasePostCommitTest):
             },
             "user": "marcus"
         }
+
+    def test_post_types(self):
+        """Ensure various POST formats"""
+        r = self.client.post('/bitbucket/',
+                             data=json.dumps(self.hg_payload),
+                             content_type='application/json')
+        self.assertEqual(r.status_code, 200)
+        r = self.client.post('/bitbucket/',
+                             data=urlencode({'payload': json.dumps(self.hg_payload)}),
+                             content_type='application/x-www-form-urlencoded')
+        self.assertEqual(r.status_code, 200)
 
     def test_bitbucket_post_commit(self):
         r = self.client.post('/bitbucket/', data=json.dumps(self.hg_payload),

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -295,6 +295,9 @@ class APIMixin(URLAccessMixin):
             'api_project_search': {'status_code': 400},
             'api_section_search': {'status_code': 400},
             'api_sync_remote_repositories': {'status_code': 403},
+            'api_webhook_github': {'status_code': 405},
+            'api_webhook_gitlab': {'status_code': 405},
+            'api_webhook_bitbucket': {'status_code': 405},
             'remoteorganization-detail': {'status_code': 404},
             'remoterepository-detail': {'status_code': 404},
         }


### PR DESCRIPTION
Fixes #2424

* Adds new API endpoint for webhook consumption
* Adds webhook signals for future use
* Cleans up old webhook implementations
* Fixes old Bitbucket webhook implementation
* Sets new webhooks to point to API endpoint
* Removes GitHub service creation by naming the webhook 'web' -- 'readthedocs' created
  an RTD service on GitHub
* Updates Gitlab fixture data with example from API
* Drops `request.POST['payload']` from all old webhooks, not sure what it was
* Made tests actually send JSON to webhook views