### PR TITLE
Fix signup issues and brand allauth emails

### DIFF
--- a/readthedocs/core/adapters.py
+++ b/readthedocs/core/adapters.py
@@ -1,0 +1,34 @@
+"""Allauth overrides"""
+
+from allauth.account.adapter import DefaultAccountAdapter
+from django.template.loader import render_to_string
+
+from readthedocs.core.utils import send_email
+
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_unicode as force_text
+
+
+class AccountAdapter(DefaultAccountAdapter):
+
+    """Customize Allauth emails to match our current patterns"""
+
+    def format_email_subject(self, subject):
+        return force_text(subject)
+
+    def send_mail(self, template_prefix, email, context):
+        subject = render_to_string(
+            '{0}_subject.txt'.format(template_prefix), context
+        )
+        subject = " ".join(subject.splitlines()).strip()
+        subject = self.format_email_subject(subject)
+
+        send_email(
+            recipient=email,
+            subject=subject,
+            template='{0}_message.txt'.format(template_prefix),
+            template_html='{0}_message.html'.format(template_prefix),
+            context=context
+        )

--- a/readthedocs/core/tasks.py
+++ b/readthedocs/core/tasks.py
@@ -41,7 +41,7 @@ def send_email_task(recipient, subject, template, template_html, context=None):
     )
     try:
         msg.attach_alternative(get_template(template_html).render(context),
-                            'text/html')
+                               'text/html')
     except TemplateDoesNotExist:
         pass
     msg.send()

--- a/readthedocs/core/tasks.py
+++ b/readthedocs/core/tasks.py
@@ -6,6 +6,7 @@ from celery import task
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import get_template
+from django.template import TemplateDoesNotExist
 
 
 log = logging.getLogger(__name__)
@@ -38,7 +39,10 @@ def send_email_task(recipient, subject, template, template_html, context=None):
         settings.DEFAULT_FROM_EMAIL,
         [recipient]
     )
-    msg.attach_alternative(get_template(template_html).render(context),
-                           'text/html')
+    try:
+        msg.attach_alternative(get_template(template_html).render(context),
+                            'text/html')
+    except TemplateDoesNotExist:
+        pass
     msg.send()
     log.info('Sent email to recipient: %s', recipient)

--- a/readthedocs/notifications/storages.py
+++ b/readthedocs/notifications/storages.py
@@ -45,11 +45,12 @@ class FallbackUniqueStorage(FallbackStorage):
         return safe_messages, all_ret
 
     def add(self, level, message, extra_tags='', *args, **kwargs):
-        persist_messages = (PersistentMessage.objects
-                            .filter(message=message,
-                                    user=self.request.user,
-                                    read=False))
-        if persist_messages.exists():
-            return
+        if self.request.user.is_authenticated():
+            persist_messages = (PersistentMessage.objects
+                                .filter(message=message,
+                                        user=self.request.user,
+                                        read=False))
+            if persist_messages.exists():
+                return
         super(FallbackUniqueStorage, self).add(level, message, extra_tags,
                                                *args, **kwargs)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -240,6 +240,7 @@ class CommunityBaseSettings(Settings):
     DOCKER_IMAGE = 'readthedocs/build:14.04'
 
     # All auth
+    ACCOUNT_ADAPTER = 'readthedocs.core.adapters.AccountAdapter'
     ACCOUNT_EMAIL_REQUIRED = True
     ACCOUNT_EMAIL_VERIFICATION = "mandatory"
     ACCOUNT_AUTHENTICATION_METHOD = "username_email"

--- a/readthedocs/templates/account/email/email_confirmation_message.html
+++ b/readthedocs/templates/account/email/email_confirmation_message.html
@@ -1,0 +1,21 @@
+{% extends "core/email/common.html" %}
+
+{% load i18n %}
+
+{% block content %}
+  {% blocktrans %}
+    <p>
+      To complete setting up your account, please verify this email address by
+      going to:
+    </p>
+
+    <p>
+      <a href="{{ activate_url }}">{{ activate_url }}</a>
+    </p>
+
+    <p>
+      If you did not sign up for an account with Read the Docs, you can
+      disregard this email.
+    </p>
+  {% endblocktrans %}
+{% endblock %}

--- a/readthedocs/templates/account/email/email_confirmation_message.txt
+++ b/readthedocs/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,13 @@
+{% extends "core/email/common.txt" %}
+
+{% load i18n %}
+
+{% block content %}{% blocktrans %}
+To verify your email address and finish setting up your account, please
+go to:
+
+{{ activate_url }}
+
+If you did not sign up for an account with Read the Docs, you can
+disregard this email.
+{% endblocktrans %}{% endblock %}

--- a/readthedocs/templates/account/email/email_confirmation_signup_message.html
+++ b/readthedocs/templates/account/email/email_confirmation_signup_message.html
@@ -1,0 +1,1 @@
+{% extends "account/email/email_confirmation_message.html" %}

--- a/readthedocs/templates/account/email/email_confirmation_signup_message.txt
+++ b/readthedocs/templates/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,1 @@
+{% extends "account/email/email_confirmation_message.txt" %}

--- a/readthedocs/templates/account/email/email_confirmation_subject.txt
+++ b/readthedocs/templates/account/email/email_confirmation_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Verify your e-mail address{% endblocktrans %}
+{% endautoescape %}

--- a/readthedocs/templates/account/email/password_key_reset_message.html
+++ b/readthedocs/templates/account/email/password_key_reset_message.html
@@ -1,0 +1,20 @@
+{% extends "core/email/common.html" %}
+
+{% load i18n %}
+
+{% block content %}
+  {% blocktrans %}
+    <p>
+      A request has been made to reset your Read the Docs password. To confirm
+      this reset request, please go to:
+    </p>
+
+    <p>
+      <a href="{{ password_reset_url }}">{{ password_reset_url }}</a>
+    </p>
+
+    <p>
+      If you did not request to reset you password, you can disregard this email.
+    </p>
+  {% endblocktrans %}
+{% endblock %}

--- a/readthedocs/templates/account/email/password_key_reset_message.txt
+++ b/readthedocs/templates/account/email/password_key_reset_message.txt
@@ -1,0 +1,12 @@
+{% extends "core/email/common.txt" %}
+
+{% load i18n %}
+
+{% block content %}{% blocktrans %}
+A request has been made to reset your Read the Docs password. To confirm
+this reset request, please go to:
+
+{{ password_reset_url }}
+
+If you did not request to reset you password, you can disregard this email.
+{% endblocktrans %}{% endblock %}

--- a/readthedocs/templates/account/email/password_key_reset_subject.txt
+++ b/readthedocs/templates/account/email/password_key_reset_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Password reset{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
This fixes a bug with the notification system on logged out users and overrides
the allauth email templates. The base emails are very generic, aren't themed like
the rest of our emails, and had very generic copy.