### PR TITLE
Avoid user notifications when LockTimeout is received

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -146,8 +146,8 @@ class UpdateDocsTask(Task):
         if self.setup_env.failure or self.config is None:
             self._log('Failing build because of setup failure: %s' % self.setup_env.failure)
 
-            # send notification to users only if the build didn't failed because of
-            # LockTimeout: this exception ocurrs when a build is triggered before the previous
+            # Send notification to users only if the build didn't fail because of
+            # LockTimeout: this exception occurs when a build is triggered before the previous
             # one has finished (e.g. two webhooks, one after the other)
             if not isinstance(self.setup_env.failure, vcs_support_utils.LockTimeout):
                 self.send_notifications()

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -145,7 +145,13 @@ class UpdateDocsTask(Task):
 
         if self.setup_env.failure or self.config is None:
             self._log('Failing build because of setup failure: %s' % self.setup_env.failure)
-            self.send_notifications()
+
+            # send notification to users only if the build didn't failed because of
+            # LockTimeout: this exception ocurrs when a build is triggered before the previous
+            # one has finished (e.g. two webhooks, one after the other)
+            if not isinstance(self.setup_env.failure, vcs_support_utils.LockTimeout):
+                self.send_notifications()
+
             self.setup_env.update_build(state=BUILD_STATE_FINISHED)
             return None
 


### PR DESCRIPTION
LockTimeout happens when there are more than one build trigger almost at the same time.

This is a fix "hotfix" for #1654.

By "hotfix" I mean that we should solve this problem in a different way at the end. Maybe by creating a RETRY status for this Build instance while they are waiting to be re-triggered and use the same context. Besides, this FAILED build shouldn't be shown to the user and they shouldn't keep registered in the user interface (history of buildings).