### PR TITLE
Fix version URLs for custom installs

### DIFF
--- a/docs/custom_installs/customization.rst
+++ b/docs/custom_installs/customization.rst
@@ -8,6 +8,10 @@ Have a local settings file
 --------------------------
 
 If you put a file named ``local_settings.py`` in the ``readthedocs/settings`` directory, it will override settings available in the base install.
+To enable options specific for custom installations, add a line::
+
+    IS_CUSTOM_INSTALL = True
+
 
 Adding your own title to pages
 ------------------------------

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -80,9 +80,15 @@ context = {
     'current_version': "{{ current_version }}",
     'MEDIA_URL': "{{ settings.MEDIA_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
+    {% if settings.IS_CUSTOM_INSTALL %}
     'versions': [{% for version in versions %}
-    ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}
+        ("{{ version.slug }}", "{{ version.get_absolute_url }}"),{% endfor %}
     ],
+    {% else %}
+    'versions': [{% for version in versions %}
+        ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}
+    ],
+    {% endif %}
     'downloads': [ {% for key, val in downloads.items %}
     ("{{ key }}", "{{ val }}"),{% endfor %}
     ],


### PR DESCRIPTION
Fixes #2162, while maintaining compatibility with production RTD.

A new setting `IS_CUSTOM_INSTALL` is provided as a global switch for any functionality specific to custom installs, so that production deployment of RTD is unaffected.