### PR TITLE
Add support for unicode Git tags/branches

### DIFF
--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -1,5 +1,7 @@
 """Mercurial-related utilities."""
+
 from __future__ import absolute_import
+
 from readthedocs.projects.exceptions import ProjectImportError
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
 


### PR DESCRIPTION
This replaces CSV parsing of the data, as CSV doesn't support unicode and is
mostly hacky.