### PR TITLE
Fix call to allauth adapter

### DIFF
--- a/readthedocs/oauth/utils.py
+++ b/readthedocs/oauth/utils.py
@@ -55,7 +55,7 @@ def attach_webhook(project, request=None):
             request,
             _('No accounts available to set webhook on. '
                 'Please connect your {network} account.'.format(
-                    network=service.adapter().get_provider().name
+                    network=service.adapter(request).get_provider().name
                 ))
         )
     return False


### PR DESCRIPTION
This apparently changed at some point. This was triggered when no accounts were
connected and a project import was attempted. Webhook setup would try to emit a
warning message for the provider.