### PR TITLE
Remove the call to our API from old projects.

### DIFF
--- a/media/javascript/rtd.js
+++ b/media/javascript/rtd.js
@@ -67,7 +67,7 @@
       }
     );
 
-    checkVersion(slug, version);
+    // checkVersion(slug, version);
     getVersions(slug, version);
     
     /*


### PR DESCRIPTION
This stops a large number of requests from old pages.
It depends on v1 of our API and it broken.