### PR TITLE
Remove the dependency on django-secure

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -68,7 +68,6 @@ class CommunityBaseSettings(Settings):
             # third party apps
             'linaro_django_pagination',
             'taggit',
-            'djangosecure',
             'guardian',
             'django_gravatar',
             'rest_framework',
@@ -125,7 +124,7 @@ class CommunityBaseSettings(Settings):
         'readthedocs.core.middleware.FooterNoSessionMiddleware',
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
-        'djangosecure.middleware.SecurityMiddleware',
+        'django.middleware.security.SecurityMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -46,7 +46,6 @@ pytz==2013b
 beautifulsoup4==4.1.3
 Unipath==0.2.1
 django-kombu==0.9.4
-django-secure==0.1.2
 mimeparse==0.1.3
 mock==1.0.1
 stripe==1.20.2


### PR DESCRIPTION
django-secure was merged into Django 1.8, and since rtd.org uses Django 1.9, migrating to using the built-in checks reduces the dependency list and avoids any problems between newer versions of Django and django-secure.

* https://github.com/carljm/django-secure
* https://docs.djangoproject.com/en/1.8/releases/1.8/#security-enhancements

---

I was looking at the list of dependencies in #2819, noticed that django-secure was a package listed as "not compatible", then went digging in its repo and discovered it was deprecated.