### PR TITLE
Link to the localhost instance of the dashboard

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -116,7 +116,7 @@ What's available
 ----------------
 
 After registering with the site (or creating yourself a superuser account),
-you will be able to log in and view the `dashboard <http://readthedocs.org/dashboard/>`_.
+you will be able to log in and view the `dashboard <http://localhost:8000/dashboard/>`_.
 
 From the dashboard you can import your existing
 docs provided that they are in a git or mercurial repo.


### PR DESCRIPTION
Points the `dashboard` link to the just installed readthedocs instance instead of going to the production URL (readthedocs.org/dashboard)