### PR TITLE
Add email header affordance

### DIFF
--- a/readthedocs/templates/core/email/base.html
+++ b/readthedocs/templates/core/email/base.html
@@ -23,7 +23,7 @@ table td {border-collapse: collapse;}
 
   td.header img {
     width: 100%;
-    height: auto;
+    height: 150px;
   }
 }
 
@@ -63,7 +63,7 @@ p {
           <tr>
             <td class="header">
               {% block header %}
-              <img src='https://media.readthedocs.org/images/email-header.png' width="100%" style="" />
+              <img src='https://media.readthedocs.org/images/email-header.png' width="100%" height="150"style="" />
               {% endblock %}
             </td>
           </tr>


### PR DESCRIPTION
Prior to this change when a user opens a RTD email the header may be very thin and then suddenly
expand as the image loads the email content lowers. This caused me to click the header instead of
the email confirmation link