### PR TITLE
Upgrade Sphinx version and theme.

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -102,7 +102,7 @@ class Virtualenv(PythonEnvironment):
 
     def install_core_requirements(self):
         requirements = [
-            'sphinx==1.3.5',
+            'sphinx==1.5.2',
             'Pygments==2.1.3',
             'setuptools==20.1.1',
             'docutils==0.12',
@@ -111,7 +111,7 @@ class Virtualenv(PythonEnvironment):
             'pillow==2.6.1',
             ('git+https://github.com/rtfd/readthedocs-sphinx-ext.git'
              '@0.6-alpha#egg=readthedocs-sphinx-ext'),
-            'sphinx-rtd-theme==0.1.9',
+            'sphinx-rtd-theme==0.2.0',
             'alabaster>=0.7,<0.8,!=0.7.5',
             'commonmark==0.5.4',
             'recommonmark==0.1.1',

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -102,7 +102,7 @@ class Virtualenv(PythonEnvironment):
 
     def install_core_requirements(self):
         requirements = [
-            'sphinx==1.5.2',
+            'sphinx==1.5.3',
             'Pygments==2.1.3',
             'setuptools==20.1.1',
             'docutils==0.12',

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -2,7 +2,7 @@
 pip==8.1.1
 virtualenv==15.0.1
 docutils==0.11
-Sphinx==1.3.5
+Sphinx==1.5.3
 Pygments==2.0.2
 mkdocs==0.14.0
 readthedocs-build==2.0.6

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -3,6 +3,7 @@ pip==8.1.1
 virtualenv==15.0.1
 docutils==0.11
 Sphinx==1.5.3
+sphinx_rtd_theme==0.2.0
 Pygments==2.0.2
 mkdocs==0.14.0
 readthedocs-build==2.0.6


### PR DESCRIPTION
I did some basic builds locally that looked and worked fine,
and we have a lot of users using 1.5 in requirements files.
We don't have a great way to stress test this,
but I think we should definitely push it out as a default.

I didn't touch the conda defaults because it doesn't update as quickly as pypi.