### PR TITLE
Enforcing linux line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*		text eol=lf


### PR DESCRIPTION
Documenting desired line endings/will help prevent windows developers don't accidentally push code with windows line endings.