### PR TITLE
SingleHtmlBuilder; impl __init__ to fix singlehtml

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -183,7 +183,10 @@ class HtmlDirBuilder(HtmlBuilder):
 
 class SingleHtmlBuilder(HtmlBuilder):
     type = 'sphinx_singlehtml'
-    sphinx_builder = 'readthedocssinglehtml'
+
+    def __init__(self, *args, **kwargs):
+        super(SingleHtmlBuilder, self).__init__(*args, **kwargs)
+        sphinx_builder = 'readthedocssinglehtml'
 
 
 class SearchBuilder(BaseSphinx):


### PR DESCRIPTION
In a previous commit, an __init__ method was added to HtmlBuilder and to
HtmlDirBuilder, however the SingleHtmlBuilder was unmodified. Since
SingleHtmlBuilder inherits from HtmlBuilder, HtmlBuilder.init is
executed which sets the instance variable "sphinx_builder" to either
"readthedocs" or "readthedocs-comments".

This instance variable from HtmlBuilder makes it impossible to get the
correct value from SingleHtmlBuilder's class variable "shpinx_builder"
"readthedocssinglehtml".

The fix is to implement the __init__ method for SingleHtmlBuilder and
set self.sphinx_builder accurately.