### PR TITLE
Fix bug with path resolution

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -186,8 +186,7 @@ class ResolverBase(object):
         if '.' in filename and '.html' not in filename:
             return filename
         filename = filename.lstrip('/')
-        filename = re.sub('index.html$', '', filename)
-        filename = re.sub('index$', '', filename)
+        filename = re.sub(r'(^|/)index(?:.html)?$', '\\1', filename)
         if filename:
             if filename.endswith('/') or filename.endswith('.html'):
                 path = filename

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -50,6 +50,13 @@ class SmartResolverPathTests(ResolverBase):
             url = resolve_path(project=self.pip, filename='foo/index/index.html')
             self.assertEqual(url, '/docs/pip/en/latest/foo/index/')
 
+    def test_resolver_filename_false_index(self):
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve_path(project=self.pip, filename='foo/foo_index.html')
+            self.assertEqual(url, '/docs/pip/en/latest/foo/foo_index.html')
+            url = resolve_path(project=self.pip, filename='foo_index/foo_index.html')
+            self.assertEqual(url, '/docs/pip/en/latest/foo_index/foo_index.html')
+
     def test_resolver_filename_sphinx(self):
         self.pip.documentation_type = 'sphinx'
         with override_settings(USE_SUBDOMAIN=False):


### PR DESCRIPTION
If a filename is `something_index.html`, `resolve_path` was stripping out the
`index.html` due to an incorrect substring lookup. Instead, look for either a
URL path separator or a beginning of line.