### PR TITLE
Fixes py27 django 1.10 dep warnings in core subdomain urls.

### DIFF
--- a/readthedocs/core/urls/subdomain.py
+++ b/readthedocs/core/urls/subdomain.py
@@ -4,33 +4,38 @@ from __future__ import absolute_import
 from functools import reduce
 from operator import add
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from django.conf.urls.static import static
+
+from readthedocs.core.views.serve import (
+    redirect_page_with_filename,
+    redirect_project_slug,
+    serve_docs
+)
 
 from readthedocs.constants import pattern_opts
 
 handler500 = 'readthedocs.core.views.server_error'
 handler404 = 'readthedocs.core.views.server_error_404'
 
-subdomain_urls = patterns(
-    '',  # base view, flake8 complains if it is on the previous line.
+subdomain_urls = [
     url(r'^(?:|projects/(?P<subproject_slug>{project_slug})/)'
         r'page/(?P<filename>.*)$'.format(**pattern_opts),
-        'readthedocs.core.views.serve.redirect_page_with_filename',
+        redirect_page_with_filename,
         name='docs_detail'),
 
     url((r'^(?:|projects/(?P<subproject_slug>{project_slug})/)$').format(**pattern_opts),
-        'readthedocs.core.views.serve.redirect_project_slug',
+        redirect_project_slug,
         name='redirect_project_slug'),
 
     url((r'^(?:|projects/(?P<subproject_slug>{project_slug})/)'
          r'(?P<lang_slug>{lang_slug})/'
          r'(?P<version_slug>{version_slug})/'
          r'(?P<filename>{filename_slug})$'.format(**pattern_opts)),
-        'readthedocs.core.views.serve.serve_docs',
-        name='docs_detail'),
-)
+         serve_docs,
+         name='docs_detail'),
+]
 
 groups = [subdomain_urls]
 

--- a/readthedocs/core/urls/subdomain.py
+++ b/readthedocs/core/urls/subdomain.py
@@ -10,14 +10,16 @@ from django.conf.urls.static import static
 
 from readthedocs.core.views.serve import (
     redirect_page_with_filename,
-    redirect_project_slug,
-    serve_docs
+    redirect_project_slug, serve_docs
 )
-
+from readthedocs.core.views import (
+    server_error_500,
+    server_error_404,
+)
 from readthedocs.constants import pattern_opts
 
-handler500 = 'readthedocs.core.views.server_error'
-handler404 = 'readthedocs.core.views.server_error_404'
+handler500 = server_error_500
+handler404 = server_error_404
 
 subdomain_urls = [
     url(r'^(?:|projects/(?P<subproject_slug>{project_slug})/)'
@@ -33,8 +35,8 @@ subdomain_urls = [
          r'(?P<lang_slug>{lang_slug})/'
          r'(?P<version_slug>{version_slug})/'
          r'(?P<filename>{filename_slug})$'.format(**pattern_opts)),
-         serve_docs,
-         name='docs_detail'),
+        serve_docs,
+        name='docs_detail'),
 ]
 
 groups = [subdomain_urls]

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -14,7 +14,8 @@ from tastypie.api import Api
 from readthedocs.api.base import (ProjectResource, UserResource,
                                   VersionResource, FileResource)
 from readthedocs.core.urls import docs_urls, core_urls, deprecated_urls
-from readthedocs.core.views import HomepageView, SupportView
+from readthedocs.core.views import (HomepageView, SupportView,
+                                    server_error_404, server_error_500)
 from readthedocs.search import views as search_views
 
 
@@ -26,8 +27,8 @@ v1_api.register(FileResource())
 
 admin.autodiscover()
 
-handler404 = 'readthedocs.core.views.server_error_404'
-handler500 = 'readthedocs.core.views.server_error_500'
+handler404 = server_error_404
+handler500 = server_error_500
 
 basic_urls = [
     url(r'^$', HomepageView.as_view(), name='homepage'),


### PR DESCRIPTION
Django 1.10 doesn't like using patterns('', ...) and instead
wants the use of a list. It also no longer wants the string path
to a callable and instead wants the callable itself.