### PR TITLE
Set machine to False when a user edits a version.

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -179,6 +179,7 @@ def project_version_detail(request, project_slug, version_slug):
                 log.info('Removing files for version %s' % version.slug)
                 broadcast(type='app', task=tasks.clear_artifacts, args=[version.pk])
                 version.built = False
+                version.machine = False
                 version.save()
         url = reverse('project_version_list', args=[project.slug])
         return HttpResponseRedirect(url)


### PR DESCRIPTION
This means a user can deactivate their stable version,
and we shouldn't keep trying to update it.