### PR TITLE
Fixed failing migrations caused by admin list_display.

### DIFF
--- a/readthedocs/comments/models.py
+++ b/readthedocs/comments/models.py
@@ -77,12 +77,12 @@ class DocumentNode(models.Model):
 
     raw_source = models.TextField(_('Raw Source'))
 
-    def __str__(self):
+    def __unicode__(self):
         return "node %s on %s for %s" % (self.id, self.page, self.project)
 
     def latest_hash(self):
         return self.snapshots.latest().hash
-
+        
     def latest_commit(self):
         return self.snapshots.latest().commit
 


### PR DESCRIPTION
`__unicode__` wasn't defined, but was being used as part of the
admin `list_display` for that model. This adds the `__unicode__` method.