### PR TITLE
Show pdf in yml-enabled setup if this format enabled

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -34,6 +34,8 @@ from readthedocs.vcs_support.base import VCSProject
 from readthedocs.vcs_support.backends import backend_cls
 from readthedocs.vcs_support.utils import Lock, NonBlockingLock
 
+from readthedocs.doc_builder.config import load_yaml_config
+
 if sys.version_info > (3,):
     # pylint: disable=import-error
     from urllib.parse import urlparse
@@ -570,8 +572,11 @@ class Project(models.Model):
         return self.aliases.exists()
 
     def has_pdf(self, version_slug=LATEST):
+        version = self.versions.get(slug=version_slug)
+        config = load_yaml_config(version)
         if not self.enable_pdf_build:
-            return False
+            if 'pdf' not in config.formats:
+                return False
         return os.path.exists(self.get_production_media_path(
             type_='pdf', version_slug=version_slug))
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -572,11 +572,15 @@ class Project(models.Model):
         return self.aliases.exists()
 
     def has_pdf(self, version_slug=LATEST):
-        version = self.versions.get(slug=version_slug)
-        config = load_yaml_config(version)
+        version = self.versions.filter(slug=version_slug).first()
         if not self.enable_pdf_build:
-            if 'pdf' not in config.formats:
+            try:
+                config = load_yaml_config(version)
+            except AttributeError:
                 return False
+            else:
+                if 'pdf' not in config.formats:
+                    return False
         return os.path.exists(self.get_production_media_path(
             type_='pdf', version_slug=version_slug))
 


### PR DESCRIPTION
This is a very early attempt to fix #2582.

It looks also, that documented yml syntax for "format" option was changed.  This fix was tested in [this repo](https://github.com/skirpichev/diofant) and it doesn't work with [.readthedocs.yml](https://github.com/diofant/diofant/blob/master/.readthedocs.yml) in my master branch, but it does if I change format configuration to:
```yaml
formats:
    htmlzip: true
    pdf: true
```
(See [yml file](https://github.com/skirpichev/diofant/blob/pdf/.readthedocs.yml) on [another branch](https://github.com/skirpichev/diofant/tree/pdf).)

Is the old syntax supported, or the docs should be adapted to reflect new syntax, documented in [spec.rst](https://github.com/rtfd/readthedocs-build/blob/master/docs/spec.rst)?