### PR TITLE
Fix errors caused by calling `dict` on a Response.

### DIFF
--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -214,5 +214,5 @@ class BitbucketService(Service):
             log.error('Bitbucket webhook creation failed for project: %s',
                       project)
             log.debug('Bitbucket webhook creation failure response: %s',
-                      dict(resp))
+                      resp.content)
             return (False, resp)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -205,7 +205,7 @@ class GitHubService(Service):
             log.error('GitHub webhook creation failed for project: %s',
                       project)
             log.debug('GitHub webhook creation failure response: %s',
-                      dict(resp))
+                      resp.content)
             return (False, resp)
 
     @classmethod


### PR DESCRIPTION
This errors in all the cases I tested (202, 400),
so I'm not sure what the original intent was.
This gives users 500's on project import if GH import fails,
so probably a pretty high priority to fix.