### PR TITLE
Import a project's programming language from GitHub.

### DIFF
--- a/readthedocs/core/management/commands/import_github_language.py
+++ b/readthedocs/core/management/commands/import_github_language.py
@@ -22,10 +22,12 @@ class Command(BaseCommand):
     Requies a ``GITHUB_AUTH_TOKEN`` to be set in the environment,
     which should contain a proper GitHub Oauth Token for rate limiting.
     """
+
     def handle(self, *args, **options):
         token = os.environ.get('GITHUB_AUTH_TOKEN')
         if not token:
             print 'Invalid GitHub token, exiting'
+            return
 
         for project in Project.objects.filter(programming_language__in=['', 'words']):
             user = repo = ''

--- a/readthedocs/core/management/commands/import_github_language.py
+++ b/readthedocs/core/management/commands/import_github_language.py
@@ -1,0 +1,51 @@
+import os
+import requests
+
+from django.core.management.base import BaseCommand
+
+from readthedocs.projects.models import Project
+from readthedocs.projects.constants import GITHUB_REGEXS, PROGRAMMING_LANGUAGES
+
+PL_DICT = {}
+
+for slug, name in PROGRAMMING_LANGUAGES:
+    PL_DICT[name] = slug
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        token = os.environ.get('GITHUB_AUTH_TOKEN')
+        if not token:
+            print 'Invalid GitHub token, exiting'
+
+        for project in Project.objects.filter(programming_language__in=['', 'words']):
+            user = repo = ''
+            repo_url = project.repo
+            for regex in GITHUB_REGEXS:
+                match = regex.search(repo_url)
+                if match:
+                    user, repo = match.groups()
+                    break
+
+            if not user:
+                print 'No GitHub repo for %s' % repo_url
+                continue
+
+            headers = {'Authorization': 'token {token}'.format(token=token)}
+            url = 'https://api.github.com/repos/{user}/{repo}/languages'.format(
+                user=user,
+                repo=repo,
+            )
+
+            resp = requests.get(url, headers=headers)
+            languages = resp.json()
+            sorted_langs = sorted(languages.items(), key=lambda x: x[1], reverse=True)
+            print 'Sorted langs: %s ' % sorted_langs
+            top_lang = sorted_langs[0][0]
+            if top_lang in PL_DICT:
+                slug = PL_DICT[top_lang]
+                print 'Setting %s to %s' % (repo_url, slug)
+                project.programming_language = slug
+                project.save()
+            else:
+                print 'Language unknown: %s' % top_lang

--- a/readthedocs/core/management/commands/import_github_language.py
+++ b/readthedocs/core/management/commands/import_github_language.py
@@ -42,12 +42,12 @@ class Command(BaseCommand):
                 print 'No GitHub repo for %s' % repo_url
                 continue
 
-            headers = {'Authorization': 'token {token}'.format(token=token)}
             url = 'https://api.github.com/repos/{user}/{repo}/languages'.format(
                 user=user,
                 repo=repo,
             )
-
+            # We need this to get around GitHub's rate limiting
+            headers = {'Authorization': 'token {token}'.format(token=token)}
             resp = requests.get(url, headers=headers)
             languages = resp.json()
             sorted_langs = sorted(languages.items(), key=lambda x: x[1], reverse=True)

--- a/readthedocs/core/management/commands/import_github_language.py
+++ b/readthedocs/core/management/commands/import_github_language.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             print 'Invalid GitHub token, exiting'
             return
 
-        for project in Project.objects.filter(programming_language__in=['', 'words']):
+        for project in Project.objects.filter(programming_language__in=['none', '', 'words']):
             user = repo = ''
             repo_url = project.repo
             for regex in GITHUB_REGEXS:

--- a/readthedocs/core/management/commands/import_github_language.py
+++ b/readthedocs/core/management/commands/import_github_language.py
@@ -13,6 +13,15 @@ for slug, name in PROGRAMMING_LANGUAGES:
 
 
 class Command(BaseCommand):
+    """
+    Import a project's programming language from GitHub.
+
+    This builds a basic management command that will set
+    a projects language to the most used one in GitHub.
+
+    Requies a ``GITHUB_AUTH_TOKEN`` to be set in the environment,
+    which should contain a proper GitHub Oauth Token for rate limiting.
+    """
     def handle(self, *args, **options):
         token = os.environ.get('GITHUB_AUTH_TOKEN')
         if not token:

--- a/readthedocs/donate/migrations/0008_add-programming-language-filter.py
+++ b/readthedocs/donate/migrations/0008_add-programming-language-filter.py
@@ -18,6 +18,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='supporterpromo',
             name='programming_language',
-            field=models.CharField(default=None, choices=[(b'words', b'Only Words'), (b'py', b'Python'), (b'js', b'Javascript'), (b'php', b'PHP'), (b'ruby', b'Ruby'), (b'perl', b'Perl'), (b'java', b'Java'), (b'go', b'Go'), (b'julia', b'Julia'), (b'c', b'C'), (b'csharp', b'C#'), (b'cpp', b'C++'), (b'objc', b'Objective-C'), (b'other', b'Other')], max_length=200, blank=True, null=True, verbose_name='Programming Language'),
+            field=models.CharField(default=None, choices=[(b'words', b'Only Words'), (b'py', b'Python'), (b'js', b'Javascript'), (b'php', b'PHP'), (b'ruby', b'Ruby'), (b'perl', b'Perl'), (b'java', b'Java'), (b'go', b'Go'), (b'julia', b'Julia'), (b'c', b'C'), (b'csharp', b'C#'), (b'cpp', b'C++'), (b'objc', b'Objective-C'), (b'other', b'Other')], max_length=20, blank=True, null=True, verbose_name='Programming Language'),
         ),
     ]

--- a/readthedocs/donate/migrations/0008_add-programming-language-filter.py
+++ b/readthedocs/donate/migrations/0008_add-programming-language-filter.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='supporterpromo',
-            name='programming_languages',
-            field=models.CharField(default=None, choices=[(b'words', b'Only Words'), (b'py', b'Python'), (b'js', b'Javascript'), (b'php', b'PHP'), (b'ruby', b'Ruby'), (b'perl', b'Perl'), (b'java', b'Java'), (b'go', b'Go'), (b'julia', b'Julia'), (b'c', b'C'), (b'csharp', b'C#'), (b'cpp', b'C++'), (b'objc', b'Objective-C'), (b'other', b'Other')], max_length=200, blank=True, null=True, verbose_name='Programming Languages'),
+            name='programming_language',
+            field=models.CharField(default=None, choices=[(b'words', b'Only Words'), (b'py', b'Python'), (b'js', b'Javascript'), (b'php', b'PHP'), (b'ruby', b'Ruby'), (b'perl', b'Perl'), (b'java', b'Java'), (b'go', b'Go'), (b'julia', b'Julia'), (b'c', b'C'), (b'csharp', b'C#'), (b'cpp', b'C++'), (b'objc', b'Objective-C'), (b'other', b'Other')], max_length=200, blank=True, null=True, verbose_name='Programming Language'),
         ),
     ]

--- a/readthedocs/donate/migrations/0008_add-programming-language-filter.py
+++ b/readthedocs/donate/migrations/0008_add-programming-language-filter.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('donate', '0007_add-impression-totals'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='supporterpromo',
+            options={'ordering': ('-live',)},
+        ),
+        migrations.AddField(
+            model_name='supporterpromo',
+            name='programming_languages',
+            field=models.CharField(default=None, choices=[(b'words', b'Only Words'), (b'py', b'Python'), (b'js', b'Javascript'), (b'php', b'PHP'), (b'ruby', b'Ruby'), (b'perl', b'Perl'), (b'java', b'Java'), (b'go', b'Go'), (b'julia', b'Julia'), (b'c', b'C'), (b'csharp', b'C#'), (b'cpp', b'C++'), (b'objc', b'Objective-C'), (b'other', b'Other')], max_length=200, blank=True, null=True, verbose_name='Programming Languages'),
+        ),
+    ]

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -72,7 +72,7 @@ class SupporterPromo(models.Model):
                                     choices=DISPLAY_CHOICES, default='doc')
     sold_impressions = models.IntegerField(_('Sold Impressions'), default=1000)
     sold_days = models.IntegerField(_('Sold Days'), default=30)
-    programming_language = models.CharField(_('Programming Language'), max_length=200,
+    programming_language = models.CharField(_('Programming Language'), max_length=20,
                                             choices=PROGRAMMING_LANGUAGES, default=None,
                                             blank=True, null=True)
     live = models.BooleanField(_('Live'), default=False)

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -72,7 +72,7 @@ class SupporterPromo(models.Model):
                                     choices=DISPLAY_CHOICES, default='doc')
     sold_impressions = models.IntegerField(_('Sold Impressions'), default=1000)
     sold_days = models.IntegerField(_('Sold Days'), default=30)
-    programming_language = models.CharField(_('Programming Languages'), max_length=200,
+    programming_language = models.CharField(_('Programming Language'), max_length=200,
                                             choices=PROGRAMMING_LANGUAGES, default=None,
                                             blank=True, null=True)
     live = models.BooleanField(_('Live'), default=False)
@@ -217,8 +217,7 @@ class GeoFilter(models.Model):
                               blank=True, null=True)
     filter_type = models.CharField(_('Filter Type'), max_length=20,
                                    choices=FILTER_CHOICES, default='')
-    countries = models.ManyToManyField(Country, related_name='filters',
-                                       blank=True)
+    countries = models.ManyToManyField(Country, related_name='filters')
 
     @property
     def codes(self):
@@ -228,8 +227,5 @@ class GeoFilter(models.Model):
         return ret
 
     def __unicode__(self):
-        codes = []
-        for code in self.countries.values_list('country'):
-            codes.append(code[0])
         return "Filter for {promo} that {type}s: {countries}".format(
-            promo=self.promo.name, type=self.filter_type, countries=','.join(codes))
+            promo=self.promo.name, type=self.filter_type, countries=self.codes)

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -72,9 +72,9 @@ class SupporterPromo(models.Model):
                                     choices=DISPLAY_CHOICES, default='doc')
     sold_impressions = models.IntegerField(_('Sold Impressions'), default=1000)
     sold_days = models.IntegerField(_('Sold Days'), default=30)
-    programming_languages = models.CharField(_('Programming Languages'), max_length=200,
-                                             choices=PROGRAMMING_LANGUAGES, default=None,
-                                             blank=True, null=True)
+    programming_language = models.CharField(_('Programming Languages'), max_length=200,
+                                            choices=PROGRAMMING_LANGUAGES, default=None,
+                                            blank=True, null=True)
     live = models.BooleanField(_('Live'), default=False)
 
     class Meta:

--- a/readthedocs/donate/models.py
+++ b/readthedocs/donate/models.py
@@ -8,6 +8,7 @@ from django_countries.fields import CountryField
 
 from readthedocs.donate.utils import get_ad_day
 from readthedocs.projects.models import Project
+from readthedocs.projects.constants import PROGRAMMING_LANGUAGES
 
 
 DISPLAY_CHOICES = (
@@ -71,6 +72,9 @@ class SupporterPromo(models.Model):
                                     choices=DISPLAY_CHOICES, default='doc')
     sold_impressions = models.IntegerField(_('Sold Impressions'), default=1000)
     sold_days = models.IntegerField(_('Sold Days'), default=30)
+    programming_languages = models.CharField(_('Programming Languages'), max_length=200,
+                                             choices=PROGRAMMING_LANGUAGES, default=None,
+                                             blank=True, null=True)
     live = models.BooleanField(_('Live'), default=False)
 
     class Meta:

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -38,8 +38,8 @@ def show_to_programming_language(promo, programming_language):
     which means show to all languages.
     """
 
-    if promo.programming_languages.count():
-        return programming_language in promo.programming_languages
+    if promo.programming_language:
+        return programming_language == promo.programming_language
     return True
 
 
@@ -96,17 +96,14 @@ def get_promo(country_code, programming_language, gold_project=False, gold_user=
 
     filtered_promos = []
     for obj in promo_queryset:
-        filtered = False
-        if country_code:
-            filtered = True
-            if show_to_geo(obj, country_code):
-                filtered_promos.append(obj)
-        if programming_language:
-            filtered = True
-            if show_to_programming_language(obj, country_code):
-                filtered_promos.append(obj)
-        if not filtered:
-            filtered_promos.append(obj)
+        # Break out if we aren't meant to show to this language
+        if programming_language and not show_to_programming_language(obj, country_code):
+                continue
+        # Break out if we aren't meant to show to this country
+        if country_code and not show_to_geo(obj, country_code):
+                continue
+        # If we haven't bailed because of language or country, possibly show the promo
+        filtered_promos.append(obj)
 
     promo_obj = choose_promo(filtered_promos)
 

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -30,6 +30,19 @@ def show_to_geo(promo, country_code):
     return True
 
 
+def show_to_programming_language(promo, programming_language):
+    """
+    Filter a promo by a specific programming language
+
+    Return True if we haven't set a specific language,
+    which means show to all languages.
+    """
+
+    if promo.programming_languages.count():
+        return programming_language in promo.programming_languages
+    return True
+
+
 def choose_promo(promo_list):
     """
     This is the algorithm to pick which promo to show.
@@ -67,7 +80,7 @@ def choose_promo(promo_list):
     return None
 
 
-def get_promo(country_code, gold_project=False, gold_user=False):
+def get_promo(country_code, programming_language, gold_project=False, gold_user=False):
     """
     Get a proper promo.
 
@@ -76,19 +89,26 @@ def get_promo(country_code, gold_project=False, gold_user=False):
     * Gold User status
     * Gold Project status
     * Geo
+    * Programming Language
     """
 
     promo_queryset = SupporterPromo.objects.filter(live=True, display_type='doc')
 
-    filtered_objects = []
+    filtered_promos = []
     for obj in promo_queryset:
+        filtered = False
         if country_code:
+            filtered = True
             if show_to_geo(obj, country_code):
-                filtered_objects.append(obj)
-        else:
-            filtered_objects.append(obj)
+                filtered_promos.append(obj)
+        if programming_language:
+            filtered = True
+            if show_to_programming_language(obj, country_code):
+                filtered_promos.append(obj)
+        if not filtered:
+            filtered_promos.append(obj)
 
-    promo_obj = choose_promo(filtered_objects)
+    promo_obj = choose_promo(filtered_promos)
 
     # Show a random house ad if we don't have anything else
     if not promo_obj:
@@ -161,6 +181,7 @@ def attach_promo_data(sender, **kwargs):
     if show_promo:
         promo_obj = get_promo(
             country_code=country_code,
+            programming_language=project.programming_language,
             gold_project=gold_project,
             gold_user=gold_user,
         )

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -97,7 +97,7 @@ def get_promo(country_code, programming_language, gold_project=False, gold_user=
     filtered_promos = []
     for obj in promo_queryset:
         # Break out if we aren't meant to show to this language
-        if programming_language and not show_to_programming_language(obj, country_code):
+        if programming_language and not show_to_programming_language(obj, programming_language):
                 continue
         # Break out if we aren't meant to show to this country
         if country_code and not show_to_geo(obj, country_code):

--- a/readthedocs/donate/signals.py
+++ b/readthedocs/donate/signals.py
@@ -98,10 +98,10 @@ def get_promo(country_code, programming_language, gold_project=False, gold_user=
     for obj in promo_queryset:
         # Break out if we aren't meant to show to this language
         if programming_language and not show_to_programming_language(obj, programming_language):
-                continue
+            continue
         # Break out if we aren't meant to show to this country
         if country_code and not show_to_geo(obj, country_code):
-                continue
+            continue
         # If we haven't bailed because of language or country, possibly show the promo
         filtered_promos.append(obj)
 

--- a/readthedocs/donate/tests.py
+++ b/readthedocs/donate/tests.py
@@ -13,7 +13,7 @@ from django_dynamic_fixture import get
 from .models import (SupporterPromo, GeoFilter, Country,
                      CLICKS, VIEWS, OFFERS,
                      INCLUDE, EXCLUDE)
-from .signals import show_to_geo, get_promo, choose_promo
+from .signals import show_to_geo, get_promo, choose_promo, show_to_programming_language
 from readthedocs.projects.models import Project
 
 
@@ -197,7 +197,9 @@ class FilterTests(TestCase):
                          slug='promo-slug',
                          link='http://example.com',
                          live=True,
-                         image='http://media.example.com/img.png')
+                         programming_language='py',
+                         image='http://media.example.com/img.png'
+                         )
         self.filter = get(GeoFilter,
                           promo=self.promo,
                           countries=[us, ca, mx],
@@ -209,6 +211,7 @@ class FilterTests(TestCase):
                           slug='promo2-slug',
                           link='http://example.com',
                           live=True,
+                          programming_language='js',
                           image='http://media.example.com/img.png')
         self.filter2 = get(GeoFilter,
                            promo=self.promo2,
@@ -216,7 +219,7 @@ class FilterTests(TestCase):
                            filter_type=EXCLUDE,
                            )
 
-        self.pip = get(Project, slug='pip', allow_promos=True)
+        self.pip = get(Project, slug='pip', allow_promos=True, programming_language='py')
 
     def test_include(self):
         # US view
@@ -257,6 +260,19 @@ class FilterTests(TestCase):
 
         ret = get_promo('RANDOM')
         self.assertEqual(ret, self.promo2)
+
+    def test_programming_language(self):
+        ret = show_to_programming_language(self.promo, 'py')
+        self.assertTrue(ret)
+
+        ret = show_to_programming_language(self.promo, 'js')
+        self.assertFalse(ret)
+
+        ret = show_to_programming_language(self.promo2, 'py')
+        self.assertTrue(ret)
+
+        ret = show_to_programming_language(self.promo2, 'js')
+        self.assertFalse(ret)
 
 
 class ProbabilityTests(TestCase):


### PR DESCRIPTION
This builds a basic management command that will set
a projects language to the most used one in GitHub.

I'm guessing this will need a bit more expansion into a similar model as the Country stuff. Currently we just have a binary y/n -- but I think folks in the future will want to do "Show this to Python, This to JS, and this to everyone else" which isn't currently well supported here.
