### PR TITLE
Alter usage of message extends

### DIFF
--- a/readthedocs/notifications/storages.py
+++ b/readthedocs/notifications/storages.py
@@ -45,12 +45,12 @@ class FallbackUniqueStorage(FallbackStorage):
         return safe_messages, all_ret
 
     def add(self, level, message, extra_tags='', *args, **kwargs):
-        if self.request.user.is_authenticated():
-            persist_messages = (PersistentMessage.objects
-                                .filter(message=message,
-                                        user=self.request.user,
-                                        read=False))
-            if persist_messages.exists():
-                return
+        user = kwargs.get('user') or self.request.user
+        persist_messages = (PersistentMessage.objects
+                            .filter(message=message,
+                                    user=user,
+                                    read=False))
+        if persist_messages.exists():
+            return
         super(FallbackUniqueStorage, self).add(level, message, extra_tags,
                                                *args, **kwargs)

--- a/readthedocs/notifications/storages.py
+++ b/readthedocs/notifications/storages.py
@@ -46,11 +46,12 @@ class FallbackUniqueStorage(FallbackStorage):
 
     def add(self, level, message, extra_tags='', *args, **kwargs):
         user = kwargs.get('user') or self.request.user
-        persist_messages = (PersistentMessage.objects
-                            .filter(message=message,
-                                    user=user,
-                                    read=False))
-        if persist_messages.exists():
-            return
+        if not user.is_anonymous():
+            persist_messages = (PersistentMessage.objects
+                                .filter(message=message,
+                                        user=user,
+                                        read=False))
+            if persist_messages.exists():
+                return
         super(FallbackUniqueStorage, self).add(level, message, extra_tags,
                                                *args, **kwargs)

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -4,10 +4,12 @@ import mock
 import django_dynamic_fixture as fixture
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, AnonymousUser
+from messages_extends.models import Message as PersistentMessage
 
 from readthedocs.notifications import Notification
 from readthedocs.notifications.backends import EmailBackend, SiteBackend
+from readthedocs.notifications.constants import ERROR
 from readthedocs.builds.models import Build
 
 
@@ -22,6 +24,8 @@ from readthedocs.builds.models import Build
 class NotificationTests(TestCase):
 
     def test_notification_custom(self, send, render_to_string):
+        render_to_string.return_value = 'Test'
+
         class TestNotification(Notification):
             name = 'foo'
             subject = 'This is {{ foo.id }}'
@@ -54,25 +58,35 @@ class NotificationBackendTests(TestCase):
 
     @mock.patch('readthedocs.notifications.backends.send_email')
     def test_email_backend(self, send_email, render_to_string):
+        render_to_string.return_value = 'Test'
+
         class TestNotification(Notification):
             name = 'foo'
             subject = 'This is {{ foo.id }}'
             context_object_name = 'foo'
+            level = ERROR
 
         build = fixture.get(Build)
         req = mock.MagicMock()
-        notify = TestNotification(object=build, request=req)
+        user = fixture.get(User)
+        notify = TestNotification(object=build, request=req, user=user)
         backend = EmailBackend(request=req)
         backend.send(notify)
 
+        self.assertEqual(render_to_string.call_count, 1)
         send_email.assert_has_calls([
-            mock.call(level=21, request=req, message=mock.ANY, extra_tags='')
+            mock.call(
+                request=mock.ANY,
+                template='core/email/common.txt',
+                context={'content': 'Test'},
+                subject=u'This is 1',
+                template_html='core/email/common.html',
+                recipient=user.email,
+            )
         ])
 
-    @mock.patch('readthedocs.notifications.storages.FallbackUniqueStorage')
-    def test_email_backend(self, storage_class, render_to_string):
-        mock_storage = mock.Mock()
-        storage_class.return_value = mock_storage
+    def test_message_backend(self, render_to_string):
+        render_to_string.return_value = 'Test'
 
         class TestNotification(Notification):
             name = 'foo'
@@ -86,6 +100,33 @@ class NotificationBackendTests(TestCase):
         backend = SiteBackend(request=req)
         backend.send(notify)
 
-        mock_storage.add.assert_has_calls([
-            mock.call(level=21, message=mock.ANY, extra_tags='', user=user)
-        ])
+        self.assertEqual(render_to_string.call_count, 1)
+        self.assertEqual(PersistentMessage.objects.count(), 1)
+
+        message = PersistentMessage.objects.first()
+        self.assertEqual(message.user, user)
+
+    def test_message_anonymous_user(self, render_to_string):
+        """Anonymous user still throwns exception on persistent messages"""
+        render_to_string.return_value = 'Test'
+
+        class TestNotification(Notification):
+            name = 'foo'
+            subject = 'This is {{ foo.id }}'
+            context_object_name = 'foo'
+
+        build = fixture.get(Build)
+        user = AnonymousUser()
+        req = mock.MagicMock()
+        notify = TestNotification(object=build, request=req, user=user)
+        backend = SiteBackend(request=req)
+
+        self.assertEqual(PersistentMessage.objects.count(), 0)
+
+        # We should never be adding persistent messages for anonymous users.
+        # Make sure message_extends sitll throws an exception here
+        with self.assertRaises(NotImplementedError):
+            backend.send(notify)
+
+        self.assertEqual(render_to_string.call_count, 1)
+        self.assertEqual(PersistentMessage.objects.count(), 0)

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -69,8 +69,11 @@ class NotificationBackendTests(TestCase):
             mock.call(level=21, request=req, message=mock.ANY, extra_tags='')
         ])
 
-    @mock.patch('readthedocs.notifications.backends.add_message')
-    def test_email_backend(self, add_message, render_to_string):
+    @mock.patch('readthedocs.notifications.storages.FallbackUniqueStorage')
+    def test_email_backend(self, storage_class, render_to_string):
+        mock_storage = mock.Mock()
+        storage_class.return_value = mock_storage
+
         class TestNotification(Notification):
             name = 'foo'
             subject = 'This is {{ foo.id }}'
@@ -83,7 +86,6 @@ class NotificationBackendTests(TestCase):
         backend = SiteBackend(request=req)
         backend.send(notify)
 
-        add_message.assert_has_calls([
-            mock.call(level=21, request=req, message=mock.ANY, extra_tags='',
-                      user=user)
+        mock_storage.add.assert_has_calls([
+            mock.call(level=21, message=mock.ANY, extra_tags='', user=user)
         ])


### PR DESCRIPTION
Instead of using the messages.add method directly, add message for the
message notification backend using the storage adapter directly. This also
removes the limitation on the storage backend that requires a request.user
is authenticated, as we are likely going to be mostly adding messages
through celery or other request-less mechanisms.