### PR TITLE
Update setuptools version.

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -104,7 +104,7 @@ class Virtualenv(PythonEnvironment):
         requirements = [
             'sphinx==1.3.5',
             'Pygments==2.1.3',
-            'setuptools==20.1.1',
+            'setuptools==28.8.0',
             'docutils==0.12',
             'mkdocs==0.15.0',
             'mock==1.0.1',


### PR DESCRIPTION
This change aligns the required `setuptools` to the version already available on the system. This avoid unnecessary downgrades of `setuptools` during environment setup.

Here is a real-life example of a downgrade on one of my project: https://readthedocs.org/projects/meta-package-manager/builds/5079681/

Also note that the build above is failing because of the presence of a marker specifying the Python version compatibility: https://github.com/kdeldycke/meta-package-manager/blob/1863a4457892a052aa53c1e2a2ae08bf3f7814c4/setup.py#L48 . This additional fragment is not recognized by the old `setuptools` 20.1.1 while the proposed 28.8.0 is going to fix this issue as well.