### PR TITLE
conf.py.tmpl; Use absolute URL for doc versions

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -81,7 +81,7 @@ context = {
     'MEDIA_URL': "{{ settings.MEDIA_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
     'versions': [{% for version in versions %}
-    ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}
+    ("{{ version.slug }}", "{{ version.get_absolute_url }}"),{% endfor %}
     ],
     'downloads': [ {% for key, val in downloads.items %}
     ("{{ key }}", "{{ val }}"),{% endfor %}


### PR DESCRIPTION
Use `version.get_absolute_url` instead of constructing a relative URL.

I traced the code back to `readthedocs.core.resolver` (https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/core/resolver.py#L132-L145), as I understand it, using `get_absolute_path` should work fine in all cases (`readthedocs.org/docs/<project>/<lang>/<version>/`, or `<project>.readthedocs.io/<lang>/<version>`, or `<project_domain>/<lang>/<version>/`, but I'll defer to the experts (and CI unit tests).


### Commit Message
```
Replaced the relative URL construction for document versions with
`version.get_absolute_url`.
```