### PR TITLE
Show the relative path of conf.py file used

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -129,8 +129,9 @@ class BaseSphinx(BaseBuilder):
         # Print the contents of conf.py in order to make the rendered
         # configfile visible in the build logs
         self.run(
-            'cat', os.path.basename(outfile_path),
-            cwd=os.path.dirname(outfile_path),
+            'cat', os.path.relpath(outfile_path,
+                                   project.checkout_path(self.version)),
+            cwd=project.checkout_path(self.version),
         )
 
     def build(self, **kwargs):

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -130,8 +130,8 @@ class BaseSphinx(BaseBuilder):
         # configfile visible in the build logs
         self.run(
             'cat', os.path.relpath(outfile_path,
-                                   project.checkout_path(self.version)),
-            cwd=project.checkout_path(self.version),
+                                   project.checkout_path(self.version.slug)),
+            cwd=project.checkout_path(self.version.slug),
         )
 
     def build(self, **kwargs):


### PR DESCRIPTION
Instead of showing just "cat conf.py" now we show "cat docs/conf.py" as a relative path starting from the checkout path (repository directory).

Refs #2735 