### PR TITLE
Add slugify fork that allows for dns safe slugging

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -145,7 +145,7 @@ def slugify(value, *args, **kwargs):
 
     :param dns_safe: Remove underscores from slug as well
     """
-    dns_safe = kwargs.pop('dns_safe', False)
+    dns_safe = kwargs.pop('dns_safe', True)
     value = slugify_base(value, *args, **kwargs)
     if dns_safe:
         value = mark_safe(re.sub('[-_]+', '-', value))

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -152,10 +152,4 @@ def slugify(value, *args, **kwargs):
     return value
 
 
-def slugify_dns_safe(value, *args, **kwargs):
-    kwargs['dns_safe'] = True
-    return slugify(value, *args, **kwargs)
-
-
 slugify = allow_lazy(slugify, six.text_type, SafeText)
-slugify_dns_safe = allow_lazy(slugify_dns_safe, six.text_type, SafeText)

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -88,7 +88,7 @@ class ProjectBasicsForm(ProjectForm):
     def clean_name(self):
         name = self.cleaned_data.get('name', '')
         if not self.instance.pk:
-            potential_slug = slugify(name, dns_safe=True)
+            potential_slug = slugify(name)
             if Project.objects.filter(slug=potential_slug).exists():
                 raise forms.ValidationError(
                     _('Invalid project name, a project already exists with that name'))

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -6,7 +6,6 @@ from urlparse import urlparse
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.template.defaultfilters import slugify
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
@@ -15,7 +14,7 @@ from textclassifier.validators import ClassifierValidator
 from guardian.shortcuts import assign
 
 from readthedocs.builds.constants import TAG
-from readthedocs.core.utils import trigger_build
+from readthedocs.core.utils import trigger_build, slugify
 from readthedocs.redirects.models import Redirect
 from readthedocs.projects import constants
 from readthedocs.projects.exceptions import ProjectSpamError
@@ -89,7 +88,7 @@ class ProjectBasicsForm(ProjectForm):
     def clean_name(self):
         name = self.cleaned_data.get('name', '')
         if not self.instance.pk:
-            potential_slug = slugify(name)
+            potential_slug = slugify(name, dns_safe=True)
             if Project.objects.filter(slug=potential_slug).exists():
                 raise forms.ValidationError(
                     _('Invalid project name, a project already exists with that name'))

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -10,14 +10,13 @@ from django.contrib.auth.models import User
 from django.core.exceptions import MultipleObjectsReturned
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.db import models
-from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
 
 from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
 from readthedocs.api.client import api
-from readthedocs.core.utils import broadcast
+from readthedocs.core.utils import broadcast, slugify
 from readthedocs.restapi.client import api as apiv2
 from readthedocs.builds.constants import LATEST, LATEST_VERBOSE_NAME, STABLE
 from readthedocs.privacy.loader import (RelatedProjectManager, ProjectManager,
@@ -304,7 +303,7 @@ class Project(models.Model):
         first_save = self.pk is None
         if not self.slug:
             # Subdomains can't have underscores in them.
-            self.slug = slugify(self.name).replace('_', '-')
+            self.slug = slugify(self.name)
             if self.slug == '':
                 raise Exception(_("Model must have slug"))
         super(Project, self).save(*args, **kwargs)

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -8,7 +8,7 @@ from django.test.utils import override_settings
 
 from readthedocs.projects.models import Project
 from readthedocs.builds.models import Version
-from readthedocs.core.utils import trigger_build
+from readthedocs.core.utils import trigger_build, slugify
 
 
 class CoreUtilTests(TestCase):
@@ -78,3 +78,16 @@ class CoreUtilTests(TestCase):
                 }
             )
         ])
+
+    def test_slugify(self):
+        """Test additional slugify"""
+        self.assertEqual(slugify('This is a test'),
+                         'this-is-a-test')
+        self.assertEqual(slugify('project_with_underscores-v.1.0'),
+                         'project_with_underscores-v10')
+        self.assertEqual(slugify('project_with_underscores-v.1.0', dns_safe=True),
+                         'project-with-underscores-v10')
+        self.assertEqual(slugify('A title_-_with separated parts'),
+                         'a-title_-_with-separated-parts')
+        self.assertEqual(slugify('A title_-_with separated parts', dns_safe=True),
+                         'a-title-with-separated-parts')

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -84,10 +84,10 @@ class CoreUtilTests(TestCase):
         self.assertEqual(slugify('This is a test'),
                          'this-is-a-test')
         self.assertEqual(slugify('project_with_underscores-v.1.0'),
-                         'project_with_underscores-v10')
-        self.assertEqual(slugify('project_with_underscores-v.1.0', dns_safe=True),
                          'project-with-underscores-v10')
+        self.assertEqual(slugify('project_with_underscores-v.1.0', dns_safe=False),
+                         'project_with_underscores-v10')
         self.assertEqual(slugify('A title_-_with separated parts'),
-                         'a-title_-_with-separated-parts')
-        self.assertEqual(slugify('A title_-_with separated parts', dns_safe=True),
                          'a-title-with-separated-parts')
+        self.assertEqual(slugify('A title_-_with separated parts', dns_safe=False),
+                         'a-title_-_with-separated-parts')


### PR DESCRIPTION
This adds a function that wraps the django core `slugify`, replacing multiple
non-alpha characters with `-`.