### PR TITLE
Removed pinned versions from conda environments

### DIFF
--- a/docs/conda.rst
+++ b/docs/conda.rst
@@ -25,9 +25,8 @@ You can enable it by creating a `readthedocs.yml` file in the root of your repos
 This Conda environment will also have Sphinx and other build time dependencies installed.
 It will use the same order of operations that we support currently:
 
-* Environment Creation (``conda create``)
+* Environment Creation (``conda env create``)
 * Dependency Installation (Sphinx)
-* User Package Installation (``conda env update``)
 
 Custom Installs
 ---------------

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -192,13 +192,11 @@ class Conda(PythonEnvironment):
 
         # Use conda for requirements it packages
         requirements = [
-            'sphinx==1.3.5',
-            'Pygments==2.2.0',
-            'docutils==0.12',
+            'sphinx',
             'mock',
-            'pillow>=3.0.0',
-            'sphinx_rtd_theme==0.1.7',
-            'alabaster>=0.7,<0.8,!=0.7.5',
+            'pillow',
+            'sphinx_rtd_theme',
+            'mkdocs',
         ]
 
         cmd = [
@@ -215,10 +213,8 @@ class Conda(PythonEnvironment):
 
         # Install pip-only things.
         pip_requirements = [
-            'mkdocs==0.15.0',
-            'readthedocs-sphinx-ext<0.6',
-            'commonmark==0.5.4',
-            'recommonmark==0.1.1',
+            'readthedocs-sphinx-ext',
+            'recommonmark',
         ]
 
         pip_cmd = [
@@ -236,12 +232,6 @@ class Conda(PythonEnvironment):
         )
 
     def install_user_requirements(self):
-        self.build_env.run(
-            'conda',
-            'env',
-            'update',
-            '--name',
-            self.version.slug,
-            '--file',
-            self.config.conda_file,
-        )
+        # as the conda environment was created by using the ``environment.yml``
+        # defined by the user, there is nothing to update at this point
+        pass


### PR DESCRIPTION
Do not pin required packages for Read The Docs but make sure they are installed once the environment is created using the `environment.yml` from the user's repository.

I tried building `poliastro` project (https://github.com/poliastro/poliastro) in my local instance and it worked. This project used python 3.6 which was incompatible with our old setup.

Related to #2566 #2584 #2589