### PR TITLE
Remove submodule docs/_themes/sphinx_rtd_theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes/sphinx_rtd_theme"]
-	path = docs/_themes/sphinx_rtd_theme
-	url = https://github.com/snide/sphinx_rtd_theme.git


### PR DESCRIPTION
The submodule `docs/_themes/sphinx_rtd_theme` appears to be unused. I spent quite a bit of time trying to test a fix for the sphinx_rtd_theme (snide/sphinx_rtd_theme#342) only to find out the submodule was a red herring, so I'd like to see it removed to prevent any future confusion.

### Commit Message

```
The submodule was only relevant for a short time and its continued
existance is a distraction for new contributors.

See: snide/sphinx_rtd_theme#342

Using git-blame, I was able to pinpoint which commit introduced the
submodule, but I wanted to be certain that it was no longer in use. So, I
manually inspected parts of the source code, ran `git grep ...`,
reviewed open and closed issues, and PRs, but found nothing conclusive
about its existence. Ultimately, git-log is what gave me the most
confidence that it is no longer necessary. As you can see, it was
introduced in October of 2013 and then made obsolete a month later.

From git-log:
  bash$ git log -G '_themes/sphinx_rtd_theme'
  commit 50619d1
  Author: Eric Holscher <eric@ericholscher.com>
  Date:   Fri Nov 8 18:55:06 2013 -0800

      Rejigger theme stuff in our own conf

  commit d9829a2
  Author: Eric Holscher <eric@ericholscher.com>
  Date:   Thu Oct 17 13:26:19 2013 -0700

      Add new theme
```