### PR TITLE
Update build status even on exception

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.template import Context, loader as template_loader
 
 from readthedocs.doc_builder.base import BaseBuilder
+from readthedocs.doc_builder.exceptions import BuildEnvironmentError
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +43,15 @@ class BaseMkdocs(BaseBuilder):
             user_config = {
                 'site_name': self.version.project.name,
             }
+        except yaml.YAMLError as exc:
+            note = ''
+            if hasattr(exc, 'problem_mark'):
+                mark = exc.problem_mark
+                note = ' (line %d, column %d)' % (mark.line+1, mark.column+1)
+            raise BuildEnvironmentError(
+                "Your mkdocs.yml could not be loaded, "
+                "possibly due to a syntax error%s" % (
+                    note,))
 
         # Handle custom docs dirs
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -294,10 +294,9 @@ class BuildEnvironment(object):
         This reports on the exception we're handling and special cases
         subclasses of BuildEnvironmentException.  For
         :py:class:`BuildEnvironmentWarning`, exit this context gracefully, but
-        don't mark the build as a failure.  For :py:class:`BuildEnvironmentError`,
-        exit gracefully, but mark the build as a failure.  For all other
-        exception classes, the build will be marked as a failure and an
-        exception will bubble up.
+        don't mark the build as a failure.  For all other exception classes,
+        including :py:class:`BuildEnvironmentError`, the build will be marked as
+        a failure and an exception will bubble up.
         """
         if exc_type is not None:
             log.error(LOG_TEMPLATE
@@ -305,13 +304,9 @@ class BuildEnvironment(object):
                               version=self.version.slug,
                               msg=exc_value),
                       exc_info=True)
-            if issubclass(exc_type, BuildEnvironmentWarning):
-                return True
-            else:
+            if not issubclass(exc_type, BuildEnvironmentWarning):
                 self.failure = exc_value
-                if issubclass(exc_type, BuildEnvironmentError):
-                    return True
-                return False
+            return True
 
     def run(self, *cmd, **kwargs):
         '''Shortcut to run command from environment'''

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -281,7 +281,7 @@ class BuildEnvironment(object):
 
     def __exit__(self, exc_type, exc_value, tb):
         ret = self.handle_exception(exc_type, exc_value, tb)
-        self.update_build(state=BUILD_STATE_FINISHED)
+        self.build['state'] = BUILD_STATE_FINISHED
         log.info(LOG_TEMPLATE
                  .format(project=self.project.slug,
                          version=self.version.slug,
@@ -480,7 +480,7 @@ class DockerEnvironment(BuildEnvironment):
                         _('A build environment is currently '
                           'running for this version'))
                     self.failure = exc
-                    self.update_build(state=BUILD_STATE_FINISHED)
+                    self.build['state'] = BUILD_STATE_FINISHED
                     raise exc
                 else:
                     log.warn(LOG_TEMPLATE

--- a/readthedocs/rtd_tests/mocks/mock_api.py
+++ b/readthedocs/rtd_tests/mocks/mock_api.py
@@ -80,7 +80,7 @@ class MockApi(object):
         return ProjectData()
 
     def build(self, x):
-        return mock.Mock(**{'get.return_value': {'state': 'triggered'}})
+        return mock.Mock(**{'get.return_value': {'id': 123, 'state': 'triggered'}})
 
     def command(self, x):
         return mock.Mock(**{'get.return_value': {}})

--- a/readthedocs/rtd_tests/mocks/mock_api.py
+++ b/readthedocs/rtd_tests/mocks/mock_api.py
@@ -9,6 +9,9 @@ class ProjectData(object):
     def get(self):
         return dict()
 
+    def put(self, x=None):
+        return x
+
 
 def mock_version(repo):
     class MockVersion(object):

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django_dynamic_fixture import get
 from mock import patch, MagicMock
 
+from readthedocs.builds.constants import BUILD_STATE_INSTALLING, BUILD_STATE_FINISHED
 from readthedocs.builds.models import Build
 from readthedocs.projects.models import Project
 from readthedocs.projects import tasks
@@ -77,6 +78,42 @@ class TestCeleryBuilding(RTDTestCase):
                 record=False,
                 intersphinx=False)
         self.assertTrue(result.successful())
+
+    @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs',
+           new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs')
+    @patch('readthedocs.doc_builder.environments.BuildEnvironment.update_build')
+    def test_update_docs_unexpected_setup_exception(self, mock_update_build, mock_setup_vcs):
+        exc = Exception()
+        mock_setup_vcs.side_effect = exc
+        build = get(Build, project=self.project,
+                    version=self.project.versions.first())
+        with mock_api(self.repo) as mapi:
+            result = tasks.update_docs.delay(
+                self.project.pk,
+                build_pk=build.pk,
+                record=False,
+                intersphinx=False)
+        self.assertTrue(result.successful())
+        mock_update_build.assert_called_once_with(state=BUILD_STATE_FINISHED)
+
+    @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs')
+    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs',
+           new=MagicMock)
+    @patch('readthedocs.doc_builder.environments.BuildEnvironment.update_build')
+    def test_update_docs_unexpected_build_exception(self, mock_update_build, mock_build_docs):
+        exc = Exception()
+        mock_build_docs.side_effect = exc
+        build = get(Build, project=self.project,
+                    version=self.project.versions.first())
+        with mock_api(self.repo) as mapi:
+            result = tasks.update_docs.delay(
+                self.project.pk,
+                build_pk=build.pk,
+                record=False,
+                intersphinx=False)
+        self.assertTrue(result.successful())
+        mock_update_build.assert_called_with(state=BUILD_STATE_FINISHED)
 
     def test_update_imported_doc(self):
         with mock_api(self.repo):

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -88,16 +88,14 @@ class TestLocalEnvironment(TestCase):
         self.assertTrue(build_env.failed)
         self.assertFalse(self.mocks.api()(DUMMY_BUILD_ID).put.called)
 
-    def test_failing_execution_with_uncaught_exception(self):
+    def test_failing_execution_with_unexpected_exception(self):
         '''Build in failing state with exception from code'''
         build_env = LocalEnvironment(version=self.version, project=self.project,
                                      build={'id': DUMMY_BUILD_ID})
 
-        def _inner():
-            with build_env:
-                raise Exception()
+        with build_env:
+            raise ValueError('uncaught')
 
-        self.assertRaises(Exception, _inner)
         self.assertFalse(self.mocks.process.communicate.called)
         self.assertTrue(build_env.done)
         self.assertTrue(build_env.failed)


### PR DESCRIPTION
This change ensures that the build status is always set to FINISHED even in the event that an unexpected exception is encountered during the build (this could be something like `yaml.safe_load` encountering an invalid YAML file).

This change also ensures that `update_build` is never called from a BuildEnvironment, and is instead only invoked from the task.