### PR TITLE
Remove package pinning for conda environments

### DIFF
--- a/docs/conda.rst
+++ b/docs/conda.rst
@@ -19,15 +19,33 @@ You can enable it by creating a `readthedocs.yml` file in the root of your repos
 
 .. code-block:: yaml
 
-	conda:
-	    file: environment.yml
+        conda:
+            file: environment.yml
 
-This Conda environment will also have Sphinx and other build time dependencies installed.
-It will use the same order of operations that we support currently:
+When using Conda environments you will need to define all the
+dependencies to build the documention in your `environment.yml` file
+since Read The Docs won't install them. So, as a reference, these are
+the dependencies you may need:
 
-* Environment Creation (``conda create``)
-* Dependency Installation (Sphinx)
-* User Package Installation (``conda env update``)
+From ``conda-forge`` channel:
+
+* sphinx
+* pygments
+* docutils
+* mock
+* pillow
+* sphinx-rtd-theme
+* alabaster
+
+From regular ``pypi`` (must be inside the ``pip`` option):
+
+* mkdocs
+* readthedocs-sphinx-ext
+* commonmark
+* recommonmark
+
+The environment is created by running ``conda create env --name {version.slug} --file environment.yml``
+after cloning the repository.
 
 Custom Installs
 ---------------
@@ -42,4 +60,3 @@ we can't safely install it as a normal dependency into the normal Python virtual
 
 .. _issue: https://github.com/rtfd/readthedocs.org/issues
 .. _Clinical Graphics: https://www.clinicalgraphics.com/
-

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -189,59 +189,11 @@ class Conda(PythonEnvironment):
         )
 
     def install_core_requirements(self):
-
-        # Use conda for requirements it packages
-        requirements = [
-            'sphinx==1.3.5',
-            'Pygments==2.2.0',
-            'docutils==0.12',
-            'mock',
-            'pillow>=3.0.0',
-            'sphinx_rtd_theme==0.1.7',
-            'alabaster>=0.7,<0.8,!=0.7.5',
-        ]
-
-        cmd = [
-            'conda',
-            'install',
-            '--yes',
-            '--name',
-            self.version.slug,
-        ]
-        cmd.extend(requirements)
-        self.build_env.run(
-            *cmd
-        )
-
-        # Install pip-only things.
-        pip_requirements = [
-            'mkdocs==0.15.0',
-            'readthedocs-sphinx-ext<0.6',
-            'commonmark==0.5.4',
-            'recommonmark==0.1.1',
-        ]
-
-        pip_cmd = [
-            'python',
-            self.venv_bin(filename='pip'),
-            'install',
-            '-U',
-            '--cache-dir',
-            self.project.pip_cache_path,
-        ]
-        pip_cmd.extend(pip_requirements)
-        self.build_env.run(
-            *pip_cmd,
-            bin_path=self.venv_bin()
-        )
+        # we do not force the conda environments to install anything by default
+        # and we rely in the ``environment.yml`` defined by the user.
+        pass
 
     def install_user_requirements(self):
-        self.build_env.run(
-            'conda',
-            'env',
-            'update',
-            '--name',
-            self.version.slug,
-            '--file',
-            self.config.conda_file,
-        )
+        # as the conda environment was created by using the ``environment.yml``
+        # defined by the user, there is nothing to update at this point.
+        pass


### PR DESCRIPTION
Now, we rely on the user's `environment.yml` to install all the needed packages to build their own documention. They will need to add sphinx dependencies.

Related to #2566 #2584 #2589 