### PR TITLE
Remove future standard library monkey patching

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -1,16 +1,15 @@
 """Signal handling for core app."""
 
 from __future__ import absolute_import
+
 import logging
 
-from django.dispatch import Signal
 from corsheaders import signals
+from django.dispatch import Signal
+from future.backports.urllib.parse import urlparse
 
 from readthedocs.projects.models import Project, Domain
 
-from future import standard_library
-standard_library.install_aliases()
-from urllib.parse import urlparse  # noqa
 
 log = logging.getLogger(__name__)
 

--- a/readthedocs/core/templatetags/core_tags.py
+++ b/readthedocs/core/templatetags/core_tags.py
@@ -7,15 +7,12 @@ import hashlib
 from builtins import str  # pylint: disable=redefined-builtin
 from django import template
 from django.conf import settings
-from django.utils.safestring import mark_safe
 from django.utils.encoding import force_bytes, force_text
+from django.utils.safestring import mark_safe
+from future.backports.urllib.parse import urlencode
 
-from readthedocs.projects.models import Project
 from readthedocs.core.resolver import resolve
-
-from future import standard_library
-standard_library.install_aliases()
-import urllib.request, urllib.parse, urllib.error  # noqa
+from readthedocs.projects.models import Project
 
 
 register = template.Library()
@@ -29,7 +26,7 @@ def gravatar(email, size=48):
     render an img tag with the hashed up bits needed for leetness
     omgwtfstillreading
     """
-    url = "http://www.gravatar.com/avatar.php?%s" % urllib.parse.urlencode({
+    url = "http://www.gravatar.com/avatar.php?%s" % urlencode({
         'gravatar_id': hashlib.md5(email).hexdigest(),
         'size': str(size)
     })

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -13,14 +13,11 @@ from django.utils import six
 from django.utils.functional import allow_lazy
 from django.utils.safestring import SafeText, mark_safe
 from django.utils.text import slugify as slugify_base
+from future.backports.urllib.parse import urlparse
 
+from ..tasks import send_email_task
 from readthedocs.builds.constants import LATEST
 from readthedocs.doc_builder.constants import DOCKER_LIMITS
-from ..tasks import send_email_task
-
-from future import standard_library  # pylint: disable=wrong-import-order
-standard_library.install_aliases()
-from urllib.parse import urlparse  # noqa
 
 
 log = logging.getLogger(__name__)

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -9,13 +9,13 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy as _
+from future.backports.urllib.parse import urlparse
 from guardian.shortcuts import assign
 from textclassifier.validators import ClassifierValidator
 
 from readthedocs.builds.constants import TAG
-from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.utils import trigger_build, slugify
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteRepository
@@ -24,10 +24,6 @@ from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.models import (
     Project, ProjectRelationship, EmailHook, WebHook, Domain)
 from readthedocs.redirects.models import Redirect
-
-from future import standard_library
-standard_library.install_aliases()
-from urllib.parse import urlparse  # noqa
 
 
 class ProjectForm(forms.ModelForm):

--- a/readthedocs/projects/migrations/0010_migrate_domain_data.py
+++ b/readthedocs/projects/migrations/0010_migrate_domain_data.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import (absolute_import, print_function, unicode_literals)
 
-from future import standard_library
-standard_library.install_aliases()
-
-import urllib.parse
-
 from django.db import models, migrations
+from future.backports.urllib.parse import urlparse
 
 import readthedocs.core.validators
 
@@ -20,7 +16,7 @@ def migrate_url(apps, schema_editor):
                 project=domain.project.slug))
             domain.delete()
             continue
-        parsed = urllib.parse(domain.url)
+        parsed = urlparse(domain.url)
         if parsed.scheme or parsed.netloc:
             domain_string = parsed.netloc
         else:

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -13,6 +13,7 @@ from django.core.urlresolvers import reverse, NoReverseMatch
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from future.backports.urllib.parse import urlparse  # noqa
 from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
@@ -36,10 +37,6 @@ from readthedocs.core.validators import validate_domain_name
 from readthedocs.vcs_support.base import VCSProject
 from readthedocs.vcs_support.backends import backend_cls
 from readthedocs.vcs_support.utils import Lock, NonBlockingLock
-
-from future import standard_library
-standard_library.install_aliases()
-from urllib.parse import urlparse  # noqa
 
 
 log = logging.getLogger(__name__)

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -1,17 +1,16 @@
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+
 import json
 import logging
-from urllib.parse import urlencode
 
 import mock
-from django_dynamic_fixture import get
 from django.test import TestCase
+from django_dynamic_fixture import get
+from future.backports.urllib.parse import urlencode
 
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
-from readthedocs.projects import tasks
+
 
 log = logging.getLogger(__name__)
 

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -6,12 +6,10 @@ import csv
 import re
 
 from builtins import bytes, str  # pylint: disable=redefined-builtin
+from six import StringIO
+
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
-
-from future import standard_library
-standard_library.install_aliases()
-from io import StringIO  # noqa
 
 
 class Backend(BaseVCS):

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -2,18 +2,16 @@
 
 from __future__ import absolute_import
 
-import re
-import logging
 import csv
+import logging
 import os
+import re
 
-from builtins import bytes, str  # pylint: disable=redefined-builtin
+from builtins import str
+from six import StringIO
+
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
-
-from future import standard_library
-standard_library.install_aliases()
-from io import StringIO  # noqa
 
 
 log = logging.getLogger(__name__)

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -4,14 +4,11 @@ from __future__ import absolute_import
 
 import csv
 
-from builtins import bytes, str  # pylint: disable=redefined-builtin
+from builtins import str
+from six import StringIO  # noqa
 
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
-
-from future import standard_library
-standard_library.install_aliases()
-from io import StringIO  # noqa
 
 
 class Backend(BaseVCS):


### PR DESCRIPTION
Patching `sys.modules`, while clever, fucks with downstream libraries. I ran
into problems with `urllib` being patched to return bytes, where a middleware
was expecting `str`. Instead, we'll be less aggressive with patching here.

This also cleans up some import ordering -- my refactoring tooling automates
this.