### PR TITLE
Add doc on DMCA takedown process

### DIFF
--- a/docs/dmca/index.rst
+++ b/docs/dmca/index.rst
@@ -1,0 +1,134 @@
+DMCA Takedown Policy
+====================
+
+These are the guidelines that Read the Docs follows when handling DMCA takedown
+requests and takedown counter requests. If you are a copyright holder wishing to
+submit a takedown request, or an author that has been notified of a takedown
+request, please familiarize yourself with `our process <Takedown Process_>`_.
+You will be asked to confirm that you have reviewed information if you submit a
+request or counter request.
+
+We aim to keep this entire process as transparent as possible. All requests and
+counter requests will be posted to this page below, in the `Request Archive`_.
+These requests will be redacted to remove all identifying information, except
+for Read the Docs user and project names.
+
+Takedown Process
+----------------
+
+Here are the steps the Read the Docs will follow in the takedown request process:
+
+Copyright holder submits a request
+    This request, if valid, will be posted publicly on this page, `down below
+    <Request Archive_>`_. The author affected by the takedown request will be
+    notified with a link to the takedown request.
+
+    For more information on submitting a takedown request, see: `Submitting a
+    Request`_
+
+Author is contacted
+    The author of the content in question will be asked to make changes to the
+    content specified in the takedown request. The author will have 24 hours to
+    make these changes. The copyright holder will be notified if and when this
+    process begins
+
+Author acknowledges changes have been made
+    The author must notify Read the Docs that changes have been made within 24
+    hours of receiving a takedown request. If the author does not respond to this
+    request, the default action will be to disable the Read the Docs project and
+    remove any hosted versions
+
+Copyright holder review
+    If the author has made changes, the copyright holder will be notified of
+    these changes. If the changes are sufficient, no further action is required,
+    though copyright holders are welcome to submit a formal retraction. If the
+    changes are not sufficient, the author's changes can be rejected. If the
+    takedown request requires alteration, a new request must be submitted.  If
+    Read the Docs does not receive a review response from the copyright holder
+    within 2 weeks, the default action at this step is to assume the takedown
+    request has been retracted.
+
+Content may be disabled
+    If the author does not respond to a request for changes, or if the copyright
+    holder has rejected the author's changes during the review process, the
+    documentation project in question will be disabled.
+
+Author submits a counter request
+    If the author believes their content was disabled as a result of a mistake,
+    a counter request may be submitted. It would be advised that authors seek
+    legal council before continuing. If the submitted counter request is
+    sufficiently detailed, this counter will also be added to `this page
+    <Request Archive_>`_. The copyright holder will be notified, with a link to
+    this counter request.
+
+    For more information on submitting a counter request, see: `Submitting a
+    Counter`_
+
+Copyright holder may file legal action
+    At this point, if the copyright holder wishes to keep the offending content
+    disabled, the copyright holder must file for legal action ordering the
+    author refrain from infringing activities on Read the Docs. The copyright
+    holder will have 2 weeks to supply Read the Docs with a copy of a valid legal
+    complaint against the author. The default action here, if the copyright
+    holder does not respond to this request, is to re-enable the author's
+    project.
+
+Submitting a Request
+~~~~~~~~~~~~~~~~~~~~
+
+Your request must:
+
+Acknowledge this process
+    You must first acknowledge you are familiar with our DMCA takedown request
+    process. If you do not acknowledge that you are familiar with our process,
+    you will be instructed to review this information.
+
+Identify the infringing content
+    You should list URLs to each piece of infringing content. If you allege that
+    the entire project is infringing on copyrights you hold, please specify the
+    entire project as infringing.
+
+Identify infringement resolution
+    You will need to specify what a user must do in order to avoid having the
+    rest of their content disabled. Be as specific as possible with this.
+    Specify if this means adding attribution, identify specific files or content
+    that should be removed, or if you allege the entire project is infringing,
+    your should be specific as to why it is infringing.
+
+Include your contact information
+    Include your name, email, physical address, and phone number.
+
+Include your signature
+    This can be a physical or electronic signature.
+
+*Requests can be submitted to:* support@readthedocs.com
+
+Submitting a Counter
+~~~~~~~~~~~~~~~~~~~~
+
+Your counter request must:
+
+Acknowledge this process
+    You must first acknowledge you are familiar with our DMCA takedown request
+    process. If you do not acknowledge that you are familiar with our process,
+    you will be instructed to review this information.
+
+Identify the infringing content that was removed
+    Specify URLs in the original takedown request that you wish to challenge.
+
+Include your contact information
+    Include your name, email, physical address, and phone number.
+
+Include your signature
+    This can be a physical or electronic signature.
+
+*Requests can be submitted to:* support@readthedocs.com
+
+Request Archive
+---------------
+
+Currently, Read the Docs has not recieved any takedown requests.
+
+..
+    * :download:`Some Company, Inc <archive/2017-01-22.txt>`
+

--- a/docs/dmca/index.rst
+++ b/docs/dmca/index.rst
@@ -8,10 +8,14 @@ request, please familiarize yourself with `our process <Takedown Process_>`_.
 You will be asked to confirm that you have reviewed information if you submit a
 request or counter request.
 
-We aim to keep this entire process as transparent as possible. All requests and
-counter requests will be posted to this page below, in the `Request Archive`_.
-These requests will be redacted to remove all identifying information, except
-for Read the Docs user and project names.
+We aim to keep this entire process as transparent as possible. Our process is
+modeled after `GitHub's DMCA takedown process <github-dmca_>`_, which we
+appreciate for it's focus on transparency and fairness. All requests and counter
+requests will be posted to this page below, in the `Request Archive`_. These
+requests will be redacted to remove all identifying information, except for Read
+the Docs user and project names.
+
+.. _github-dmca: https://help.github.com/articles/dmca-takedown-policy/
 
 Takedown Process
 ----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,7 @@ Information about development is also available:
    open-source-philosophy
    story
    talks
+   dmca/index
 
 .. _feature-docs:
 


### PR DESCRIPTION
This is an explicit procedure for handling takedown requests. This idea is
modeled after GitHub's procedure:

* https://github.com/github/dmca
* https://help.github.com/articles/dmca-takedown-policy/