### PR TITLE
Remove hardcoded readthedocs.org URL

### DIFF
--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -101,7 +101,7 @@
         <dt>Search</dt>
         <dd>
           <div style="padding: 6px;">
-            <form id="flyout-search-form" class="wy-form" target="_blank" action="https://readthedocs.org{% url 'elastic_project_search' project.slug %}" method="get">
+            <form id="flyout-search-form" class="wy-form" target="_blank" action="//{{ settings.PRODUCTION_DOMAIN }}{% url 'elastic_project_search' project.slug %}" method="get">
               <input type="text" name="q" placeholder="Search docs">
               </form>
           </div>


### PR DESCRIPTION
When using a custom readthedocs server, the search box in the documentation footer link to readthedocs.org website instead of the production domain host.

Using ``settings.PRODUCTION_DOMAIN`` fix the problem.