### PR TITLE
Upgrade all packages using `pur` tool

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -339,11 +339,11 @@ class Project(models.Model):
                     'Re-symlinking superprojects: project=%s',
                     self.slug,
                 )
-                for superproject in self.superprojects.all():
+                for relationship in self.superprojects.all():
                     broadcast(
                         type='app',
                         task=tasks.symlink_project,
-                        args=[superproject.pk],
+                        args=[relationship.parent.pk],
                     )
 
         except Exception:

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -466,6 +466,7 @@ class IntegrationsTests(TestCase):
         trigger_build.assert_has_calls(
             [mock.call(force=True, version=mock.ANY, project=self.project)])
 
+        trigger_build_call_count = trigger_build.call_count
         client.post(
             '/api/v2/webhook/bitbucket/{0}/'.format(self.project.slug),
             {
@@ -479,8 +480,7 @@ class IntegrationsTests(TestCase):
             },
             format='json',
         )
-        trigger_build.assert_not_called(
-            [mock.call(force=True, version=mock.ANY, project=self.project)])
+        self.assertEqual(trigger_build_call_count, trigger_build.call_count)
 
     def test_bitbucket_invalid_webhook(self, trigger_build):
         """Bitbucket webhook unhandled event."""

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -926,7 +926,7 @@ class TestPublicSymlinkUnicode(TempSiterootCase, TestCase):
             project.description = 'New description'
             project.save()
             # called once for this project itself
-            broadcast.assert_any_calls(
+            broadcast.assert_any_call(
                 type='app',
                 task=symlink_project,
                 args=[project.pk],
@@ -944,13 +944,13 @@ class TestPublicSymlinkUnicode(TempSiterootCase, TestCase):
             subproject.description = 'New subproject description'
             subproject.save()
             # subproject symlinks
-            broadcast.assert_any_calls(
+            broadcast.assert_any_call(
                 type='app',
                 task=symlink_project,
                 args=[subproject.pk],
             )
             # superproject symlinks
-            broadcast.assert_any_calls(
+            broadcast.assert_any_call(
                 type='app',
                 task=symlink_project,
                 args=[project.pk],

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -34,7 +34,11 @@ defusedxml==0.5.0
 # Basic tools
 redis==2.10.6
 celery==4.1.0
-django-allauth==0.35.0
+
+# django-allauth 0.33.0 dropped support for Django 1.9
+# https://django-allauth.readthedocs.io/en/latest/release-notes.html#backwards-incompatible-changes
+django-allauth==0.32.0
+
 dnspython==1.15.0
 
 # VCS

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -6,7 +6,11 @@ docutils==0.14
 Sphinx==1.7.0
 sphinx_rtd_theme==0.2.5b1
 Pygments==2.2.0
-mkdocs==0.17.2
+
+# latest compatible version with our code
+# https://github.com/rtfd/readthedocs.org/pull/2916#discussion_r172991757
+mkdocs==0.15.0
+
 django==1.9.13
 six==1.11.0
 future==0.16.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -70,7 +70,11 @@ dj-pagination==2.3.2
 
 # Docs
 sphinxcontrib-httpdomain==1.5.0
-commonmark==0.7.4
+
+# commonmark 0.5.5 is the latest version compatible with our docs, the
+# newer ones make `tox -e docs` to fail
+commonmark==0.5.5
+
 recommonmark==0.4.0
 
 # Version comparison stuff

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -3,7 +3,7 @@ pip==9.0.1
 appdirs==1.4.3
 virtualenv==15.1.0
 docutils==0.14
-Sphinx==1.6.5
+Sphinx==1.6.6
 sphinx_rtd_theme==0.2.5b1
 Pygments==2.2.0
 mkdocs==0.17.2
@@ -18,7 +18,7 @@ django-tastypie==0.13.0
 django-haystack==2.6.1
 celery-haystack==0.10
 django-guardian==1.4.9
-django-extensions==1.9.8
+django-extensions==1.9.9
 
 # djangorestframework 3.7.x drops support for django 1.9.x
 djangorestframework==3.6.4
@@ -43,7 +43,7 @@ httplib2==0.10.3
 # Search
 elasticsearch==1.5.0
 pyelasticsearch==0.7.1
-pyquery==1.3.0
+pyquery==1.4.0
 
 # Utils
 django-gravatar2==1.4.2
@@ -69,7 +69,7 @@ django-taggit==0.22.2
 dj-pagination==2.3.2
 
 # Docs
-sphinxcontrib-httpdomain==1.5.0
+sphinxcontrib-httpdomain==1.6.0
 
 # commonmark 0.5.5 is the latest version compatible with our docs, the
 # newer ones make `tox -e docs` to fail

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,29 +1,29 @@
 # Base packages
 pip==9.0.1
 appdirs==1.4.3
-virtualenv==15.0.1
-docutils==0.11
-Sphinx==1.5.3
+virtualenv==15.1.0
+docutils==0.13.1
+Sphinx==1.6.2
 sphinx_rtd_theme==0.2.5b1
 Pygments==2.2.0
-mkdocs==0.14.0
+mkdocs==0.16.3
 django==1.9.12
 six==1.10.0
 future==0.16.0
 readthedocs-build<2.1
 
-django-tastypie==0.13.0
-django-haystack==2.6.0
+django-tastypie==0.13.3
+django-haystack==2.6.1
 celery-haystack==0.10
-django-guardian==1.4.6
-django-extensions==1.7.4
-djangorestframework==3.5.4
+django-guardian==1.4.8
+django-extensions==1.7.9
+djangorestframework==3.6.3
 django-vanilla-views==1.0.4
-jsonfield==1.0.3
+jsonfield==2.0.1
 
-requests==2.9.1
+requests==2.16.5
 slumber==0.7.1
-lxml==3.3.5
+lxml==3.7.3
 defusedxml==0.5.0
 
 # Basic tools
@@ -33,35 +33,35 @@ django-allauth==0.32.0
 dnspython==1.15.0
 
 # VCS
-httplib2==0.7.7
+httplib2==0.10.3
 
 # Search
 elasticsearch==1.5.0
 pyelasticsearch==0.7.1
-pyquery==1.2.2
+pyquery==1.2.17
 
 # Utils
 django-gravatar2==1.4.0
 pytz==2013b
-beautifulsoup4==4.1.3
+beautifulsoup4==4.6.0
 Unipath==1.1
 django-kombu==0.9.4
 mimeparse==0.1.3
-mock==1.0.1
-stripe==1.20.2
-django-formtools==1.0
-django-dynamic-fixture==1.8.5
+mock==2.0.0
+stripe==1.56.0
+django-formtools==2.0
+django-dynamic-fixture==1.9.5
 docker-py==1.3.1
 django-textclassifier==1.0
-django-annoying==0.10.1
+django-annoying==0.10.3
 django-messages-extends==0.5
 djangorestframework-jsonp==1.0.2
 django-taggit==0.22.2
 dj-pagination==2.3.2
 
 # Docs
-sphinxcontrib-httpdomain==1.4.0
-commonmark==0.5.5
+sphinxcontrib-httpdomain==1.5.0
+commonmark==0.7.3
 recommonmark==0.4.0
 
 # Version comparison stuff
@@ -69,4 +69,4 @@ packaging==16.8
 
 # Commenting stuff
 django-cors-middleware==1.3.1
-nilsimsa==0.3.7
+nilsimsa==0.3.8

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -3,7 +3,7 @@ pip==9.0.1
 appdirs==1.4.3
 virtualenv==15.1.0
 docutils==0.14
-Sphinx==1.6.6
+Sphinx==1.7.0
 sphinx_rtd_theme==0.2.5b1
 Pygments==2.2.0
 mkdocs==0.17.2
@@ -15,10 +15,10 @@ readthedocs-build<2.1
 # django-tastypie 0.13.x and 0.14.0 are not compatible with our code
 django-tastypie==0.13.0
 
-django-haystack==2.6.1
+django-haystack==2.7.0
 celery-haystack==0.10
 django-guardian==1.4.9
-django-extensions==1.9.9
+django-extensions==2.0.0
 
 # djangorestframework 3.7.x drops support for django 1.9.x
 djangorestframework==3.6.4
@@ -34,7 +34,7 @@ defusedxml==0.5.0
 # Basic tools
 redis==2.10.6
 celery==4.1.0
-django-allauth==0.34.0
+django-allauth==0.35.0
 dnspython==1.15.0
 
 # VCS
@@ -47,7 +47,7 @@ pyquery==1.4.0
 
 # Utils
 django-gravatar2==1.4.2
-pytz==2017.3
+pytz==2018.3
 beautifulsoup4==4.6.0
 Unipath==1.1
 django-kombu==0.9.4
@@ -63,7 +63,7 @@ django-dynamic-fixture==2.0.0
 docker-py==1.3.1
 django-textclassifier==1.0
 django-annoying==0.10.4
-django-messages-extends==0.5
+django-messages-extends==0.6.0
 djangorestframework-jsonp==1.0.2
 django-taggit==0.22.2
 dj-pagination==2.3.2

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -2,34 +2,39 @@
 pip==9.0.1
 appdirs==1.4.3
 virtualenv==15.1.0
-docutils==0.13.1
-Sphinx==1.6.2
+docutils==0.14
+Sphinx==1.6.5
 sphinx_rtd_theme==0.2.5b1
 Pygments==2.2.0
-mkdocs==0.16.3
-django==1.9.12
-six==1.10.0
+mkdocs==0.17.2
+django==1.9.13
+six==1.11.0
 future==0.16.0
 readthedocs-build<2.1
 
-django-tastypie==0.13.3
+# django-tastypie 0.13.x and 0.14.0 are not compatible with our code
+django-tastypie==0.13.0
+
 django-haystack==2.6.1
 celery-haystack==0.10
-django-guardian==1.4.8
-django-extensions==1.7.9
-djangorestframework==3.6.3
-django-vanilla-views==1.0.4
-jsonfield==2.0.1
+django-guardian==1.4.9
+django-extensions==1.9.8
 
-requests==2.16.5
+# djangorestframework 3.7.x drops support for django 1.9.x
+djangorestframework==3.6.4
+
+django-vanilla-views==1.0.4
+jsonfield==2.0.2
+
+requests==2.18.4
 slumber==0.7.1
-lxml==3.7.3
+lxml==4.1.1
 defusedxml==0.5.0
 
 # Basic tools
 redis==2.10.6
 celery==4.1.0
-django-allauth==0.32.0
+django-allauth==0.34.0
 dnspython==1.15.0
 
 # VCS
@@ -38,22 +43,26 @@ httplib2==0.10.3
 # Search
 elasticsearch==1.5.0
 pyelasticsearch==0.7.1
-pyquery==1.2.17
+pyquery==1.3.0
 
 # Utils
-django-gravatar2==1.4.0
-pytz==2013b
+django-gravatar2==1.4.2
+pytz==2017.3
 beautifulsoup4==4.6.0
 Unipath==1.1
 django-kombu==0.9.4
 mimeparse==0.1.3
 mock==2.0.0
-stripe==1.56.0
-django-formtools==2.0
-django-dynamic-fixture==1.9.5
+
+# stripe 1.20.2 is the latest compatible with our code base (otherwise
+# gold/tests/test_forms.py fails)
+stripe==1.20.2
+
+django-formtools==2.1
+django-dynamic-fixture==2.0.0
 docker-py==1.3.1
 django-textclassifier==1.0
-django-annoying==0.10.3
+django-annoying==0.10.4
 django-messages-extends==0.5
 djangorestframework-jsonp==1.0.2
 django-taggit==0.22.2
@@ -61,7 +70,7 @@ dj-pagination==2.3.2
 
 # Docs
 sphinxcontrib-httpdomain==1.5.0
-commonmark==0.7.3
+commonmark==0.7.4
 recommonmark==0.4.0
 
 # Version comparison stuff


### PR DESCRIPTION
These ones were not upgraded since they are incompatible:

* django
* docker-py
* celery
* elasticsearch
* pyelasticsearch

This is just a way to run all the test with this environment and also to discuss with other people if this is something we really want.

Closes #1893