### PR TITLE
This merges all the bugfix PR's I had into one.

### DIFF
--- a/media/javascript/rtd.js
+++ b/media/javascript/rtd.js
@@ -67,7 +67,7 @@
       }
     );
 
-    checkVersion(slug, version);
+    // checkVersion(slug, version);
     getVersions(slug, version);
     
     /*

--- a/media/javascript/rtd.js
+++ b/media/javascript/rtd.js
@@ -67,6 +67,8 @@
       }
     );
 
+    // This is a deprecated API and file, so removing this to reduce errors
+    // on our servers.
     // checkVersion(slug, version);
     getVersions(slug, version);
     

--- a/media/javascript/rtd.js
+++ b/media/javascript/rtd.js
@@ -78,12 +78,12 @@
     */
 
 
-    $.ajax({
-    url: "https://api.grokthedocs.com/static/javascript/bundle-client.js",
-    crossDomain: true,
-    dataType: "script",
-    cache: true,
-    });
+    // $.ajax({
+    // url: "https://api.grokthedocs.com/static/javascript/bundle-client.js",
+    // crossDomain: true,
+    // dataType: "script",
+    // cache: true,
+    // });
 
 
 

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -56,17 +56,17 @@ class ResolverBase(object):
         # Only support `/docs/project' URLs outside our normal environment. Normally
         # the path should always have a subdomain or CNAME domain
         if subdomain or cname or (self._use_subdomain()):
-            url = '/'
+            url = u'/'
         else:
-            url = '/docs/{project_slug}/'
+            url = u'/docs/{project_slug}/'
 
         if subproject_slug:
-            url += 'projects/{subproject_slug}/'
+            url += u'projects/{subproject_slug}/'
 
         if single_version:
-            url += '{filename}'
+            url += u'{filename}'
         else:
-            url += '{language}/{version_slug}/{filename}'
+            url += u'{language}/{version_slug}/{filename}'
 
         return url.format(
             project_slug=project_slug, filename=filename,

--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -26,6 +26,8 @@ def decide_if_cors(sender, request, **kwargs):
 
     Returns True when a request should be given CORS access.
     """
+    if 'HTTP_ORIGIN' not in request.META:
+        return False
     host = urlparse(request.META['HTTP_ORIGIN']).netloc.split(':')[0]
     valid_url = False
     for url in WHITELIST_URLS:

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -214,5 +214,5 @@ class BitbucketService(Service):
             log.error('Bitbucket webhook creation failed for project: %s',
                       project)
             log.debug('Bitbucket webhook creation failure response: %s',
-                      dict(resp))
+                      resp.content)
             return (False, resp)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -205,7 +205,7 @@ class GitHubService(Service):
             log.error('GitHub webhook creation failed for project: %s',
                       project)
             log.debug('GitHub webhook creation failure response: %s',
-                      dict(resp))
+                      resp.content)
             return (False, resp)
 
     @classmethod

--- a/readthedocs/projects/version_handling.py
+++ b/readthedocs/projects/version_handling.py
@@ -1,5 +1,6 @@
 """Project version handling"""
 
+import unicodedata
 from collections import defaultdict
 from packaging.version import Version
 from packaging.version import InvalidVersion
@@ -107,8 +108,8 @@ def version_windows(versions, major=1, minor=1, point=1):
 
 def parse_version_failsafe(version_string):
     try:
-        return Version(version_string)
-    except InvalidVersion:
+        return Version(unicodedata.normalize('NFKD', version_string).encode('ascii', 'ignore'))
+    except (UnicodeError, InvalidVersion):
         return None
 
 

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -132,27 +132,23 @@ class ProjectViewSet(viewsets.ModelViewSet):
             log.exception("Sync Versions Error: %s" % e.message)
             return Response({'error': e.message}, status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            old_stable = project.get_stable_version()
-            promoted_version = project.update_stable_version()
-            if promoted_version:
-                new_stable = project.get_stable_version()
-                log.info(
-                    "Triggering new stable build: {project}:{version}".format(
-                        project=project.slug,
-                        version=new_stable.identifier))
-                trigger_build(project=project, version=new_stable)
+        promoted_version = project.update_stable_version()
+        if promoted_version:
+            new_stable = project.get_stable_version()
+            log.info(
+                "Triggering new stable build: {project}:{version}".format(
+                    project=project.slug,
+                    version=new_stable.identifier))
+            trigger_build(project=project, version=new_stable)
 
-                # Marking the tag that is considered the new stable version as
-                # active and building it if it was just added.
-                if (
-                        activate_new_stable and
-                        promoted_version.slug in added_versions):
-                    promoted_version.active = True
-                    promoted_version.save()
-                    trigger_build(project=project, version=promoted_version)
-        except:
-            log.exception("Stable Version Failure", exc_info=True)
+            # Marking the tag that is considered the new stable version as
+            # active and building it if it was just added.
+            if (
+                    activate_new_stable and
+                    promoted_version.slug in added_versions):
+                promoted_version.active = True
+                promoted_version.save()
+                trigger_build(project=project, version=promoted_version)
 
         return Response({
             'added_versions': added_versions,

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import json
 
 from django.test import TestCase
@@ -344,3 +346,18 @@ class TestStableVersion(TestCase):
         version_stable = Version.objects.get(slug=STABLE)
         self.assertFalse(version_stable.active)
         self.assertEqual(version_stable.identifier, '1.0.0')
+
+    def test_unicode(self):
+        version_post_data = {
+            'branches': [],
+            'tags': [
+                {'identifier': 'foo-£', 'verbose_name': 'foo-£'},
+            ]
+        }
+
+        resp = self.client.post(
+            '/api/v2/project/%s/sync_versions/' % self.pip.pk,
+            data=json.dumps(version_post_data),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
Fix errors caused by calling `dict` on a Response.

This errors in all the cases I tested (202, 400), so I'm not sure what the
original intent was. This gives users 500's on project import if GH import
fails, so probably a pretty high priority to fix.

--

Fix CORS requests not having ORIGIN

--

Fix unicode handling in resolver

We should probably upgrade to Python 3 to remove all these issues, but this
at least will fix this one.

--

Validate the JSON file we're trying to load works.

This fixes errors on search indexing of files that don't fit the format.
This was triggering on eg. `searchindex.json` in the JSON builders

--

Remove the call to our API from old projects.

This stops a large number of requests from old pages. It depends on v1 of
our API and it broken.