### PR TITLE
Remove YAML unicode tags from Mkdocs config

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -100,7 +100,7 @@ class BaseMkdocs(BaseBuilder):
         if 'theme_dir' not in user_config and self.use_theme:
             user_config['theme_dir'] = TEMPLATE_DIR
 
-        yaml.dump(
+        yaml.safe_dump(
             user_config,
             open(os.path.join(self.root_path, 'mkdocs.yml'), 'w')
         )
@@ -187,7 +187,7 @@ class MkdocsJSON(BaseMkdocs):
         )
         if user_config['theme_dir'] == TEMPLATE_DIR:
             del user_config['theme_dir']
-        yaml.dump(
+        yaml.safe_dump(
             user_config,
             open(os.path.join(self.root_path, 'mkdocs.yml'), 'w')
         )


### PR DESCRIPTION
In the case of a unicode string without a unicode character, YAML adds a tag to
ensure the text is read as unicode, ie:

    In [1]: import yaml

    In [2]: yaml.dump(u'surprise!')
    Out[2]: "!!python/unicode 'surprise!'\n"

This forces only literals are output to the YAML config, by using `safe_dump`
instead of `dump`