### PR TITLE
Upgrade to Django 1.9.10

### DIFF
--- a/readthedocs/core/utils/extend.py
+++ b/readthedocs/core/utils/extend.py
@@ -3,7 +3,7 @@
 import inspect
 
 from django.conf import settings
-from django.utils.module_loading import import_by_path
+from django.utils.module_loading import import_string
 from django.utils.functional import LazyObject
 
 
@@ -45,7 +45,7 @@ class SettingsOverrideObject(LazyObject):
         if cls_path is None and self._override_setting is not None:
             cls_path = getattr(settings, self._override_setting, None)
         if cls_path is not None:
-            cls = import_by_path(cls_path)
+            cls = import_string(cls_path)
         self._wrapped = cls()
 
     def _get_class_id(self):

--- a/readthedocs/doc_builder/loader.py
+++ b/readthedocs/doc_builder/loader.py
@@ -1,4 +1,5 @@
-from django.utils.importlib import import_module
+from importlib import import_module
+
 from django.conf import settings
 
 # Managers

--- a/readthedocs/oauth/services/__init__.py
+++ b/readthedocs/oauth/services/__init__.py
@@ -1,12 +1,12 @@
 """Conditional classes for OAuth services"""
 
-from django.utils.module_loading import import_by_path
+from django.utils.module_loading import import_string
 from django.conf import settings
 
-GitHubService = import_by_path(
+GitHubService = import_string(
     getattr(settings, 'OAUTH_GITHUB_SERVICE',
             'readthedocs.oauth.services.github.GitHubService'))
-BitbucketService = import_by_path(
+BitbucketService = import_string(
     getattr(settings, 'OAUTH_BITBUCKET_SERVICE',
             'readthedocs.oauth.services.bitbucket.BitbucketService'))
 

--- a/readthedocs/privacy/loader.py
+++ b/readthedocs/privacy/loader.py
@@ -1,36 +1,36 @@
-from django.utils.module_loading import import_by_path
+from django.utils.module_loading import import_string
 from django.conf import settings
 
 # Managers
-ProjectManager = import_by_path(
+ProjectManager = import_string(
     getattr(settings, 'PROJECT_MANAGER',
             'readthedocs.privacy.backend.ProjectManager'))
-VersionManager = import_by_path(
+VersionManager = import_string(
     getattr(settings, 'VERSION_MANAGER',
             'readthedocs.privacy.backend.VersionManager'))
-BuildManager = import_by_path(
+BuildManager = import_string(
     getattr(settings, 'BUILD_MANAGER',
             'readthedocs.privacy.backend.BuildManager'))
 
-RelatedProjectManager = import_by_path(
+RelatedProjectManager = import_string(
     getattr(settings, 'RELATED_PROJECT_MANAGER',
             'readthedocs.privacy.backend.RelatedProjectManager'))
-RelatedBuildManager = import_by_path(
+RelatedBuildManager = import_string(
     getattr(settings, 'RELATED_BUILD_MANAGER',
             'readthedocs.privacy.backend.RelatedBuildManager'))
-RelatedUserManager = import_by_path(
+RelatedUserManager = import_string(
     getattr(settings, 'RELATED_USER_MANAGER',
             'readthedocs.privacy.backend.RelatedUserManager'))
-ChildRelatedProjectManager = import_by_path(
+ChildRelatedProjectManager = import_string(
     getattr(settings, 'CHILD_RELATED_PROJECT_MANAGER',
             'readthedocs.privacy.backend.ChildRelatedProjectManager'))
 
 # Permissions
-AdminPermission = import_by_path(
+AdminPermission = import_string(
     getattr(settings, 'ADMIN_PERMISSION',
             'readthedocs.privacy.backend.AdminPermission'))
 
 # Syncers
-Syncer = import_by_path(
+Syncer = import_string(
     getattr(settings, 'FILE_SYNCER',
             'readthedocs.privacy.backends.syncers.LocalSyncer'))

--- a/readthedocs/projects/backends/views.py
+++ b/readthedocs/projects/backends/views.py
@@ -5,19 +5,19 @@ Use these views instead of calling the views directly, in order to allow for
 settings override of the view class.
 """
 
-from django.utils.module_loading import import_by_path
+from django.utils.module_loading import import_string
 from django.conf import settings
 
 
 # Project Import Wizard
-ImportWizardView = import_by_path(getattr(
+ImportWizardView = import_string(getattr(
     settings,
     'PROJECT_IMPORT_VIEW',
     'readthedocs.projects.views.private.ImportWizardView'
 ))
 
 # Project demo import
-ImportDemoView = import_by_path(getattr(
+ImportDemoView = import_string(getattr(
     settings,
     'PROJECT_IMPORT_DEMO_VIEW',
     'readthedocs.projects.views.private.ImportDemoView'

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -1,5 +1,6 @@
 """Public project views"""
 
+from collections import OrderedDict
 import operator
 import os
 import json
@@ -16,7 +17,6 @@ from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
 from django.views.decorators.cache import cache_control
 from django.views.generic import ListView, DetailView
-from django.utils.datastructures import SortedDict
 from django.views.decorators.cache import cache_page
 
 from taggit.models import Tag
@@ -138,7 +138,7 @@ def project_downloads(request, project_slug):
     """A detail view for a project with various dataz"""
     project = get_object_or_404(Project.objects.protected(request.user), slug=project_slug)
     versions = Version.objects.public(user=request.user, project=project)
-    version_data = SortedDict()
+    version_data = OrderedDict()
     for version in versions:
         data = version.get_downloads()
         # Don't show ones that have no downloads.

--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -14,14 +14,16 @@ from readthedocs.restapi.views import (
 )
 
 router = routers.DefaultRouter()
-router.register(r'build', BuildViewSet)
-router.register(r'command', BuildCommandViewSet)
-router.register(r'version', VersionViewSet)
-router.register(r'project', ProjectViewSet)
-router.register(r'notification', NotificationViewSet)
-router.register(r'domain', DomainViewSet)
-router.register(r'remote/org', RemoteOrganizationViewSet)
-router.register(r'remote/repo', RemoteRepositoryViewSet)
+router.register(r'build', BuildViewSet, base_name='build')
+router.register(r'command', BuildCommandViewSet, base_name='buildcommandresult')
+router.register(r'version', VersionViewSet, base_name='version')
+router.register(r'project', ProjectViewSet, base_name='project')
+router.register(r'notification', NotificationViewSet, base_name='emailhook')
+router.register(r'domain', DomainViewSet, base_name='domain')
+router.register(
+    r'remote/org', RemoteOrganizationViewSet, base_name='remoteorganization')
+router.register(
+    r'remote/repo', RemoteRepositoryViewSet, base_name='remoterepository')
 router.register(r'comments', CommentViewSet, base_name="comments")
 
 urlpatterns = [

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -4,8 +4,9 @@ from django.conf import settings
 
 
 from rest_framework import decorators, permissions
-from rest_framework.renderers import JSONPRenderer, JSONRenderer
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
+from rest_framework_jsonp.renderers import JSONPRenderer
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import TAG

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -35,13 +35,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
     renderer_classes = (JSONRenderer,)
     serializer_class = ProjectSerializer
     filter_class = ProjectFilter
-    model = Project
     paginate_by = 100
     paginate_by_param = 'page_size'
     max_paginate_by = 1000
 
     def get_queryset(self):
-        return self.model.objects.api(self.request.user)
+        return Project.objects.api(self.request.user)
 
     @decorators.detail_route()
     def valid_versions(self, request, **kwargs):
@@ -165,19 +164,17 @@ class VersionViewSet(viewsets.ReadOnlyModelViewSet):
     renderer_classes = (JSONRenderer,)
     serializer_class = VersionSerializer
     filter_class = VersionFilter
-    model = Version
 
     def get_queryset(self):
-        return self.model.objects.api(self.request.user)
+        return Version.objects.api(self.request.user)
 
 
 class BuildViewSet(viewsets.ModelViewSet):
     permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer,)
-    model = Build
 
     def get_queryset(self):
-        return self.model.objects.api(self.request.user)
+        return Build.objects.api(self.request.user)
 
     def get_serializer_class(self):
         """Vary serializer class based on user status
@@ -194,19 +191,17 @@ class BuildCommandViewSet(viewsets.ModelViewSet):
     permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = BuildCommandSerializer
-    model = BuildCommandResult
 
     def get_queryset(self):
-        return self.model.objects.api(self.request.user)
+        return BuildCommandResult.objects.api(self.request.user)
 
 
 class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated, RelatedProjectIsOwner)
     renderer_classes = (JSONRenderer,)
-    model = EmailHook
 
     def get_queryset(self):
-        return self.model.objects.api(self.request.user)
+        return EmailHook.objects.api(self.request.user)
 
 
 class DomainViewSet(viewsets.ModelViewSet):
@@ -214,21 +209,19 @@ class DomainViewSet(viewsets.ModelViewSet):
     renderer_classes = (JSONRenderer,)
     serializer_class = DomainSerializer
     filter_class = DomainFilter
-    model = Domain
 
     def get_queryset(self):
-        return self.model.objects.api(self.request.user)
+        return Domain.objects.api(self.request.user)
 
 
 class RemoteOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsOwner]
     renderer_classes = (JSONRenderer,)
     serializer_class = RemoteOrganizationSerializer
-    model = RemoteOrganization
     paginate_by = 25
 
     def get_queryset(self):
-        return (self.model.objects.api(self.request.user)
+        return (RemoteOrganization.objects.api(self.request.user)
                 .filter(account__provider__in=[service.adapter.provider_id
                                                for service in registry]))
 
@@ -237,10 +230,9 @@ class RemoteRepositoryViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsOwner]
     renderer_classes = (JSONRenderer,)
     serializer_class = RemoteRepositorySerializer
-    model = RemoteRepository
 
     def get_queryset(self):
-        query = self.model.objects.api(self.request.user)
+        query = RemoteRepository.objects.api(self.request.user)
         org = self.request.query_params.get('org', None)
         if org is not None:
             query = query.filter(organization__pk=org)

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -156,7 +156,7 @@ class APITests(TestCase):
                                 HTTP_AUTHORIZATION='Basic %s' % super_auth)
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp['location'],
-                         'http://testserver/api/v1/project/24/')
+                         '/api/v1/project/24/')
         resp = self.client.get('/api/v1/project/24/', data={'format': 'json'},
                                HTTP_AUTHORIZATION='Basic %s' % eric_auth)
         self.assertEqual(resp.status_code, 200)

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -29,8 +29,8 @@ class TestLocalEnvironment(TestCase):
 
     def setUp(self):
         self.project = Project.objects.get(slug='pip')
-        self.version = Version(slug='foo', verbose_name='foobar')
-        self.project.versions.add(self.version, bulk=False)
+        self.version = self.project.versions.create(slug='foo',
+                                                    verbose_name='foobar')
         self.mocks = EnvironmentMockGroup()
         self.mocks.start()
 

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -30,7 +30,7 @@ class TestLocalEnvironment(TestCase):
     def setUp(self):
         self.project = Project.objects.get(slug='pip')
         self.version = Version(slug='foo', verbose_name='foobar')
-        self.project.versions.add(self.version)
+        self.project.versions.add(self.version, bulk=False)
         self.mocks = EnvironmentMockGroup()
         self.mocks.start()
 
@@ -106,7 +106,7 @@ class TestDockerEnvironment(TestCase):
     def setUp(self):
         self.project = Project.objects.get(slug='pip')
         self.version = Version(slug='foo', verbose_name='foobar')
-        self.project.versions.add(self.version)
+        self.project.versions.add(self.version, bulk=False)
         self.mocks = EnvironmentMockGroup()
         self.mocks.start()
 

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -284,8 +284,8 @@ class CorePostCommitTest(BasePostCommitTest):
         rtd.save()
         r = self.client.post('/build/%s' % rtd.pk, {'version_slug': 'master'})
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(
-            r._headers['location'][1], 'http://testserver/projects/read-the-docs/builds/')
+        self.assertEqual(r._headers['location'][1],
+                         '/projects/read-the-docs/builds/')
 
     def test_hook_state_tracking(self):
         rtd = Project.objects.get(slug='read-the-docs')
@@ -430,5 +430,3 @@ class BitBucketHookTests(BasePostCommitTest):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
             r.content, '(URL Build) Build Started: bitbucket.org/test/project [latest]')
-
-

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -282,7 +282,7 @@ class PrivacyTests(TestCase):
         self.assertEqual(r.status_code, 200)
         r = self.client.get('/projects/django-kong/downloads/pdf/latest/')
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/media/pdf/django-kong/latest/django-kong.pdf')
+        self.assertEqual(r._headers['location'][1], '/media/pdf/django-kong/latest/django-kong.pdf')
 
         # Auth'd user
         self.client.login(username='eric', password='test')
@@ -290,7 +290,7 @@ class PrivacyTests(TestCase):
         self.assertEqual(r.status_code, 200)
         r = self.client.get('/projects/django-kong/downloads/pdf/latest/')
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/media/pdf/django-kong/latest/django-kong.pdf')
+        self.assertEqual(r._headers['location'][1], '/media/pdf/django-kong/latest/django-kong.pdf')
 
     @override_settings(DEFAULT_PRIVACY_LEVEL='public')
     def test_public_private_repo_downloading(self):
@@ -309,7 +309,7 @@ class PrivacyTests(TestCase):
         self.assertEqual(r.status_code, 200)
         r = self.client.get('/projects/django-kong/downloads/pdf/latest/')
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/media/pdf/django-kong/latest/django-kong.pdf')
+        self.assertEqual(r._headers['location'][1], '/media/pdf/django-kong/latest/django-kong.pdf')
 
     @override_settings(DEFAULT_PRIVACY_LEVEL='public')
     def test_public_download_filename(self):
@@ -318,15 +318,15 @@ class PrivacyTests(TestCase):
         self.client.login(username='eric', password='test')
         r = self.client.get('/projects/django-kong/downloads/pdf/latest/')
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/media/pdf/django-kong/latest/django-kong.pdf')
+        self.assertEqual(r._headers['location'][1], '/media/pdf/django-kong/latest/django-kong.pdf')
 
         r = self.client.get('/projects/django-kong/downloads/epub/latest/')
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/media/epub/django-kong/latest/django-kong.epub')
+        self.assertEqual(r._headers['location'][1], '/media/epub/django-kong/latest/django-kong.epub')
 
         r = self.client.get('/projects/django-kong/downloads/htmlzip/latest/')
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/media/htmlzip/django-kong/latest/django-kong.zip')
+        self.assertEqual(r._headers['location'][1], '/media/htmlzip/django-kong/latest/django-kong.zip')
 
 # Build Filtering
 

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -59,9 +59,6 @@ class URLAccessMixin(object):
         if self.context_data and getattr(response, 'context'):
             self._test_context(response)
         for (key, val) in response_attrs.items():
-            if getattr(response, key) != val:
-                from pdb import set_trace
-                set_trace()
             self.assertEqual(getattr(response, key), val)
         return response
 

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -59,6 +59,9 @@ class URLAccessMixin(object):
         if self.context_data and getattr(response, 'context'):
             self._test_context(response)
         for (key, val) in response_attrs.items():
+            if getattr(response, key) != val:
+                from pdb import set_trace
+                set_trace()
             self.assertEqual(getattr(response, key), val)
         return response
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -205,8 +205,7 @@ class TestImportDemoView(MockBuildTestCase):
     def test_import_demo_pass(self):
         resp = self.client.get('/dashboard/import/manual/demo/')
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['Location'],
-                         'http://testserver/projects/eric-demo/')
+        self.assertEqual(resp['Location'], '/projects/eric-demo/')
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
         messages = list(resp_redir.context['messages'])
@@ -219,8 +218,7 @@ class TestImportDemoView(MockBuildTestCase):
 
         resp = self.client.get('/dashboard/import/manual/demo/')
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['Location'],
-                         'http://testserver/projects/eric-demo/')
+        self.assertEqual(resp['Location'], '/projects/eric-demo/')
 
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
@@ -239,8 +237,7 @@ class TestImportDemoView(MockBuildTestCase):
         self.client.login(username='test', password='test')
         resp = self.client.get('/dashboard/import/manual/demo/')
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['Location'],
-                         'http://testserver/projects/test-demo/')
+        self.assertEqual(resp['Location'], '/projects/test-demo/')
 
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
@@ -256,8 +253,7 @@ class TestImportDemoView(MockBuildTestCase):
 
         resp = self.client.get('/dashboard/import/manual/demo/')
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['Location'],
-                         'http://testserver/projects/eric-demo/')
+        self.assertEqual(resp['Location'], '/projects/eric-demo/')
 
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)
@@ -283,8 +279,7 @@ class TestImportDemoView(MockBuildTestCase):
 
         resp = self.client.get('/dashboard/import/manual/demo/')
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['Location'],
-                         'http://testserver/dashboard/')
+        self.assertEqual(resp['Location'], '/dashboard/')
 
         resp_redir = self.client.get(resp['Location'])
         self.assertEqual(resp_redir.status_code, 200)

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -260,12 +260,12 @@ class RedirectBuildTests(TestCase):
     def test_redirect_list(self):
         r = self.client.get('/builds/project-1/')
         self.assertEqual(r.status_code, 301)
-        self.assertEqual(r['Location'], 'http://testserver/projects/project-1/builds/')
+        self.assertEqual(r['Location'], '/projects/project-1/builds/')
 
     def test_redirect_detail(self):
         r = self.client.get('/builds/project-1/1337/')
         self.assertEqual(r.status_code, 301)
-        self.assertEqual(r['Location'], 'http://testserver/projects/project-1/builds/1337/')
+        self.assertEqual(r['Location'], '/projects/project-1/builds/1337/')
 
 
 @override_settings(PUBLIC_DOMAIN='readthedocs.org', USE_SUBDOMAIN=False)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -67,7 +67,7 @@ class CommunityBaseSettings(Settings):
             'django.contrib.humanize',
 
             # third party apps
-            'pagination',
+            'linaro_django_pagination',
             'taggit',
             'djangosecure',
             'guardian',
@@ -129,7 +129,7 @@ class CommunityBaseSettings(Settings):
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
-        'pagination.middleware.PaginationMiddleware',
+        'linaro_django_pagination.middleware.PaginationMiddleware',
         'readthedocs.core.middleware.SubdomainMiddleware',
         'readthedocs.core.middleware.SingleVersionMiddleware',
         'corsheaders.middleware.CorsMiddleware',
@@ -345,7 +345,7 @@ class CommunityBaseSettings(Settings):
         'handlers': {
             'null': {
                 'level': 'DEBUG',
-                'class': 'django.utils.log.NullHandler',
+                'class': 'logging.NullHandler',
             },
             'exceptionlog': {
                 'level': 'DEBUG',

--- a/readthedocs/templates/account/email.html
+++ b/readthedocs/templates/account/email.html
@@ -1,7 +1,6 @@
 {% extends "profiles/base_profile_edit.html" %}
 
 {% load i18n %}
-{% load url from future %}
 
 {% block title %}{% trans "Change Email" %}{% endblock %}
 

--- a/readthedocs/templates/account/login.html
+++ b/readthedocs/templates/account/login.html
@@ -2,7 +2,6 @@
 
 {% load i18n %}
 {% load account %}
-{% load url from future %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 

--- a/readthedocs/templates/socialaccount/connections.html
+++ b/readthedocs/templates/socialaccount/connections.html
@@ -1,7 +1,6 @@
 {% extends "profiles/base_profile_edit.html" %}
 
 {% load i18n %}
-{% load url from future %}
 
 {% block title %}{% trans "Connected Services" %}{% endblock %}
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -6,7 +6,7 @@ Sphinx==1.3.5
 Pygments==2.0.2
 mkdocs==0.14.0
 git+https://github.com/rtfd/readthedocs-build.git@ef2d91962aeb5391f21245d1e3c311e33785649d#egg=readthedocs-build-2.0.6.dev
-django==1.9.0
+django==1.9.10
 
 django-tastypie==0.13.0
 django-haystack==2.5.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -6,14 +6,14 @@ Sphinx==1.3.5
 Pygments==2.0.2
 mkdocs==0.14.0
 git+https://github.com/rtfd/readthedocs-build.git@ef2d91962aeb5391f21245d1e3c311e33785649d#egg=readthedocs-build-2.0.6.dev
-django==1.8.3
+django==1.9.0
 
-django-tastypie==0.12.2
+django-tastypie==0.13.0
 django-haystack==2.5.0
 celery-haystack==0.7.2
-django-guardian==1.3.0
-django-extensions==1.3.8
-djangorestframework==3.0.4
+django-guardian==1.4.6
+django-extensions==1.7.4
+djangorestframework==3.1.2
 django-vanilla-views==1.0.4
 pytest-django==2.8.0
 
@@ -26,7 +26,7 @@ django-countries==3.4.1
 # Basic tools
 redis==2.10.3
 celery==3.1.23
-django-celery==3.1.16
+django-celery==3.1.17
 git+https://github.com/pennersr/django-allauth.git@d869aff9#egg=django-allauth
 dnspython==1.11.0
 
@@ -54,8 +54,9 @@ django-formtools==1.0
 django-dynamic-fixture==1.8.5
 docker-py==1.3.1
 django-textclassifier==1.0
-django-annoying==0.8.4
+django-annoying==0.10.1
 django-messages-extends==0.5
+djangorestframework-jsonp==1.0.2
 
 # Docs
 sphinxcontrib-httpdomain==1.4.0
@@ -72,5 +73,5 @@ nilsimsa==0.3.7
 
 # Pegged git requirements
 git+https://github.com/alex/django-filter.git#egg=django-filter
-git+https://github.com/ericflo/django-pagination.git@e5f669036c#egg=django_pagination-dev
+git+https://github.com/zyga/django-pagination.git@86caf15#egg=django_pagination-dev
 git+https://github.com/alex/django-taggit.git#egg=django_taggit-dev


### PR DESCRIPTION
Upgrade to Django 1.9.0

I also updated the following libraries for compatibility with this version of Django:

```
-django-tastypie==0.12.2
+django-tastypie==0.13.0

-django-guardian==1.3.0
+django-guardian==1.4.6

-django-extensions==1.3.8
+django-extensions==1.7.4

-djangorestframework==3.0.4
+djangorestframework==3.1.2

-django-celery==3.1.16
+django-celery==3.1.17

-django-annoying==0.8.4
+django-annoying==0.10.1

# The JSONP serializer was removed from restframework into a new package
+djangorestframework-jsonp==1.0.2

# Uses a more recent version of this unmaintained library, for compat with Django 1.9 and python 3
-git+https://github.com/ericflo/django-pagination.git@e5f669036c#egg=django_pagination-dev
+git+https://github.com/zyga/django-pagination.git@86caf15#egg=django_pagination-dev
```
