### PR TITLE
Fix pagination of Builds on build list page.

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -42,6 +42,7 @@ class BuildList(BuildBase, ListView):
         context['filter'] = filter
         context['active_builds'] = active_builds
         context['versions'] = Version.objects.public(user=self.request.user, project=self.project)
+        context['build_qs'] = filter.qs
 
         try:
             redis = Redis.from_url(settings.BROKER_URL)

--- a/readthedocs/templates/builds/build_list.html
+++ b/readthedocs/templates/builds/build_list.html
@@ -45,7 +45,7 @@ Filters
 
 <div id="build_list">
 
-        {% autopaginate filter.qs 15 %}
+        {% autopaginate build_qs 15 %}
 
         <!-- BEGIN builds list -->
         <div class="module">

--- a/readthedocs/templates/core/build_list_detailed.html
+++ b/readthedocs/templates/core/build_list_detailed.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load static %}
 
-          {% for build in filter.qs %}
+          {% for build in build_qs %}
           <li class="module-item col-span">
             <div id="build-{{ build.id }}">
                 <a href="{{ build.get_absolute_url }}"><span id="build-state">{% if build.state != 'finished' %}{{ build.get_state_display }} {% else %} {% if build.success %}{% trans "Passed" %}{% else %}{% trans "Failed" %}{% endif %}{% endif %}</span>


### PR DESCRIPTION
A change in the Django Filter project made it so the previous method didn't work.
We aren't currently using the filters,
so we should probably remove them for simplicity,
but this fixes the main issue.