### PR TITLE
Fixed build results page on firefox (part two)

### DIFF
--- a/readthedocs/builds/static/builds/css/detail.css
+++ b/readthedocs/builds/static/builds/css/detail.css
@@ -110,7 +110,6 @@ div.build-command div.build-command-output {
 div.build-command div.build-command-run > span,
 div.build-command div.build-command-output > span {
     display: block;
-    margin-bottom: -16px;
     font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
     white-space: pre;
     overflow-x: scroll;

--- a/readthedocs/builds/static/builds/css/detail.css
+++ b/readthedocs/builds/static/builds/css/detail.css
@@ -107,15 +107,8 @@ div.build-command div.build-command-output {
     margin-top: .5em;
 }
 
-div.build-command:not(*:root) div.build-command-run > span,
-div.build-command:not(*:root) div.build-command-output > span {
-    /* workaround for extraneous padding on Chrome. See #2251 */
-    margin-bottom: -16px;
-}
-
 div.build-command div.build-command-run > span,
 div.build-command div.build-command-output > span {
-    display: block;
     font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
     white-space: pre;
     overflow-x: scroll;

--- a/readthedocs/builds/static/builds/css/detail.css
+++ b/readthedocs/builds/static/builds/css/detail.css
@@ -107,6 +107,12 @@ div.build-command div.build-command-output {
     margin-top: .5em;
 }
 
+div.build-command:not(*:root) div.build-command-run > span,
+div.build-command:not(*:root) div.build-command-output > span {
+    /* workaround for extraneous padding on Chrome. See #2251 */
+    margin-bottom: -16px;
+}
+
 div.build-command div.build-command-run > span,
 div.build-command div.build-command-output > span {
     display: block;


### PR DESCRIPTION
This PR builds on and obviates #2350 by addressing concerns about aesthetics on Chrome, by moving the hack into its own documented style definition.

I did try to track the origin of the original style, but it was part of the bulk commit in a95f08d9b, which lends no insight into the intention of the style, and is probably just an artifact of the author using Chrome to develop the view.