### PR TITLE
Pass build env python limits to config object

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -62,13 +62,15 @@ class ConfigWrapper(object):
 
     @property
     def python_version(self):
+        # There should always be a version in the YAML config. If the config
+        # version is the default response of `2`, then assume we can use the
+        # Python.python_interpreter version to infer this value instead.
+        version = 2
         if 'version' in self._yaml_config.get('python', {}):
-            return self._yaml_config['python']['version']
-        else:
-            if self._project.python_interpreter == 'python':
-                return 2
-            else:
-                return 3
+            version = self._yaml_config['python']['version']
+        if version == 2 and self._project.python_interpreter == 'python3':
+            version = 3
+        return version
 
     @property
     def use_system_site_packages(self):

--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -56,7 +56,7 @@ class ConfigWrapper(object):
             # gave us a version of '2', or '3'
             ver = max(filter(
                 lambda x: x < ver + 1,
-                self._yaml_config.get_supported_versions(),
+                self._yaml_config.get_valid_python_versions(),
             ))
         return 'python{0}'.format(ver)
 

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -15,6 +15,7 @@ SPHINX_STATIC_DIR = os.path.join(SPHINX_TEMPLATE_DIR, '_static')
 
 PDF_RE = re.compile('Output written on (.*?)')
 
+# Docker
 DOCKER_SOCKET = getattr(settings, 'DOCKER_SOCKET', 'unix:///var/run/docker.sock')
 DOCKER_VERSION = getattr(settings, 'DOCKER_VERSION', 'auto')
 DOCKER_IMAGE = getattr(settings, 'DOCKER_IMAGE', 'rtfd-build')
@@ -25,3 +26,16 @@ DOCKER_TIMEOUT_EXIT_CODE = 42
 DOCKER_OOM_EXIT_CODE = 137
 
 DOCKER_HOSTNAME_MAX_LEN = 64
+
+# Build images
+BUILD_IMAGES = {
+    'readthedocs/build:14.04': {
+        'python': {'supported_versions': [2, 2.7, 3, 3.3]},
+    },
+    'readthedocs/build:16.04': {
+        'python': {'supported_versions': [2, 2.7, 3, 3.5]},
+    },
+    'readthedocs/build:beta': {
+        'python': {'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6]},
+    },
+}

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -18,7 +18,7 @@ PDF_RE = re.compile('Output written on (.*?)')
 # Docker
 DOCKER_SOCKET = getattr(settings, 'DOCKER_SOCKET', 'unix:///var/run/docker.sock')
 DOCKER_VERSION = getattr(settings, 'DOCKER_VERSION', 'auto')
-DOCKER_IMAGE = getattr(settings, 'DOCKER_IMAGE', 'rtfd-build')
+DOCKER_IMAGE = getattr(settings, 'DOCKER_IMAGE', 'readthedocs/build:2.0')
 DOCKER_LIMITS = {'memory': '200m', 'time': 600}
 DOCKER_LIMITS.update(getattr(settings, 'DOCKER_LIMITS', {}))
 
@@ -29,13 +29,13 @@ DOCKER_HOSTNAME_MAX_LEN = 64
 
 # Build images
 BUILD_IMAGES = {
-    'readthedocs/build:14.04': {
+    'readthedocs/build:1.0': {
         'python': {'supported_versions': [2, 2.7, 3, 3.3]},
     },
-    'readthedocs/build:16.04': {
+    'readthedocs/build:2.0': {
         'python': {'supported_versions': [2, 2.7, 3, 3.5]},
     },
-    'readthedocs/build:beta': {
+    'readthedocs/build:latest': {
         'python': {'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6]},
     },
 }

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -10,7 +10,7 @@ from readthedocs.doc_builder.environments import LocalEnvironment
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.projects.tasks import UpdateDocsTask
-from readthedocs.rtd_tests.tests.test_config_wrapper import get_build_config
+from readthedocs.rtd_tests.tests.test_config_wrapper import create_load
 
 from ..mocks.environment import EnvironmentMockGroup
 
@@ -40,8 +40,7 @@ class BuildEnvironmentTests(TestCase):
 
         build_env = LocalEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=version, yaml_config=yaml_config)
+        config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
         task.build_docs()
@@ -65,8 +64,7 @@ class BuildEnvironmentTests(TestCase):
 
         build_env = LocalEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=version, yaml_config=yaml_config)
+        config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
 
@@ -91,8 +89,7 @@ class BuildEnvironmentTests(TestCase):
 
         build_env = LocalEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=version, yaml_config=yaml_config)
+        config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
         task.build_docs()
@@ -116,8 +113,9 @@ class BuildEnvironmentTests(TestCase):
 
         build_env = LocalEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
-        yaml_config = get_build_config({'formats': ['epub']})
-        config = ConfigWrapper(version=version, yaml_config=yaml_config)
+        config = ConfigWrapper(version=version, yaml_config=create_load({
+            'formats': ['epub']
+        })()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
         task.build_docs()
@@ -171,8 +169,7 @@ class BuildEnvironmentTests(TestCase):
 
         build_env = LocalEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=version, yaml_config=yaml_config)
+        config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
 
@@ -213,8 +210,7 @@ class BuildEnvironmentTests(TestCase):
 
         build_env = LocalEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=version, yaml_config=yaml_config)
+        config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
 

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
-
 from django_dynamic_fixture import get
-from readthedocs_build.config import BuildConfig
 
+from readthedocs_build.config import BuildConfig
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
 from readthedocs.doc_builder.config import ConfigWrapper
@@ -40,11 +39,11 @@ class ConfigWrapperTests(TestCase):
     def test_python_interpreter(self):
         yaml_config = get_build_config({'python': {'version': 3}})
         config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
-        self.assertEqual(config.python_interpreter, 'python3')
+        self.assertEqual(config.python_interpreter, 'python3.5')
 
         yaml_config = get_build_config({})
         config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
-        self.assertEqual(config.python_interpreter, 'python')
+        self.assertEqual(config.python_interpreter, 'python2.7')
 
     def test_install_project(self):
         yaml_config = get_build_config({'python': {'setup_py_install': True}})

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -18,8 +18,12 @@ def create_load(config=None):
     if config is None:
         config = {}
 
-    def inner(path, env_config):
-        env_config_defaults = {'output_base': ''}
+    def inner(path=None, env_config=None):
+        env_config_defaults = {
+            'output_base': '',
+            'name': '1',
+            'type': 'sphinx',
+        }
         if env_config is not None:
             env_config_defaults.update(env_config)
         yaml_config = ProjectConfig([

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -1,98 +1,193 @@
+import mock
 from django.test import TestCase
 from django_dynamic_fixture import get
 
-from readthedocs_build.config import BuildConfig
+from readthedocs_build.config import BuildConfig, ProjectConfig, InvalidConfig
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
-from readthedocs.doc_builder.config import ConfigWrapper
+from readthedocs.doc_builder.config import ConfigWrapper, load_yaml_config
 
 
-def get_build_config(config, env_config=None, source_file='readthedocs.yml',
-                     source_position=0):
-    config['name'] = 'test'
-    config['type'] = 'sphinx'
-    ret_config = BuildConfig(
-        {'output_base': ''},
-        config,
-        source_file=source_file,
-        source_position=source_position)
-    ret_config.validate()
-    return ret_config
+def create_load(config=None):
+    """Mock out the function of the build load function
+
+    This will create a ProjectConfig list of BuildConfig objects and validate
+    them. The default load function iterates over files and builds up a list of
+    objects. Instead of mocking all of this, just mock the end result.
+    """
+    if config is None:
+        config = {}
+
+    def inner(path, env_config):
+        env_config_defaults = {'output_base': ''}
+        if env_config is not None:
+            env_config_defaults.update(env_config)
+        yaml_config = ProjectConfig([
+            BuildConfig(env_config_defaults,
+                        config,
+                        source_file='readthedocs.yml',
+                        source_position=0)
+        ])
+        yaml_config.validate()
+        return yaml_config
+    return inner
 
 
-class ConfigWrapperTests(TestCase):
+@mock.patch('readthedocs.doc_builder.config.load_config')
+class LoadConfigTests(TestCase):
 
     def setUp(self):
-        self.project = get(Project, slug='test', python_interpreter='python',
+        self.project = get(Project, main_language_project=None,
                            install_project=False, requirements_file='urls.py')
-        self.version = get(Version, project=self.project, slug='foobar')
+        self.version = get(Version, project=self.project)
 
-    def test_python_version(self):
-        yaml_config = get_build_config({'python': {'version': 3}})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
-        self.assertEqual(config.python_version, 3)
-
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+    def test_python_supported_versions_default_image_1_0(self, load_config):
+        load_config.side_effect = create_load()
+        self.project.container_image = 'readthedocs/build:1.0'
+        self.project.save()
+        config = load_yaml_config(self.version)
+        self.assertEqual(load_config.call_count, 1)
+        load_config.assert_has_calls([
+            mock.call(path=mock.ANY, env_config={
+                'python': {'supported_versions': [2, 2.7, 3, 3.3]},
+                'type': 'sphinx',
+                'output_base': '',
+                'name': mock.ANY
+            }),
+        ])
         self.assertEqual(config.python_version, 2)
 
-    def test_python_interpreter(self):
-        yaml_config = get_build_config({'python': {'version': 3}})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
-        self.assertEqual(config.python_interpreter, 'python3.5')
+    def test_python_supported_versions_image_2_0(self, load_config):
+        load_config.side_effect = create_load()
+        self.project.container_image = 'readthedocs/build:2.0'
+        self.project.save()
+        config = load_yaml_config(self.version)
+        self.assertEqual(load_config.call_count, 1)
+        load_config.assert_has_calls([
+            mock.call(path=mock.ANY, env_config={
+                'python': {'supported_versions': [2, 2.7, 3, 3.5]},
+                'type': 'sphinx',
+                'output_base': '',
+                'name': mock.ANY
+            }),
+        ])
+        self.assertEqual(config.python_version, 2)
 
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+    def test_python_supported_versions_image_latest(self, load_config):
+        load_config.side_effect = create_load()
+        self.project.container_image = 'readthedocs/build:latest'
+        self.project.save()
+        config = load_yaml_config(self.version)
+        self.assertEqual(load_config.call_count, 1)
+        load_config.assert_has_calls([
+            mock.call(path=mock.ANY, env_config={
+                'python': {'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6]},
+                'type': 'sphinx',
+                'output_base': '',
+                'name': mock.ANY
+            }),
+        ])
+        self.assertEqual(config.python_version, 2)
+
+    def test_python_default_version(self, load_config):
+        load_config.side_effect = create_load()
+        config = load_yaml_config(self.version)
+        self.assertEqual(config.python_version, 2)
         self.assertEqual(config.python_interpreter, 'python2.7')
 
-    def test_install_project(self):
-        yaml_config = get_build_config({'python': {'setup_py_install': True}})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
-        self.assertEqual(config.install_project, True)
+    def test_python_set_python_version_on_project(self, load_config):
+        load_config.side_effect = create_load()
+        self.project.container_image = 'readthedocs/build:2.0'
+        self.project.python_interpreter = 'python3'
+        self.project.save()
+        config = load_yaml_config(self.version)
+        self.assertEqual(config.python_version, 3)
+        self.assertEqual(config.python_interpreter, 'python3.5')
 
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+    def test_python_set_python_version_in_config(self, load_config):
+        load_config.side_effect = create_load({
+            'python': {'version': 3.5}
+        })
+        self.project.container_image = 'readthedocs/build:2.0'
+        self.project.save()
+        config = load_yaml_config(self.version)
+        self.assertEqual(config.python_version, 3.5)
+        self.assertEqual(config.python_interpreter, 'python3.5')
+
+    def test_python_invalid_version_in_config(self, load_config):
+        load_config.side_effect = create_load({
+            'python': {'version': 2.6}
+        })
+        self.project.container_image = 'readthedocs/build:2.0'
+        self.project.save()
+        with self.assertRaises(InvalidConfig):
+            config = load_yaml_config(self.version)
+
+    def test_install_project(self, load_config):
+        load_config.side_effect = create_load()
+        config = load_yaml_config(self.version)
         self.assertEqual(config.install_project, False)
 
-    def test_extra_requirements(self):
-        yaml_config = get_build_config({'python': {
-            'pip_install': True,
-            'extra_requirements': ['tests', 'docs']}})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        load_config.side_effect = create_load({
+            'python': {'setup_py_install': True}
+        })
+        config = load_yaml_config(self.version)
+        self.assertEqual(config.install_project, True)
+
+    def test_extra_requirements(self, load_config):
+        load_config.side_effect = create_load({
+            'python': {
+                'pip_install': True,
+                'extra_requirements': ['tests', 'docs']
+            }
+        })
+        config = load_yaml_config(self.version)
         self.assertEqual(config.extra_requirements, ['tests', 'docs'])
 
-        yaml_config = get_build_config({'python': {
-            'extra_requirements': ['tests', 'docs']}})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        load_config.side_effect = create_load({
+            'python': {
+                'extra_requirements': ['tests', 'docs']
+            }
+        })
+        config = load_yaml_config(self.version)
         self.assertEqual(config.extra_requirements, [])
 
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        load_config.side_effect = create_load()
+        config = load_yaml_config(self.version)
         self.assertEqual(config.extra_requirements, [])
 
-        yaml_config = get_build_config({'python': {
-            'setup_py_install': True,
-            'extra_requirements': ['tests', 'docs']}})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        load_config.side_effect = create_load({
+            'python': {
+                'setup_py_install': True,
+                'extra_requirements': ['tests', 'docs']
+            }
+        })
+        config = load_yaml_config(self.version)
         self.assertEqual(config.extra_requirements, [])
 
-    def test_conda(self):
+    def test_conda(self, load_config):
         to_find = 'urls.py'
-        yaml_config = get_build_config({'conda': {'file': to_find}})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        load_config.side_effect = create_load({
+            'conda': {
+                'file': to_find
+            }
+        })
+        config = load_yaml_config(self.version)
         self.assertEqual(config.use_conda, True)
         self.assertTrue(config.conda_file[-len(to_find):] == to_find)
 
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        load_config.side_effect = create_load()
+        config = load_yaml_config(self.version)
         self.assertEqual(config.use_conda, False)
         self.assertEqual(config.conda_file, None)
 
-    def test_requirements_file(self):
-        yaml_config = get_build_config({'requirements_file': 'wsgi.py'})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+    def test_requirements_file(self, load_config):
+        load_config.side_effect = create_load({
+            'requirements_file': 'wsgi.py'
+        })
+        config = load_yaml_config(self.version)
         self.assertEqual(config.requirements_file, 'wsgi.py')
 
-        yaml_config = get_build_config({})
-        config = ConfigWrapper(version=self.version, yaml_config=yaml_config)
+        load_config.side_effect = create_load()
+        config = load_yaml_config(self.version)
         self.assertEqual(config.requirements_file, 'urls.py')

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -240,7 +240,7 @@ class CommunityBaseSettings(Settings):
 
     # Docker
     DOCKER_ENABLE = False
-    DOCKER_IMAGE = 'readthedocs/build:14.04'
+    DOCKER_IMAGE = 'readthedocs/build:1.0'
 
     # All auth
     ACCOUNT_ADAPTER = 'readthedocs.core.adapters.AccountAdapter'

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -5,7 +5,7 @@ docutils==0.11
 Sphinx==1.3.5
 Pygments==2.0.2
 mkdocs==0.14.0
-git+https://github.com/rtfd/readthedocs-build.git@31082ec0e7c6597c8e05c0e821271aaacd715dc7#egg=readthedocs-build-2.0.7.dev
+readthedocs-build==2.0.6
 django==1.8.16
 
 django-tastypie==0.12.2

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -5,7 +5,7 @@ docutils==0.11
 Sphinx==1.3.5
 Pygments==2.0.2
 mkdocs==0.14.0
-git+https://github.com/rtfd/readthedocs-build.git@db4ad19df4f432bfbbd56d05964c58b6634356f3#egg=readthedocs-build-2.0.6.dev
+git+https://github.com/rtfd/readthedocs-build.git@31082ec0e7c6597c8e05c0e821271aaacd715dc7#egg=readthedocs-build-2.0.7.dev
 django==1.8.16
 
 django-tastypie==0.12.2


### PR DESCRIPTION
* Pass in build env python limitations to config
* Exposes parsing error to user on build output

Requires rtfd/readthedocs-build#21