### PR TITLE
Switch all uses of print to be a function, not a statement

### DIFF
--- a/deploy/delete_stale_projects.py
+++ b/deploy/delete_stale_projects.py
@@ -11,11 +11,11 @@ for slug in build_projects:
     if slug not in slugs and slug.replace('_', '-') not in slugs:
         final.append(slug)
 
-print "To delete: %s" % len(final)
+print("To delete: %s" % len(final))
 
 for to_del in final:
     root = '/home/docs/checkouts/readthedocs.org'
-    print "Deleting " + to_del
+    print("Deleting " + to_del)
     shutil.rmtree('{root}/user_builds/{slug}'.format(root=root, slug=to_del), ignore_errors=True)
     shutil.rmtree('{root}/media/pdf/{slug}'.format(root=root, slug=to_del), ignore_errors=True)
     shutil.rmtree('{root}/media/epub/{slug}'.format(root=root, slug=to_del), ignore_errors=True)

--- a/deploy/flask-redirects.py
+++ b/deploy/flask-redirects.py
@@ -19,7 +19,7 @@ def redirect_front():
 
     SUBDOMAIN = CNAME = False
 
-    print "Got request {host}".format(host=request.host)
+    print("Got request {host}".format(host=request.host))
     if PRODUCTION_DOMAIN in request.host:
         SUBDOMAIN = True
         slug = request.host.split('.')[0]
@@ -37,19 +37,19 @@ def redirect_front():
         version = json_obj['version']
         language = json_obj['language']
         single_version = json_obj['single_version']
-    except Exception, e:
-        print e
+    except Exception as e:
+        print(e)
 
     if single_version:
         if SUBDOMAIN:
             sendfile = "/user_builds/{slug}/translations/{language}/{version}/".format(slug=slug, language=language, version=version)
         elif CNAME:
             sendfile = "/public_cname_root/{cname}/".format(cname=cname, language=language, version=version)
-        print "Redirecting {host} to {sendfile}".format(host=request.host, sendfile=sendfile)
+        print("Redirecting {host} to {sendfile}".format(host=request.host, sendfile=sendfile))
         return make_response('', 303, {'X-Accel-Redirect': sendfile})
     else:
         url = '/{language}/{version}/'.format(language=language, version=version)
-        print "Redirecting {host} to {url}".format(host=request.host, url=url)
+        print("Redirecting {host} to {url}".format(host=request.host, url=url))
         return redirect(url)
 
 

--- a/deploy/nginx-smoke-test.py
+++ b/deploy/nginx-smoke-test.py
@@ -66,15 +66,15 @@ def run_test(fn, *args):
     ret_value = fn(*args)
     result = 'ok' if ret_value else 'ERROR'
     url = args[0]
-    print "{url: <65} ...  {result}".format(url=url, result=result)
+    print("{url: <65} ...  {result}".format(url=url, result=result))
     return ret_value
 
 
 def header(msg):
     """Give each test a sexy header."""
-    print
-    print msg
-    print "-----------------------------"
+    print()
+    print(msg)
+    print("-----------------------------")
 
 
 def summary_results(num_tests, num_fails):
@@ -115,7 +115,7 @@ def main():
     for url, redirect in redirected_urls:
         run_test(redirected, url, redirect)
 
-    print summary_results(TESTS, FAILS)
+    print(summary_results(TESTS, FAILS))
 
     exit_code = 1 if (FAILS > 0) else 0
     return exit_code

--- a/readthedocs/core/management/commands/archive.py
+++ b/readthedocs/core/management/commands/archive.py
@@ -33,4 +33,4 @@ class Command(BaseCommand):
             'MEDIA_URL': settings.MEDIA_URL,
         }
         html = template_loader.get_template('archive/index.html').render(context)
-        print html
+        print(html)

--- a/readthedocs/core/management/commands/import_github_language.py
+++ b/readthedocs/core/management/commands/import_github_language.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         token = os.environ.get('GITHUB_AUTH_TOKEN')
         if not token:
-            print 'Invalid GitHub token, exiting'
+            print('Invalid GitHub token, exiting')
             return
 
         for project in Project.objects.filter(
@@ -45,7 +45,7 @@ class Command(BaseCommand):
                     break
 
             if not user:
-                print 'No GitHub repo for %s' % repo_url
+                print('No GitHub repo for %s' % repo_url)
                 continue
 
             cache_key = '%s-%s' % (user, repo)
@@ -62,14 +62,14 @@ class Command(BaseCommand):
                 if not languages:
                     continue
                 sorted_langs = sorted(languages.items(), key=lambda x: x[1], reverse=True)
-                print 'Sorted langs: %s ' % sorted_langs
+                print('Sorted langs: %s ' % sorted_langs)
                 top_lang = sorted_langs[0][0]
             else:
-                print 'Cached top_lang: %s' % top_lang
+                print('Cached top_lang: %s' % top_lang)
             if top_lang in PL_DICT:
                 slug = PL_DICT[top_lang]
-                print 'Setting %s to %s' % (repo_url, slug)
+                print('Setting %s to %s' % (repo_url, slug))
                 Project.objects.filter(pk=project.pk).update(programming_language=slug)
             else:
-                print 'Language unknown: %s' % top_lang
+                print('Language unknown: %s' % top_lang)
             cache.set(cache_key, top_lang, 60 * 600)

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -86,10 +86,10 @@ class URLAccessMixin(object):
             for not_obj in self.context_data:
                 if isinstance(obj, list) or isinstance(obj, set) or isinstance(obj, tuple):
                     self.assertNotIn(not_obj, obj)
-                    print "%s not in %s" % (not_obj, obj)
+                    print("%s not in %s" % (not_obj, obj))
                 else:
                     self.assertNotEqual(not_obj, obj)
-                    print "%s is not %s" % (not_obj, obj)
+                    print("%s is not %s" % (not_obj, obj))
 
     def _test_url(self, urlpatterns):
         deconstructed_urls = extract_views_from_urlpatterns(urlpatterns)

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -148,11 +148,11 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
         body['facets']['taxonomy']['facet_filter'] = final_filter
 
     if settings.DEBUG:
-        print "Before Signal"
+        print("Before Signal")
         pprint(body)
     before_file_search.send(request=request, sender=PageIndex, body=body)
     if settings.DEBUG:
-        print "After Signal"
+        print("After Signal")
         pprint(body)
 
     return PageIndex().search(body, **kwargs)


### PR DESCRIPTION
Picking up from [Eric’s comment](https://github.com/rtfd/readthedocs.org/pull/2819#issuecomment-300048415) on #2819, this patch converts every use of `print` as a statement to be `print()` as a function.

Aimed at improving eventual Python 3 compatibility, without breaking anything on Python 2.7.

There is a pylint check for print-statement, but (1) I couldn't get it working, and (2) it wants you to add `from __future__ import print_function` everywhere, which is a bigger patch.