### PR TITLE
Revert "conf.py.tmpl; Use absolute URL for doc versions"

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -81,7 +81,7 @@ context = {
     'MEDIA_URL': "{{ settings.MEDIA_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
     'versions': [{% for version in versions %}
-    ("{{ version.slug }}", "{{ version.get_absolute_url }}"),{% endfor %}
+    ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}
     ],
     'downloads': [ {% for key, val in downloads.items %}
     ("{{ key }}", "{{ val }}"),{% endfor %}


### PR DESCRIPTION
This reverts commit 95bc81d2fa4c92279ab2ca6f795124d9689f1dab.

This commit introduced a bug with our builders, as the builders do not have
access to our database. The methods used in this commit rely on the database,
and must be added to the api return instead.

This was added with #2536