### PR TITLE
Fix {% trans %} tags in password reset email. Fixes #3036.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .coverage
 .idea
 .vagrant
+.vscode
 .tox
 .env
 .rope_project/

--- a/readthedocs/templates/account/email/password_reset_key_message.html
+++ b/readthedocs/templates/account/email/password_reset_key_message.html
@@ -12,6 +12,6 @@
     </p>
 
     <p>
-      {% trans "If you did not request to reset you password, you can disregard this email." %}
+      {% trans "If you did not request to reset your password, you can disregard this email." %}
     </p>
 {% endblock %}

--- a/readthedocs/templates/account/email/password_reset_key_message.html
+++ b/readthedocs/templates/account/email/password_reset_key_message.html
@@ -4,8 +4,7 @@
 
 {% block content %}
     <p>
-      {% trans "A request has been made to reset your Read the Docs password. To confirm
-this reset request, please go to:" %}
+      {% trans "A request has been made to reset your Read the Docs password. To confirm this reset request, please go to:" %}
     </p>
 
     <p>

--- a/readthedocs/templates/account/email/password_reset_key_message.txt
+++ b/readthedocs/templates/account/email/password_reset_key_message.txt
@@ -3,8 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-{% trans "A request has been made to reset your Read the Docs password. To confirm
-this reset request, please go to:" %}
+{% trans "A request has been made to reset your Read the Docs password. To confirm this reset request, please go to:" %}
 
 {{ password_reset_url }}
 

--- a/readthedocs/templates/account/email/password_reset_key_message.txt
+++ b/readthedocs/templates/account/email/password_reset_key_message.txt
@@ -7,5 +7,5 @@
 
 {{ password_reset_url }}
 
-{% trans "If you did not request to reset you password, you can disregard this email." %}
+{% trans "If you did not request to reset your password, you can disregard this email." %}
 {% endblock %}


### PR DESCRIPTION
TIL linebreaks will prevent `{% trans %}` tags from being parsed.