### PR TITLE
Clean up handling of translation syncing.

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -494,6 +494,7 @@ class TranslationForm(forms.Form):
 
     def save(self):
         project = self.parent.translations.add(self.translation)
+        self.parent.save()
         return project
 
 

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -494,6 +494,7 @@ class TranslationForm(forms.Form):
 
     def save(self):
         project = self.parent.translations.add(self.translation)
+        # Run symlinking and other sync logic to make sure we are in a good state.
         self.parent.save()
         return project
 

--- a/readthedocs/templates/core/project_bar.html
+++ b/readthedocs/templates/core/project_bar.html
@@ -6,4 +6,7 @@
   {% if request.user|is_project_user:project %}
     <a href="{% url "projects_dashboard" %}">{% trans "Projects" %}</a>&nbsp;&gt;
   {% endif %}
+  {% if project.superprojects.count %}
+    <a href="{% url "projects_detail" project.superprojects.all.0.parent.slug %}">{{ project.superprojects.all.0.parent.name }}</a>&nbsp;&gt;
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Clean up handling of translation syncing.

This makes sure we properly run all the post-save logic on the parent on translation,
also it adds a UI element to the page to show that subprojects are in fact, subprojects.