### PR TITLE
Fix Travis CI build on Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install --lts
   - nvm use --lts
+  - npm install -g bower
   - npm install
   - bower install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install --lts
   - nvm use --lts
-  - npm install -g bower
+  - npm install -g bower gulp
   - npm install
   - bower install
 script:


### PR DESCRIPTION
Travis CI has switched from Ubuntu Precise to Trusty as part of some environment changes: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
This broke building RTD on Travis CI due to `bower` and `gulp` command-line commands not being available.
This PR adds them back and fixes #3019.