### PR TITLE
Changes and fixes to symlinking and serving

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -12,8 +12,8 @@ from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
 from readthedocs.core.utils import broadcast
-from readthedocs.privacy.loader import (VersionManager, RelatedBuildManager,
-                                        BuildManager)
+from readthedocs.privacy.backend import VersionQuerySet, VersionManager
+from readthedocs.privacy.loader import RelatedBuildManager, BuildManager
 from readthedocs.projects.models import Project
 from readthedocs.projects.constants import (PRIVACY_CHOICES, GITHUB_URL,
                                             GITHUB_REGEXS, BITBUCKET_URL,
@@ -69,7 +69,8 @@ class Version(models.Model):
     )
     tags = TaggableManager(blank=True)
     machine = models.BooleanField(_('Machine Created'), default=False)
-    objects = VersionManager()
+
+    objects = VersionManager.from_queryset(VersionQuerySet)()
 
     class Meta:
         unique_together = [('project', 'slug')]

--- a/readthedocs/core/symlink.py
+++ b/readthedocs/core/symlink.py
@@ -61,6 +61,7 @@ from collections import OrderedDict
 from django.conf import settings
 
 from readthedocs.builds.models import Version
+from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.projects import constants
 from readthedocs.projects.models import Domain
 from readthedocs.projects.utils import run
@@ -293,7 +294,7 @@ class Symlink(object):
             return None
 
 
-class PublicSymlink(Symlink):
+class PublicSymlinkBase(Symlink):
     CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'public_cname_root')
     WEB_ROOT = os.path.join(settings.SITE_ROOT, 'public_web_root')
     PROJECT_CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'public_cname_project')
@@ -309,7 +310,7 @@ class PublicSymlink(Symlink):
         return self.project.translations.protected()
 
 
-class PrivateSymlink(Symlink):
+class PrivateSymlinkBase(Symlink):
     CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'private_cname_root')
     WEB_ROOT = os.path.join(settings.SITE_ROOT, 'private_web_root')
     PROJECT_CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'private_cname_project')
@@ -323,3 +324,13 @@ class PrivateSymlink(Symlink):
 
     def get_translations(self):
         return self.project.translations.private()
+
+
+class PublicSymlink(SettingsOverrideObject):
+
+    _default_class = PublicSymlinkBase
+
+
+class PrivateSymlink(SettingsOverrideObject):
+
+    _default_class = PrivateSymlinkBase

--- a/readthedocs/core/utils/extend.py
+++ b/readthedocs/core/utils/extend.py
@@ -6,6 +6,28 @@ from django.conf import settings
 from django.utils.module_loading import import_by_path
 
 
+def get_override_class(proxy_class, default_class):
+    class_id = '.'.join([
+        inspect.getmodule(proxy_class).__name__,
+        proxy_class.__name__
+    ])
+    class_path = getattr(settings, 'CLASS_OVERRIDES', {}).get(class_id)
+    if class_path is None and proxy_class._override_setting is not None:
+        class_path = getattr(settings, proxy_class._override_setting, None)
+    if class_path is not None:
+        default_class = import_by_path(class_path)
+    return default_class
+
+
+class SettingsOverrideMeta(type):
+
+    """Meta class for passing along classmethod class to the underlying class"""
+
+    def __getattr__(cls, attr):
+        proxy_class = getattr(cls, '_default_class')
+        return getattr(proxy_class, attr)
+
+
 class SettingsOverrideObject(object):
 
     """Base class for creating class that can be overridden
@@ -29,25 +51,15 @@ class SettingsOverrideObject(object):
     attempt to pull the key :py:cvar:`_override_setting` from ``settings``.
     """
 
+    __metaclass__ = SettingsOverrideMeta
+
     _default_class = None
     _override_setting = None
 
     def __new__(cls, *args, **kwargs):
         """Set up wrapped object
 
-        This is called when attributes are accessed on :py:class:`LazyObject`
-        and the underlying wrapped object does not yet exist.
+        Create an instance of the underlying proxy class and return instead of
+        this class.
         """
-        cls_new = cls._default_class
-        cls_path = (getattr(settings, 'CLASS_OVERRIDES', {})
-                    .get(cls._get_class_id()))
-        if cls_path is None and cls._override_setting is not None:
-            cls_path = getattr(settings, cls._override_setting, None)
-        if cls_path is not None:
-            cls_new = import_by_path(cls_path)
-        return cls_new(*args, **kwargs)
-
-    @classmethod
-    def _get_class_id(cls):
-        # type() here, because LazyObject overrides some attribute access
-        return '.'.join([inspect.getmodule(cls).__name__, cls.__name__])
+        return get_override_class(cls, cls._default_class)(*args, **kwargs)

--- a/readthedocs/core/utils/extend.py
+++ b/readthedocs/core/utils/extend.py
@@ -4,10 +4,9 @@ import inspect
 
 from django.conf import settings
 from django.utils.module_loading import import_by_path
-from django.utils.functional import LazyObject
 
 
-class SettingsOverrideObject(LazyObject):
+class SettingsOverrideObject(object):
 
     """Base class for creating class that can be overridden
 
@@ -33,22 +32,22 @@ class SettingsOverrideObject(LazyObject):
     _default_class = None
     _override_setting = None
 
-    def _setup(self):
+    def __new__(cls, *args, **kwargs):
         """Set up wrapped object
 
         This is called when attributes are accessed on :py:class:`LazyObject`
         and the underlying wrapped object does not yet exist.
         """
-        cls = self._default_class
+        cls_new = cls._default_class
         cls_path = (getattr(settings, 'CLASS_OVERRIDES', {})
-                    .get(self._get_class_id()))
-        if cls_path is None and self._override_setting is not None:
-            cls_path = getattr(settings, self._override_setting, None)
+                    .get(cls._get_class_id()))
+        if cls_path is None and cls._override_setting is not None:
+            cls_path = getattr(settings, cls._override_setting, None)
         if cls_path is not None:
-            cls = import_by_path(cls_path)
-        self._wrapped = cls()
+            cls_new = import_by_path(cls_path)
+        return cls_new(*args, **kwargs)
 
-    def _get_class_id(self):
+    @classmethod
+    def _get_class_id(cls):
         # type() here, because LazyObject overrides some attribute access
-        return '.'.join([inspect.getmodule(type(self)).__name__,
-                         type(self).__name__])
+        return '.'.join([inspect.getmodule(cls).__name__, cls.__name__])

--- a/readthedocs/core/utils/extend.py
+++ b/readthedocs/core/utils/extend.py
@@ -32,7 +32,7 @@ class SettingsOverrideMeta(type):
 
     """Meta class for passing along classmethod class to the underlying class"""
 
-    def __getattr__(cls, attr):
+    def __getattr__(cls, attr):  # noqa: pep8 false positive
         proxy_class = getattr(cls, '_default_class')
         return getattr(proxy_class, attr)
 

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -146,6 +146,13 @@ class VersionManager(models.Manager):
         defaults.update(kwargs)
         return self.create(**defaults)
 
+    def for_project(self, project):
+        """Return all versions for a project, including translations"""
+        return self.filter(
+            models.Q(project=project) |
+            models.Q(project__main_language_project=project)
+        )
+
 
 class BuildManager(models.Manager):
 

--- a/readthedocs/privacy/backend.py
+++ b/readthedocs/privacy/backend.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.db import models
 
 from guardian.shortcuts import get_objects_for_user
@@ -14,7 +12,6 @@ from readthedocs.core.utils.extend import (SettingsOverrideObject,
                                            get_override_class)
 from readthedocs.projects import constants
 
-log = logging.getLogger(__name__)
 
 class ProjectManager(models.Manager):
 
@@ -87,6 +84,9 @@ class VersionManager(models.Manager):
 
     @classmethod
     def from_queryset(cls, queryset_class, class_name=None):
+        # This is overridden because :py:meth:`models.Manager.from_queryset`
+        # uses `inspect` to retrieve the class methods, and the proxy class has
+        # no direct members.
         queryset_class = get_override_class(
             VersionQuerySet,
             VersionQuerySet._default_class

--- a/readthedocs/privacy/loader.py
+++ b/readthedocs/privacy/loader.py
@@ -5,9 +5,7 @@ from django.conf import settings
 ProjectManager = import_by_path(
     getattr(settings, 'PROJECT_MANAGER',
             'readthedocs.privacy.backend.ProjectManager'))
-VersionManager = import_by_path(
-    getattr(settings, 'VERSION_MANAGER',
-            'readthedocs.privacy.backend.VersionManager'))
+# VersionQuerySet was replaced by SettingsOverrideObject
 BuildManager = import_by_path(
     getattr(settings, 'BUILD_MANAGER',
             'readthedocs.privacy.backend.BuildManager'))

--- a/readthedocs/rtd_tests/tests/test_extend.py
+++ b/readthedocs/rtd_tests/tests/test_extend.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, override_settings
 
-from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.core.utils.extend import (SettingsOverrideObject,
+                                           get_override_class)
 
 
 # Top level to ensure module name is correct
@@ -29,9 +30,11 @@ class ExtendTests(TestCase):
             _override_setting = 'FOO_OVERRIDE_CLASS'
 
         foo = Foo()
-        self.assertEqual(foo._get_class_id(), EXTEND_PATH)
         self.assertEqual(foo.__class__.__name__, 'FooBase')
         self.assertEqual(foo.bar(), 1)
+
+        override_class = get_override_class(Foo, Foo._default_class)
+        self.assertEqual(override_class, FooBase)
 
     @override_settings(FOO_OVERRIDE_CLASS=EXTEND_OVERRIDE_PATH)
     def test_with_basic_override(self):
@@ -41,9 +44,11 @@ class ExtendTests(TestCase):
             _override_setting = 'FOO_OVERRIDE_CLASS'
 
         foo = Foo()
-        self.assertEqual(foo._get_class_id(), EXTEND_PATH)
         self.assertEqual(foo.__class__.__name__, 'NewFoo')
         self.assertEqual(foo.bar(), 2)
+
+        override_class = get_override_class(Foo, Foo._default_class)
+        self.assertEqual(override_class, NewFoo)
 
     @override_settings(FOO_OVERRIDE_CLASS=None,
                        CLASS_OVERRIDES={
@@ -56,9 +61,11 @@ class ExtendTests(TestCase):
             _override_setting = 'FOO_OVERRIDE_CLASS'
 
         foo = Foo()
-        self.assertEqual(foo._get_class_id(), EXTEND_PATH)
         self.assertEqual(foo.__class__.__name__, 'NewFoo')
         self.assertEqual(foo.bar(), 2)
+
+        override_class = get_override_class(Foo, Foo._default_class)
+        self.assertEqual(override_class, NewFoo)
 
     @override_settings(FOO_OVERRIDE_CLASS=None,
                        CLASS_OVERRIDES={
@@ -70,6 +77,8 @@ class ExtendTests(TestCase):
             _default_class = FooBase
 
         foo = Foo()
-        self.assertEqual(foo._get_class_id(), EXTEND_PATH)
         self.assertEqual(foo.__class__.__name__, 'NewFoo')
         self.assertEqual(foo.bar(), 2)
+
+        override_class = get_override_class(Foo, Foo._default_class)
+        self.assertEqual(override_class, NewFoo)


### PR DESCRIPTION
This allows for override of the symlinking classes, as we need to be able to
override how public and private symlinks are determined. Test coverage is expanded greatly on symlinking here:

* Dropped pattern of testing for command execution and singular symlinks for testing filesystem snapshot
* Symlinks are built under isolated tempdirs now
* All testcases test public/private privacy
* Privacy level on project/versions is explicit now

Our extension pattern was tuned up and simplified here, the django lazy object didn't allow for passing of classmethods.

This also moves the Version manager into a Version queryset + manager pattern, as we need to be able to chain queries from the managers, which isn't possible without a queryset object. This is a pattern we should adopt on the remaining managers, but I didn't touch that here. I'll open a ticket to address this.