### PR TITLE
make tests parallelizable (multi processing) using pytest-xdist

### DIFF
--- a/readthedocs/rtd_tests/base.py
+++ b/readthedocs/rtd_tests/base.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import logging
+import tempfile
 from collections import OrderedDict
 
 from mock import patch
@@ -18,7 +19,7 @@ class RTDTestCase(TestCase):
     def setUp(self):
         self.original_DOCROOT = settings.DOCROOT
         self.cwd = os.path.dirname(__file__)
-        self.build_dir = os.path.join(self.cwd, 'builds')
+        self.build_dir = tempfile.mkdtemp()
         log.info("build dir: %s", self.build_dir)
         if not os.path.exists(self.build_dir):
             os.makedirs(self.build_dir)

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -7,6 +7,7 @@ from django.test.utils import override_settings
 from django_dynamic_fixture import get, new
 
 from corsheaders.middleware import CorsMiddleware
+from mock import patch
 
 from readthedocs.core.middleware import SubdomainMiddleware
 from readthedocs.projects.models import Project, Domain
@@ -95,10 +96,12 @@ class MiddlewareTests(TestCase):
         self.assertEqual(request.slug, 'pip')
 
     @override_settings(USE_SUBDOMAIN=True)
+    # no need to do a real dns query so patch cname_to_slug
+    @patch('readthedocs.core.middleware.cname_to_slug', new=lambda x: 'doesnt')
     def test_use_subdomain_on(self):
         request = self.factory.get(self.url, HTTP_HOST='doesnt.really.matter')
         ret_val = self.middleware.process_request(request)
-        self.assertEqual(ret_val, None)
+        self.assertIsNone(ret_val, None)
 
 
 class TestCORSMiddleware(TestCase):

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -13,6 +13,9 @@ class CommunityTestSettings(CommunityDevSettings):
     PRODUCTION_DOMAIN = 'readthedocs.org'
     GROK_API_HOST = 'http://localhost:8888'
 
+    DEBUG = False
+    TEMPLATE_DEBUG = False
+
 
 CommunityTestSettings.load_settings(__name__)
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -18,7 +18,6 @@ django-extensions==1.7.4
 djangorestframework==3.5.4
 django-vanilla-views==1.0.4
 jsonfield==1.0.3
-pytest-django==2.8.0
 
 requests==2.3.0
 slumber==0.6.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,0 +1,6 @@
+-r pip.txt
+
+pytest-django==2.8.0
+pytest-xdist==1.16.0
+apipkg==1.4
+execnet==1.4.1

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     DJANGO_SETTINGS_MODULE=settings.test
     LANG=C
     DJANGO_SETTINGS_SKIP_LOCAL=True
-deps = -r{toxinidir}/requirements/pip.txt
+deps = -r{toxinidir}/requirements/testing.txt
 changedir = {toxinidir}/readthedocs
 commands =
     py.test {posargs}


### PR DESCRIPTION
Be ware that running tests in parallel may cause tests to flake. 
This commit does not make parallel test the default it only makes it possible.

usage
-----
tox -- -n 4


Benchmarking
------------
using the following command ( on my old laptop...)

`time tox -e py27 -- -n 6 --ignore=rtd_tests/tests/test_celery.py`

w/o xdist: 1 min 24 seconds
2 processes: 53 seconds
3 processes: 44 seconds
4 processes: 40 seconds
5 processes: 40 seconds (tests flake)
6 processes: 43 seconds (tests flake)

~ 2x speedup!