### PR TITLE
Handle celery.exceptions.SoftTimeLimitExceeded

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -178,9 +178,7 @@ class UpdateDocsTask(Task):
                 outcomes = self.build_docs()
                 build_id = self.build.get('id')
             except SoftTimeLimitExceeded:
-                raise BuildEnvironmentError(
-                    'Failing build because the maximum time to build the '
-                    'documentation was reached.')
+                raise BuildEnvironmentError(_('Build exited due to time out'))
 
             # Web Server Tasks
             if build_id:


### PR DESCRIPTION
When the celery soft_time_limit is reached the celery exception is catched and the build is reported as failed to be shown as an error message to the user.

This bug was found when looking at #2697 