### PR TITLE
Conda Support: Relax strict dependency on sphinx 1.3.5

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -193,7 +193,7 @@ class Conda(PythonEnvironment):
 
         # Use conda for requirements it packages
         requirements = [
-            'sphinx==1.3.5',
+            'sphinx>=1.3.5',
             'Pygments==2.1.1',
             'docutils==0.12',
             'mock',


### PR DESCRIPTION
Fixes #2566 where the strict dependency on sphinx 1.3.5 in the core requirements prevents the use of tools that require a more recent version of sphinx.