### PR TITLE
Use pip to install mkdocs for base conda build env

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -215,7 +215,6 @@ class Conda(PythonEnvironment):
             'mock',
             'pillow',
             'sphinx_rtd_theme',
-            'mkdocs',
         ]
 
         cmd = [
@@ -232,6 +231,7 @@ class Conda(PythonEnvironment):
 
         # Install pip-only things.
         pip_requirements = [
+            'mkdocs',
             'readthedocs-sphinx-ext',
             'recommonmark',
         ]


### PR DESCRIPTION
Addresses #2975 

Currently, `mkdocs` is not available in the default conda channel (anaconda). It is available in the `conda-forge` channel.

There are two possible ways to add `mkdocs` into the core conda build environment:

- `conda install -c conda-forge mkdocs` which if done I would recommend installing all the core conda packages from conda-forge

- Alternatively, install `mkdocs` into the core conda build environment using `pip`.

I've gone ahead and created a PR for the second approach since it does not add additional code just moves the `mkdocs` package from one list to another.

