### PR TITLE
Intro Dockerfile to ease help adoption.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,84 @@
+# Git
+.git
+.gitignore
+
+# CI
+.codeclimate.yml
+.travis.yml
+
+# Docker
+docker-compose.yml
+.docker
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env/
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# Sqlite database
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# FROM readthedocs/build:latest
+FROM python:2.7.13
+# FROM python:3.6.1
+
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        elasticsearch \
+        redis-server \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app
+COPY requirements /usr/src/app/requirements
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app/
+
+RUN python manage.py migrate
+RUN python manage.py createsuperuser --noinput \
+      --username root \
+      --email dev@localhost
+RUN python manage.py collectstatic --noinput
+RUN python manage.py loaddata test_data
+
+CMD python manage.py runserver
+
+EXPOSE 8000


### PR DESCRIPTION
@ericholscher, [I have an idea](https://twitter.com/sanscore0/status/885621269625880577).

First, setting up a RTD instance is hard. When setting up a long-running service, a little bit of pain is fine. However, for potential contributors and evaluators, that initial barrier can shun them away. By creating and distributing a Dockerfile, then we give these users a very simple way to run RTD locally. This way, they can run and play with RTD which should _hopefully_ help generate more interest.

### Commit Message
```
Users of this Dockerfile can be either contributors or administrators.

For contributors, they will be able to make changes and be able to see
their changes by rebuilding the image.

For administrators, they will be able to quickly evaluate RTD without
having to contribute a lot of time.

Build:
$ docker build --tag rtfd-server .

Run:
$ docker run -p 8000:8000 rtfd-server
```
I'm not intending for this PR to be accepted as-is, but to help generate ideas. I can speak of the design decisions so far.

Notes about the design:

 * This Dockerfile tries to follow the [Installation Instructions](http://docs.readthedocs.io/en/latest/install.html).
 * It uses `python:2.7.13`
    * It can use `python:3.6.1`, but currently, untested.
    * I haven't attempted it, but using `readthedocs/build:latest` might be more interesting because it would allow the flexibility of choosing which version of Python.
    * I attempted to use `python:2.7.13-onbuild`, but it will only work if I refactor`./requirements.txt`.
 * Installs `redis-server`
    * I don't think that `apt-get` starts Redis, if so a RUN command will have to be add.
 * Installs `elasticsearch`
    * Same concern as `redis-server`.

I could rewrite the Dockerfile as a `docker-compose.yml` file. That would allow for splitting out the RTD, the database, redis, and elasticsearch to their own containers, and add an nginx instance as well.

At present, running the container has one obvious issue:

```
$ docker run -p 8000:8000 rtfd-server
System check identified some issues:

WARNINGS:
?: (guardian.W001) Guardian authentication backend is not hooked. You can add this in settings as eg: `AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend', 'guardian.backends.ObjectPermissionBackend')`.
```

I haven't investigated the problem, but the warning does give a good idea on how to resolve it.


Thoughts?