### PR TITLE
Let identifier_friendly cope with unicode in identifiers

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -175,7 +175,7 @@ class Version(models.Model):
     def identifier_friendly(self):
         '''Return display friendly identifier'''
         re_sha = re.compile(r'^[0-9a-f]{40}$', re.I)
-        if re_sha.match(str(self.identifier)):
+        if re_sha.match(self.identifier):
             return self.identifier[:8]
         return self.identifier
 

--- a/readthedocs/projects/version_handling.py
+++ b/readthedocs/projects/version_handling.py
@@ -108,7 +108,7 @@ def version_windows(versions, major=1, minor=1, point=1):
 def parse_version_failsafe(version_string):
     try:
         return Version(version_string)
-    except (InvalidVersion, UnicodeEncodeError):
+    except InvalidVersion:
         return None
 
 

--- a/readthedocs/projects/version_handling.py
+++ b/readthedocs/projects/version_handling.py
@@ -108,7 +108,7 @@ def version_windows(versions, major=1, minor=1, point=1):
 def parse_version_failsafe(version_string):
     try:
         return Version(version_string)
-    except InvalidVersion:
+    except (InvalidVersion, UnicodeEncodeError):
         return None
 
 

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -15,7 +15,6 @@ from readthedocs.projects.models import Project
 class VersionCommitNameTests(TestCase):
     def test_branch_name_unicode_non_ascii(self):
         unicode_name = 'abc_\xd1\x84_\xe2\x99\x98'.decode('utf-8')
-
         version = new(Version, identifier=unicode_name, type=BRANCH)
         self.assertEqual(version.identifier_friendly, unicode_name)
 

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -25,19 +25,8 @@ class VersionCommitNameTests(TestCase):
                       type=BRANCH)
         self.assertEqual(version.commit_name, 'release-2.5.x')
 
-    def test_branch_name_unicode(self):
-        version = new(Version, identifier=u'release-2.5.x',
-                      slug='release-2.5.x', verbose_name='release-2.5.x',
-                      type=BRANCH)
-        self.assertEqual(version.commit_name, 'release-2.5.x')
-
     def test_tag_name(self):
         version = new(Version, identifier='10f1b29a2bd2', slug='release-2.5.0',
-                      verbose_name='release-2.5.0', type=TAG)
-        self.assertEqual(version.commit_name, 'release-2.5.0')
-
-    def test_tag_name_unicode(self):
-        version = new(Version, identifier=u'10f1b29a2bd2', slug='release-2.5.0',
                       verbose_name='release-2.5.0', type=TAG)
         self.assertEqual(version.commit_name, 'release-2.5.0')
 
@@ -49,13 +38,6 @@ class VersionCommitNameTests(TestCase):
     def test_stable_version_tag(self):
         version = new(Version,
                       identifier='3d92b728b7d7b842259ac2020c2fa389f13aff0d',
-                      slug=STABLE, verbose_name=STABLE, type=TAG)
-        self.assertEqual(version.commit_name,
-                         '3d92b728b7d7b842259ac2020c2fa389f13aff0d')
-
-    def test_stable_version_tag_unicode(self):
-        version = new(Version,
-                      identifier=u'3d92b728b7d7b842259ac2020c2fa389f13aff0d',
                       slug=STABLE, verbose_name=STABLE, type=TAG)
         self.assertEqual(version.commit_name,
                          '3d92b728b7d7b842259ac2020c2fa389f13aff0d')

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -19,6 +19,13 @@ class VersionCommitNameTests(TestCase):
         version = new(Version, identifier=unicode_name, type=BRANCH)
         self.assertEqual(version.identifier_friendly, unicode_name)
 
+    def test_branch_name_made_friendly_when_sha(self):
+        commit_hash = '3d92b728b7d7b842259ac2020c2fa389f13aff0d'
+        version = new(Version, identifier=commit_hash,
+                      slug=STABLE, verbose_name=STABLE, type=TAG)
+        # we shorten commit hashes to keep things readable
+        self.assertEqual(version.identifier_friendly, '3d92b728')
+
     def test_branch_name(self):
         version = new(Version, identifier='release-2.5.x',
                       slug='release-2.5.x', verbose_name='release-2.5.x',

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -13,6 +13,12 @@ from readthedocs.projects.models import Project
 
 
 class VersionCommitNameTests(TestCase):
+    def test_branch_name_unicode(self):
+        unicode_name = 'abc_\xd1\x84_\xe2\x99\x98'.decode('utf-8')
+
+        version = new(Version, identifier=unicode_name, type=BRANCH)
+        self.assertEqual(version.identifier_friendly, unicode_name)
+
     def test_branch_name(self):
         version = new(Version, identifier='release-2.5.x',
                       slug='release-2.5.x', verbose_name='release-2.5.x',

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -13,7 +13,7 @@ from readthedocs.projects.models import Project
 
 
 class VersionCommitNameTests(TestCase):
-    def test_branch_name_unicode(self):
+    def test_branch_name_unicode_non_ascii(self):
         unicode_name = 'abc_\xd1\x84_\xe2\x99\x98'.decode('utf-8')
 
         version = new(Version, identifier=unicode_name, type=BRANCH)
@@ -25,8 +25,19 @@ class VersionCommitNameTests(TestCase):
                       type=BRANCH)
         self.assertEqual(version.commit_name, 'release-2.5.x')
 
+    def test_branch_name_unicode(self):
+        version = new(Version, identifier=u'release-2.5.x',
+                      slug='release-2.5.x', verbose_name='release-2.5.x',
+                      type=BRANCH)
+        self.assertEqual(version.commit_name, 'release-2.5.x')
+
     def test_tag_name(self):
         version = new(Version, identifier='10f1b29a2bd2', slug='release-2.5.0',
+                      verbose_name='release-2.5.0', type=TAG)
+        self.assertEqual(version.commit_name, 'release-2.5.0')
+
+    def test_tag_name_unicode(self):
+        version = new(Version, identifier=u'10f1b29a2bd2', slug='release-2.5.0',
                       verbose_name='release-2.5.0', type=TAG)
         self.assertEqual(version.commit_name, 'release-2.5.0')
 
@@ -38,6 +49,13 @@ class VersionCommitNameTests(TestCase):
     def test_stable_version_tag(self):
         version = new(Version,
                       identifier='3d92b728b7d7b842259ac2020c2fa389f13aff0d',
+                      slug=STABLE, verbose_name=STABLE, type=TAG)
+        self.assertEqual(version.commit_name,
+                         '3d92b728b7d7b842259ac2020c2fa389f13aff0d')
+
+    def test_stable_version_tag_unicode(self):
+        version = new(Version,
+                      identifier=u'3d92b728b7d7b842259ac2020c2fa389f13aff0d',
                       slug=STABLE, verbose_name=STABLE, type=TAG)
         self.assertEqual(version.commit_name,
                          '3d92b728b7d7b842259ac2020c2fa389f13aff0d')


### PR DESCRIPTION
This fixes rendering of /projects/$proj/versions/ when a branch name contains a character which cannot be expressed in ascii.

The test here is very low-level compared the primary symptom; should I be adding something higher level as well?