### PR TITLE
Stop cascading delete on translation deletion

### DIFF
--- a/readthedocs/projects/migrations/0018_fix-translation-model.py
+++ b/readthedocs/projects/migrations/0018_fix-translation-model.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0017_add_domain_https'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='main_language_project',
+            field=models.ForeignKey(related_name='translations', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='projects.Project', null=True),
+        ),
+    ]

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -242,6 +242,7 @@ class Project(models.Model):
     # A subproject pointed at its main language, so it can be tracked
     main_language_project = models.ForeignKey('self',
                                               related_name='translations',
+                                              on_delete=models.SET_NULL,
                                               blank=True, null=True)
 
     # Version State

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -48,6 +48,15 @@ class TestProject(TestCase):
             set(translation_ids_from_orm)
         )
 
+    def test_translation_delete(self):
+        project_a = get(Project)
+        project_b = get(Project, main_language_project=project_a)
+        self.assertTrue(Project.objects.filter(pk=project_a.pk).exists())
+        self.assertTrue(Project.objects.filter(pk=project_b.pk).exists())
+        project_a.delete()
+        self.assertFalse(Project.objects.filter(pk=project_a.pk).exists())
+        self.assertTrue(Project.objects.filter(pk=project_b.pk).exists())
+
     def test_token(self):
         r = self.client.get('/api/v2/project/6/token/', {})
         resp = json.loads(r.content)


### PR DESCRIPTION
Deletes here shouldn't cascade to the child translation project.