### PR TITLE
Fixed issue with bitbucket webhook when it's not valid

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -279,8 +279,15 @@ def bitbucket_build(request):
         )
         log.debug('Bitbucket webhook payload:\n\n%s\n\n', data)
         projects = get_project_from_url(search_url)
-        if projects:
+        if projects and branches:
             return _build_url(search_url, projects, branches)
+        elif not branches:
+            log.error(
+                'Commits/Banches not found url=%s branches=%s',
+                search_url,
+                branches
+            )
+            return HttpResponseNotFound('Commits/Banches not found')
         else:
             log.error('Project match not found: url=%s', search_url)
             return HttpResponseNotFound('Project match not found')

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -283,11 +283,11 @@ def bitbucket_build(request):
             return _build_url(search_url, projects, branches)
         elif not branches:
             log.error(
-                'Commits/Banches not found url=%s branches=%s',
+                'Commit/branch not found url=%s branches=%s',
                 search_url,
                 branches
             )
-            return HttpResponseNotFound('Commits/Banches not found')
+            return HttpResponseNotFound('Commit/branch not found')
         else:
             log.error('Project match not found: url=%s', search_url)
             return HttpResponseNotFound('Project match not found')

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -352,7 +352,7 @@ class BitBucketHookTests(BasePostCommitTest):
                             "type": "modified"
                         }
                     ],
-                    "message": "Added some featureA things",
+                    "message": "Added some feature things",
                     "node": "d14d26a93fd2",
                     "parents": [
                             "1b458191f31a"
@@ -439,6 +439,36 @@ class BitBucketHookTests(BasePostCommitTest):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
             r.content, '(URL Build) Build Started: bitbucket.org/sphinx/sphinx [latest]')
+
+    def test_bitbucket_post_commit_empty_commit_list(self):
+        self.hg_payload['commits'] = []
+        self.git_payload['commits'] = []
+
+        r = self.client.post('/bitbucket/', data=json.dumps(self.hg_payload),
+                             content_type='application/json')
+        self.assertEqual(r.status_code, 404)
+        self.assertEqual(r.content, 'Commits/Banches not found')
+
+        r = self.client.post('/bitbucket/', data=json.dumps(self.git_payload),
+                             content_type='application/json')
+        self.assertEqual(r.status_code, 404)
+        self.assertEqual(r.content, 'Commits/Banches not found')
+
+
+    def test_bitbucket_post_commit_non_existent_url(self):
+        self.hg_payload['repository']['absolute_url'] = '/invalid/repository'
+        self.git_payload['repository']['absolute_url'] = '/invalid/repository'
+
+        r = self.client.post('/bitbucket/', data=json.dumps(self.hg_payload),
+                             content_type='application/json')
+        self.assertEqual(r.status_code, 404)
+        self.assertEqual(r.content, 'Project match not found')
+
+        r = self.client.post('/bitbucket/', data=json.dumps(self.git_payload),
+                             content_type='application/json')
+        self.assertEqual(r.status_code, 404)
+        self.assertEqual(r.content, 'Project match not found')
+
 
     def test_bitbucket_post_commit_hook_builds_branch_docs_if_it_should(self):
         """

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -447,12 +447,12 @@ class BitBucketHookTests(BasePostCommitTest):
         r = self.client.post('/bitbucket/', data=json.dumps(self.hg_payload),
                              content_type='application/json')
         self.assertEqual(r.status_code, 404)
-        self.assertEqual(r.content, 'Commits/Banches not found')
+        self.assertEqual(r.content, 'Commit/branch not found')
 
         r = self.client.post('/bitbucket/', data=json.dumps(self.git_payload),
                              content_type='application/json')
         self.assertEqual(r.status_code, 404)
-        self.assertEqual(r.content, 'Commits/Banches not found')
+        self.assertEqual(r.content, 'Commit/branch not found')
 
 
     def test_bitbucket_post_commit_non_existent_url(self):


### PR DESCRIPTION
For some reason, bitbucket is sending a webhook with incomplete
data ('commits' is the empty list), and we need it to process the
webhook.

This commit adds a new validation for the 'commits' data (branches
variable inside RTD) before start the building process.

https://sentry.io/read-the-docs/readthedocs-org/issues/235650096/