### PR TITLE
Pin django-filter

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -56,6 +56,7 @@ docker-py==1.3.1
 django-textclassifier==1.0
 django-annoying==0.8.4
 django-messages-extends==0.5
+django-filter<1.0
 
 # Docs
 sphinxcontrib-httpdomain==1.4.0
@@ -71,6 +72,5 @@ git+https://github.com/zestedesavoir/django-cors-middleware.git@def9dc2f5e81eed5
 nilsimsa==0.3.7
 
 # Pegged git requirements
-git+https://github.com/alex/django-filter.git#egg=django-filter
 git+https://github.com/ericflo/django-pagination.git@e5f669036c#egg=django_pagination-dev
 git+https://github.com/alex/django-taggit.git#egg=django_taggit-dev


### PR DESCRIPTION
The new 1.0 series is incompatible, and I've opened #2498 for this purpose.

Meanwhile, as the current master is broken because of this, the version should be pinned - I guess it's sort of bad practice to use the `master` branch anyways, am thinking it's possibly also an outdated decision now.

This fixes #2495 and #2490