### PR TITLE
Bump readthedocs-sphinx-ext to 0.5.5 to resolve search issues

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -109,8 +109,7 @@ class Virtualenv(PythonEnvironment):
             'mkdocs==0.15.0',
             'mock==1.0.1',
             'pillow==2.6.1',
-            ('git+https://github.com/rtfd/readthedocs-sphinx-ext.git'
-             '@0.6-alpha#egg=readthedocs-sphinx-ext'),
+            'readthedocs-sphinx-ext<0.6',
             'sphinx-rtd-theme<0.3',
             'alabaster>=0.7,<0.8,!=0.7.5',
             'commonmark==0.5.4',
@@ -217,8 +216,7 @@ class Conda(PythonEnvironment):
         # Install pip-only things.
         pip_requirements = [
             'mkdocs==0.15.0',
-            ('git+https://github.com/rtfd/readthedocs-sphinx-ext.git'
-             '@0.6-alpha#egg=readthedocs-sphinx-ext'),
+            'readthedocs-sphinx-ext<0.6',
             'commonmark==0.5.4',
             'recommonmark==0.1.1',
         ]


### PR DESCRIPTION
Addresses #2708 by using a version of our extension that supports more than one
version of Sphinx.

Refs #1895
Refs #1850
Refs #2755