### PR TITLE
LOG_DEBUG setting is not used at all

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -30,7 +30,6 @@ class CommunityBaseSettings(Settings):
     DEBUG = True
     TEMPLATE_DEBUG = DEBUG
     TASTYPIE_FULL_DEBUG = True
-    LOG_DEBUG = False
 
     # Domains and URLs
     PRODUCTION_DOMAIN = 'readthedocs.org'


### PR DESCRIPTION
I'm removing this one since it's not used and makes confusion when trying to enable logging :)