### PR TITLE
Fix classmethod pass through on settings extend classes

### DIFF
--- a/readthedocs/core/utils/extend.py
+++ b/readthedocs/core/utils/extend.py
@@ -34,7 +34,7 @@ class SettingsOverrideMeta(type):
     """Meta class for passing along classmethod class to the underlying class"""
 
     def __getattr__(cls, attr):  # noqa: pep8 false positive
-        proxy_class = getattr(cls, '_default_class')
+        proxy_class = get_override_class(cls, getattr(cls, '_default_class'))
         return getattr(proxy_class, attr)
 
 

--- a/readthedocs/rtd_tests/tests/test_extend.py
+++ b/readthedocs/rtd_tests/tests/test_extend.py
@@ -9,9 +9,17 @@ class FooBase(object):
     def bar(self):
         return 1
 
+    @classmethod
+    def baz(cls):
+        return 1
+
 
 class NewFoo(FooBase):
     def bar(self):
+        return 2
+
+    @classmethod
+    def baz(cls):
         return 2
 
 
@@ -32,6 +40,7 @@ class ExtendTests(TestCase):
         foo = Foo()
         self.assertEqual(foo.__class__.__name__, 'FooBase')
         self.assertEqual(foo.bar(), 1)
+        self.assertEqual(Foo.baz(), 1)
 
         override_class = get_override_class(Foo, Foo._default_class)
         self.assertEqual(override_class, FooBase)
@@ -46,6 +55,7 @@ class ExtendTests(TestCase):
         foo = Foo()
         self.assertEqual(foo.__class__.__name__, 'NewFoo')
         self.assertEqual(foo.bar(), 2)
+        self.assertEqual(Foo.baz(), 2)
 
         override_class = get_override_class(Foo, Foo._default_class)
         self.assertEqual(override_class, NewFoo)
@@ -63,6 +73,7 @@ class ExtendTests(TestCase):
         foo = Foo()
         self.assertEqual(foo.__class__.__name__, 'NewFoo')
         self.assertEqual(foo.bar(), 2)
+        self.assertEqual(Foo.baz(), 2)
 
         override_class = get_override_class(Foo, Foo._default_class)
         self.assertEqual(override_class, NewFoo)
@@ -79,6 +90,7 @@ class ExtendTests(TestCase):
         foo = Foo()
         self.assertEqual(foo.__class__.__name__, 'NewFoo')
         self.assertEqual(foo.bar(), 2)
+        self.assertEqual(Foo.baz(), 2)
 
         override_class = get_override_class(Foo, Foo._default_class)
         self.assertEqual(override_class, NewFoo)


### PR DESCRIPTION
Classmethods weren't resolving to the intended class correctly.