### PR TITLE
Remove apiv1 from our internal usage.

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -22,7 +22,6 @@ from slumber.exceptions import HttpClientError
 from readthedocs.builds.constants import BUILD_STATE_FINISHED
 from readthedocs.builds.models import BuildCommandResultMixin
 from readthedocs.projects.constants import LOG_TEMPLATE
-from readthedocs.api.client import api as api_v1
 from readthedocs.restapi.client import api as api_v2
 
 from .exceptions import (BuildEnvironmentException, BuildEnvironmentError,
@@ -37,7 +36,7 @@ log = logging.getLogger(__name__)
 
 
 __all__ = (
-    'api_v1', 'api_v2',
+    'api_v2',
     'BuildCommand', 'DockerBuildCommand',
     'BuildEnvironment', 'LocalEnvironment', 'DockerEnvironment',
 )

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -17,7 +17,6 @@ from future.backports.urllib.parse import urlparse  # noqa
 from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
-from readthedocs.api.client import api
 from readthedocs.builds.constants import LATEST, LATEST_VERBOSE_NAME, STABLE
 from readthedocs.core.resolver import resolve, resolve_domain
 from readthedocs.core.utils import broadcast, slugify
@@ -32,6 +31,8 @@ from readthedocs.projects.querysets import (
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
 from readthedocs.projects.utils import make_api_version
 from readthedocs.projects.version_handling import determine_stable_version, version_windows
+# transitioning from v1 to v2, rename for now, remove later
+from readthedocs.restapi.client import api
 from readthedocs.restapi.client import api as apiv2
 from readthedocs.vcs_support.backends import backend_cls
 from readthedocs.vcs_support.base import VCSProject
@@ -641,8 +642,7 @@ class Project(models.Model):
 
     def api_versions(self):
         ret = []
-        for version_data in api.version.get(project=self.pk,
-                                            active=True)['objects']:
+        for version_data in api.project(self.pk).active_versions.get()['versions']:
             version = make_api_version(version_data)
             ret.append(version)
         return sort_version_aware(ret)

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -31,9 +31,7 @@ from readthedocs.projects.querysets import (
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
 from readthedocs.projects.utils import make_api_version
 from readthedocs.projects.version_handling import determine_stable_version, version_windows
-# transitioning from v1 to v2, rename for now, remove later
 from readthedocs.restapi.client import api
-from readthedocs.restapi.client import api as apiv2
 from readthedocs.vcs_support.backends import backend_cls
 from readthedocs.vcs_support.base import VCSProject
 from readthedocs.vcs_support.utils import Lock, NonBlockingLock
@@ -358,7 +356,7 @@ class Project(models.Model):
 
     def get_canonical_url(self):
         if getattr(settings, 'DONT_HIT_DB', True):
-            return apiv2.project(self.pk).canonical_url().get()['url']
+            return api.project(self.pk).canonical_url().get()['url']
         return self.get_docs_url()
 
     def get_subproject_urls(self):
@@ -369,7 +367,7 @@ class Project(models.Model):
         if getattr(settings, 'DONT_HIT_DB', True):
             return [(proj['slug'], proj['canonical_url'])
                     for proj in (
-                        apiv2.project(self.pk)
+                        api.project(self.pk)
                         .subprojects()
                         .get()['subprojects'])]
         return [(proj.child.slug, proj.child.get_docs_url())

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -234,7 +234,7 @@ class UpdateDocsTask(Task):
     @staticmethod
     def get_project(project_pk):
         """Get project from API"""
-        project_data = api_v1.project(project_pk).get()
+        project_data = api_v2.project(project_pk).get()
         project = make_api_project(project_data)
         return project
 
@@ -242,9 +242,9 @@ class UpdateDocsTask(Task):
     def get_version(project, version_pk):
         """Ensure we're using a sane version"""
         if version_pk:
-            version_data = api_v1.version(version_pk).get()
+            version_data = api_v2.version(version_pk).get()
         else:
-            version_data = (api_v1
+            version_data = (api_v2
                             .version(project.slug)
                             .get(slug=LATEST)['objects'][0])
         return make_api_version(version_data)
@@ -509,7 +509,7 @@ def update_imported_docs(version_pk):
 
     :param version_pk: Version id to update
     """
-    version_data = api_v1.version(version_pk).get()
+    version_data = api_v2.version(version_pk).get()
     version = make_api_version(version_data)
     project = version.project
     ret_dict = {}

--- a/readthedocs/restapi/serializers.py
+++ b/readthedocs/restapi/serializers.py
@@ -26,13 +26,9 @@ class ProjectSerializer(serializers.ModelSerializer):
         )
 
 
-class ProjectSerializerFull(ProjectSerializer):
+class ProjectAdminSerializer(ProjectSerializer):
 
-    """Serializer to return all Project fields, for use by builder instances"""
-
-    class Meta(object):
-        model = Project
-        # The following fields are required by builder processes
+    class Meta(ProjectSerializer.Meta):
         fields = ProjectSerializer.Meta.fields + (
             'enable_epub_build',
             'enable_pdf_build',
@@ -66,7 +62,15 @@ class VersionSerializer(serializers.ModelSerializer):
         )
 
 
+class VersionAdminSerializer(VersionSerializer):
+
+    """Version serializer that returns admin project data"""
+
+    project = ProjectAdminSerializer()
+
+
 class BuildCommandSerializer(serializers.ModelSerializer):
+
     run_time = serializers.ReadOnlyField()
 
     class Meta(object):
@@ -76,7 +80,7 @@ class BuildCommandSerializer(serializers.ModelSerializer):
 
 class BuildSerializer(serializers.ModelSerializer):
 
-    """Readonly version of the build serializer, used for user facing display"""
+    """Build serializer for user display, doesn't display internal fields"""
 
     commands = BuildCommandSerializer(many=True, read_only=True)
     state_display = serializers.ReadOnlyField(source='get_state_display')
@@ -86,13 +90,12 @@ class BuildSerializer(serializers.ModelSerializer):
         exclude = ('builder',)
 
 
-class BuildSerializerFull(BuildSerializer):
+class BuildAdminSerializer(BuildSerializer):
 
-    """Writeable Build instance serializer, for admin access by builders"""
+    """Build serializer for display to admin users and build instances"""
 
-    class Meta(object):
-        model = Build
-        exclude = ('')
+    class Meta(BuildSerializer.Meta):
+        exclude = ()
 
 
 class SearchIndexSerializer(serializers.Serializer):

--- a/readthedocs/restapi/serializers.py
+++ b/readthedocs/restapi/serializers.py
@@ -24,6 +24,24 @@ class ProjectSerializer(serializers.ModelSerializer):
             'users',
             'canonical_url',
         )
+        # Fields needed for properly passing data to the builds
+        build_extra = (
+            'enable_epub_build',
+            'enable_pdf_build',
+            'conf_py_file',
+            'analytics_code',
+            'cdn_enabled',
+            'container_image',
+            'container_mem_limit',
+            'container_time_limit',
+            'install_project',
+            'use_system_packages',
+            'suffix',
+            'skip',
+            'requirements_file',
+            'python_interpreter',
+        )
+        fields += build_extra
 
 
 class VersionSerializer(serializers.ModelSerializer):

--- a/readthedocs/restapi/serializers.py
+++ b/readthedocs/restapi/serializers.py
@@ -24,8 +24,16 @@ class ProjectSerializer(serializers.ModelSerializer):
             'users',
             'canonical_url',
         )
-        # Fields needed for properly passing data to the builds
-        build_extra = (
+
+
+class ProjectSerializerFull(ProjectSerializer):
+
+    """Serializer to return all Project fields, for use by builder instances"""
+
+    class Meta(object):
+        model = Project
+        # The following fields are required by builder processes
+        fields = ProjectSerializer.Meta.fields + (
             'enable_epub_build',
             'enable_pdf_build',
             'conf_py_file',
@@ -41,7 +49,6 @@ class ProjectSerializer(serializers.ModelSerializer):
             'requirements_file',
             'python_interpreter',
         )
-        fields += build_extra
 
 
 class VersionSerializer(serializers.ModelSerializer):

--- a/readthedocs/restapi/utils.py
+++ b/readthedocs/restapi/utils.py
@@ -115,9 +115,8 @@ def index_search_request(version, page_list, commit, project_scale, page_scale,
     routes.extend([p.parent.slug for p in project.superprojects.all()])
     for page in page_list:
         log.debug("Indexing page: %s:%s", project.slug, page['path'])
-        page_id = (hashlib
-                   .md5('-'.join([project.slug, version.slug, page['path']]))
-                   .hexdigest())
+        to_hash = '-'.join([project.slug, version.slug, page['path']])
+        page_id = hashlib.md5(to_hash.encode('utf-8')).hexdigest()
         index_list.append({
             'id': page_id,
             'project': project.slug,
@@ -132,11 +131,10 @@ def index_search_request(version, page_list, commit, project_scale, page_scale,
         })
         if section:
             for sect in page['sections']:
+                id_to_hash = '-'.join([project.slug, version.slug,
+                                       page['path'], sect['id']])
                 section_index_list.append({
-                    'id': (hashlib
-                           .md5('-'.join([project.slug, version.slug,
-                                         page['path'], sect['id']]))
-                           .hexdigest()),
+                    'id': (hashlib.md5(id_to_hash.encode('utf-8')).hexdigest()),
                     'project': project.slug,
                     'version': version.slug,
                     'path': page['path'],

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -81,6 +81,15 @@ class ProjectViewSet(viewsets.ModelViewSet):
             'subprojects': ProjectSerializer(children, many=True).data
         })
 
+    @detail_route()
+    def active_versions(self, request, **kwargs):
+        project = get_object_or_404(
+            Project.objects.api(request.user), pk=kwargs['pk'])
+        versions = project.versions.filter(active=True)
+        return Response({
+            'versions': VersionSerializer(versions, many=True).data
+        })
+
     @decorators.detail_route(permission_classes=[permissions.IsAdminUser])
     def token(self, request, **kwargs):
         project = get_object_or_404(

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -23,8 +23,8 @@ from ..permissions import (APIPermission, APIRestrictedPermission,
                            RelatedProjectIsOwner, IsOwner)
 from ..serializers import (BuildSerializerFull, BuildSerializer,
                            BuildCommandSerializer, ProjectSerializer,
-                           VersionSerializer, DomainSerializer,
-                           RemoteOrganizationSerializer,
+                           ProjectSerializerFull, VersionSerializer,
+                           DomainSerializer, RemoteOrganizationSerializer,
                            RemoteRepositorySerializer)
 from .. import utils as api_utils
 
@@ -45,6 +45,11 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return self.model.objects.api(self.request.user)
+
+    def get_serializer_class(self):
+        if self.request.user.is_staff:
+            return ProjectSerializerFull
+        return self.serializer_class
 
     @decorators.detail_route()
     def valid_versions(self, request, **kwargs):

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -21,9 +21,10 @@ from readthedocs.projects.version_handling import determine_stable_version
 
 from ..permissions import (APIPermission, APIRestrictedPermission,
                            RelatedProjectIsOwner, IsOwner)
-from ..serializers import (BuildSerializerFull, BuildSerializer,
-                           BuildCommandSerializer, ProjectSerializer,
-                           ProjectSerializerFull, VersionSerializer,
+from ..serializers import (BuildSerializer, BuildAdminSerializer,
+                           BuildCommandSerializer,
+                           ProjectSerializer, ProjectAdminSerializer,
+                           VersionSerializer, VersionAdminSerializer,
                            DomainSerializer, RemoteOrganizationSerializer,
                            RemoteRepositorySerializer)
 from .. import utils as api_utils
@@ -31,25 +32,40 @@ from .. import utils as api_utils
 log = logging.getLogger(__name__)
 
 
-class ProjectViewSet(viewsets.ModelViewSet):
+class UserSelectViewSet(viewsets.ModelViewSet):
+
+    """View set that varies serializer class based on request user credentials
+
+    Viewsets using this class should have an attribute `admin_serializer_class`,
+    which is a serializer that might have more fields that only admin/staff
+    users require. If the user is staff, this class will be returned instead.
+    """
+
+    def get_serializer_class(self):
+        try:
+            if self.request.user.is_staff and self.admin_serializer_class is not None:
+                return self.admin_serializer_class
+        except AttributeError:
+            pass
+        return self.serializer_class
+
+    def get_queryset(self):
+        """Use our API manager method to determine authorization on queryset"""
+        return self.model.objects.api(self.request.user)
+
+
+class ProjectViewSet(UserSelectViewSet):
 
     """List, filter, etc. Projects."""
 
     permission_classes = [APIPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = ProjectSerializer
+    admin_serializer_class = ProjectAdminSerializer
     model = Project
     paginate_by = 100
     paginate_by_param = 'page_size'
     max_paginate_by = 1000
-
-    def get_queryset(self):
-        return self.model.objects.api(self.request.user)
-
-    def get_serializer_class(self):
-        if self.request.user.is_staff:
-            return ProjectSerializerFull
-        return self.serializer_class
 
     @decorators.detail_route()
     def valid_versions(self, request, **kwargs):
@@ -171,34 +187,21 @@ class ProjectViewSet(viewsets.ModelViewSet):
         })
 
 
-class VersionViewSet(viewsets.ModelViewSet):
+class VersionViewSet(UserSelectViewSet):
 
     permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = VersionSerializer
+    admin_serializer_class = VersionAdminSerializer
     model = Version
 
-    def get_queryset(self):
-        return self.model.objects.api(self.request.user)
 
-
-class BuildViewSetBase(viewsets.ModelViewSet):
+class BuildViewSetBase(UserSelectViewSet):
     permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer,)
+    serializer_class = BuildSerializer
+    admin_serializer_class = BuildAdminSerializer
     model = Build
-
-    def get_queryset(self):
-        return self.model.objects.api(self.request.user)
-
-    def get_serializer_class(self):
-        """Vary serializer class based on user status
-
-        This is used to allow write to write-only fields on Build by admin users
-        and to not return those fields to non-admin users.
-        """
-        if self.request.user.is_staff:
-            return BuildSerializerFull
-        return BuildSerializer
 
 
 class BuildViewSet(SettingsOverrideObject):
@@ -208,17 +211,11 @@ class BuildViewSet(SettingsOverrideObject):
     _default_class = BuildViewSetBase
 
 
-class BuildCommandViewSet(viewsets.ModelViewSet):
-
-    """This is currently a write-only way to update the commands on build."""
-
+class BuildCommandViewSet(UserSelectViewSet):
     permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = BuildCommandSerializer
     model = BuildCommandResult
-
-    def get_queryset(self):
-        return self.model.objects.api(self.request.user)
 
 
 class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
@@ -230,14 +227,11 @@ class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
         return self.model.objects.api(self.request.user)
 
 
-class DomainViewSet(viewsets.ModelViewSet):
+class DomainViewSet(UserSelectViewSet):
     permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = DomainSerializer
     model = Domain
-
-    def get_queryset(self):
-        return self.model.objects.api(self.request.user)
 
 
 class RemoteOrganizationViewSet(viewsets.ReadOnlyModelViewSet):

--- a/readthedocs/rtd_tests/mocks/mock_api.py
+++ b/readthedocs/rtd_tests/mocks/mock_api.py
@@ -96,7 +96,5 @@ def mock_api(repo):
     with mock.patch('readthedocs.restapi.client.api', api_mock), \
             mock.patch('readthedocs.api.client.api', api_mock), \
             mock.patch('readthedocs.projects.tasks.api_v2', api_mock), \
-            mock.patch('readthedocs.projects.tasks.api_v1', api_mock), \
-            mock.patch('readthedocs.doc_builder.environments.api_v1', api_mock), \
             mock.patch('readthedocs.doc_builder.environments.api_v2', api_mock):
         yield api_mock

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -157,10 +157,6 @@ class BuildEnvironmentTests(TestCase):
 
     def test_build_pdf_latex_failures(self):
         '''Build failure if latex fails'''
-        if six.PY3:
-            import pytest
-            pytest.xfail(
-                "test_build_pdf_latex_failures is known to fail on 3.6")
 
         self.mocks.patches['html_build'].stop()
         self.mocks.patches['pdf_build'].stop()
@@ -183,11 +179,11 @@ class BuildEnvironmentTests(TestCase):
 
         # Mock out the separate calls to Popen using an iterable side_effect
         returns = [
-            (('', ''), 0),  # sphinx-build html
-            (('', ''), 0),  # sphinx-build pdf
-            (('', ''), 1),  # latex
-            (('', ''), 0),  # makeindex
-            (('', ''), 0),  # latex
+            ((b'', b''), 0),  # sphinx-build html
+            ((b'', b''), 0),  # sphinx-build pdf
+            ((b'', b''), 1),  # latex
+            ((b'', b''), 0),  # makeindex
+            ((b'', b''), 0),  # latex
         ]
         mock_obj = mock.Mock()
         mock_obj.communicate.side_effect = [output for (output, status)
@@ -203,10 +199,6 @@ class BuildEnvironmentTests(TestCase):
 
     def test_build_pdf_latex_not_failure(self):
         '''Test pass during PDF builds and bad latex failure status code'''
-        if six.PY3:
-            import pytest
-            pytest.xfail(
-                "test_build_pdf_latex_not_failure is known to fail on 3.6")
 
         self.mocks.patches['html_build'].stop()
         self.mocks.patches['pdf_build'].stop()
@@ -229,11 +221,11 @@ class BuildEnvironmentTests(TestCase):
 
         # Mock out the separate calls to Popen using an iterable side_effect
         returns = [
-            (('', ''), 0),  # sphinx-build html
-            (('', ''), 0),  # sphinx-build pdf
-            (('Output written on foo.pdf', ''), 1),  # latex
-            (('', ''), 0),  # makeindex
-            (('', ''), 0),  # latex
+            ((b'', b''), 0),  # sphinx-build html
+            ((b'', b''), 0),  # sphinx-build pdf
+            ((b'Output written on foo.pdf', b''), 1),  # latex
+            ((b'', b''), 0),  # makeindex
+            ((b'', b''), 0),  # latex
         ]
         mock_obj = mock.Mock()
         mock_obj.communicate.side_effect = [output for (output, status)

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -3,12 +3,10 @@ import mock
 from django.test import TestCase
 from django_dynamic_fixture import get
 
-import six
-
 from readthedocs_build.config import BuildConfig, ProjectConfig, InvalidConfig
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
-from readthedocs.doc_builder.config import ConfigWrapper, load_yaml_config
+from readthedocs.doc_builder.config import load_yaml_config
 
 
 def create_load(config=None):
@@ -128,7 +126,7 @@ class LoadConfigTests(TestCase):
         self.project.container_image = 'readthedocs/build:2.0'
         self.project.save()
         with self.assertRaises(InvalidConfig):
-            config = load_yaml_config(self.version)
+            load_yaml_config(self.version)
 
     def test_install_project(self, load_config):
         load_config.side_effect = create_load()
@@ -189,11 +187,7 @@ class LoadConfigTests(TestCase):
         self.assertEqual(config.conda_file, None)
 
     def test_requirements_file(self, load_config):
-        if six.PY3:
-            import pytest
-            pytest.xfail("test_requirements_file is known to fail on 3.6")
-
-        requirements_file = 'wsgi.py' if six.PY2 else 'readthedocs/wsgi.py'
+        requirements_file = 'wsgi.py'
         load_config.side_effect = create_load({
             'requirements_file': requirements_file
         })

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -29,6 +29,7 @@ class CommunityDevSettings(CommunityBaseSettings):
     SLUMBER_USERNAME = 'test'
     SLUMBER_PASSWORD = 'test'  # noqa: ignore dodgy check
     SLUMBER_API_HOST = 'http://localhost:8000'
+    PUBLIC_API_URL = 'http://localhost:8000'
 
     BROKER_URL = 'redis://localhost:6379/0'
     CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -71,7 +71,10 @@ class BaseCLI(object):
         except UnicodeDecodeError:
             # >:x
             pass
-        return (process.returncode, stdout, stderr)
+        return (
+            process.returncode,
+            stdout.decode('utf-8'),
+            stderr.decode('utf-8'))
 
     @property
     def env(self):


### PR DESCRIPTION
Forked from #3051

- Replace references to api_v1 in projects/tasks.py
- Replace `__unicode__` with `__str__` in comments.admin.py
- Remove mocks of `projects.tasks.api_v1`