### PR TITLE
Fix issue where we can't find conf.py and raise bad error.

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -65,10 +65,10 @@ class BaseSphinx(BaseBuilder):
 
         project = self.project
         # Open file for appending.
-        outfile_path = project.conf_file(self.version.slug)
         try:
+            outfile_path = project.conf_file(self.version.slug)
             outfile = codecs.open(outfile_path, encoding='utf-8', mode='a')
-        except IOError:
+        except (ProjectImportError, IOError):
             trace = sys.exc_info()[2]
             raise ProjectImportError('Conf file not found'), None, trace
         try:


### PR DESCRIPTION
This was causing users with invalid conf.py file settings
to get an "unknown error" message.

This was the traceback that was fixed:

```
Feb  7 20:55:41 build01 readthedocs/readthedocs.doc_builder.environments[32422]: ERROR (Build) [flowframework:latest] Conf File Missing. Please make sure you have a conf.py in your project. [readthedocs.doc_builder.environments:306]
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/readthedocs/projects/tasks.py", line 170, in run
    outcomes = self.build_docs()
  File "/home/docs/checkouts/readthedocs.org/readthedocs/projects/tasks.py", line 331, in build_docs
    outcomes['html'] = self.build_docs_html()
  File "/home/docs/checkouts/readthedocs.org/readthedocs/projects/tasks.py", line 348, in build_docs_html
    html_builder.append_conf()
  File "/home/docs/checkouts/readthedocs.org/readthedocs/doc_builder/backends/sphinx.py", line 68, in append_conf
    outfile_path = project.conf_file(self.version.slug)
  File "/home/docs/checkouts/readthedocs.org/readthedocs/projects/models.py", line 539, in conf_file
    u"Conf File Missing. Please make sure you have a conf.py in your project.")
ProjectImportError: Conf File Missing. Please make sure you have a conf.py in your project
```