### PR TITLE
Remove extra envs from python version run with tox-travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 envlist = py{27,36},lint,docs
 skipsdist = True
 
-[travis:python]
-2.7 = py27
-3.6 = py36
+[travis]
+python =
+    2.7: py27
+    3.6: py36
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist = py{27,36},lint,docs
 skipsdist = True
 
-[tox:travis]
-2.7 = py27,lint,docs
+[travis:python]
+2.7 = py27
 3.6 = py36
 
 [testenv]


### PR DESCRIPTION
This stops multiple envs from running on the py27/py36 test envs