### PR TITLE
Adds support for custom conda channels in the config file

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -88,6 +88,13 @@ class ConfigWrapper(object):
             return None
 
     @property
+    def conda_channels(self):
+        if 'channels' in self._yaml_config.get('conda', []):
+            return self._yaml_config['conda']['channels']
+        else:
+            return None
+
+    @property
     def requirements_file(self):
         if 'requirements_file' in self._yaml_config:
             return self._yaml_config['requirements_file']

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -178,15 +178,20 @@ class Conda(PythonEnvironment):
             # Re-create conda directory each time to keep fresh state
             self._log('Removing existing conda directory')
             shutil.rmtree(version_path)
+
+        conda_cmd = [
+            'conda', 'env', 'create', '--prefix', self.venv_path(),
+            '--file', self.config.conda_file
+        ]
+
+        if self.config.conda_channels is not None:
+            for channel in self.config.conda_channels:
+                conda_cmd.append('-c')
+                conda_cmd.append(channel)
+
         self.build_env.run(
-            'conda',
-            'env',
-            'create',
-            '--name',
-            self.version.slug,
-            '--file',
-            self.config.conda_file,
             bin_path=None,  # Don't use conda bin that doesn't exist yet
+            *conda_cmd
         )
 
     def install_core_requirements(self):
@@ -206,8 +211,8 @@ class Conda(PythonEnvironment):
             'conda',
             'install',
             '--yes',
-            '--name',
-            self.version.slug,
+            '--prefix',
+            self.venv_path(),
         ]
         cmd.extend(requirements)
         self.build_env.run(
@@ -238,12 +243,5 @@ class Conda(PythonEnvironment):
         )
 
     def install_user_requirements(self):
-        self.build_env.run(
-            'conda',
-            'env',
-            'update',
-            '--name',
-            self.version.slug,
-            '--file',
-            self.config.conda_file,
-        )
+        # User requirements are installed during the conda create
+        pass


### PR DESCRIPTION
A project I'm involved with (UV-CDAT/vcs) uses automodule, and our build is kind of gnarly (lots of misc. science tools), so we distribute conda packages to install everything. We're not on the main conda channel, though; we live at http://anaconda.org/uvcdat. In order to successfully build our API docs, we need to be able to specify the channels to use for conda to find our packages. The environment.yml file sometimes-sort-of-supports doing this itself, but the most reliable way is to manually specify what channels to search (using the `-c` option). I added support to the config file for a conda > channels list, and reworked the install process to handle it appropriately.

I also made the conda install use path-based environments, so it works more or less the same as virtualenv. I'm about 75% sure that the `install_user_requirements` function wasn't doing anything useful for the conda build (since creating the environment from a conda environment file installs all of the packages listed in it), so I removed the body of that function.

I was a little confused as to how to run tests; I wound up with: 

`DJANGO_SETTINGS_MODULE=readthedocs.settings.test py.test --ignore rtd`

which got me a few failures (which all look path related). I'll happily run again given more input as to how to do so. I'm also happy to add tests as necessary.