### PR TITLE
Update Getting Started so autobuild matches manual build

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -48,7 +48,7 @@ or `this template`_ if you need help). Build them to see how they look::
 
     $ make html
 
-.. note:: You can use ``sphinx-autobuild`` to auto-reload your docs. Run ``sphinx-autobuild . _build_html`` instead.
+.. note:: You can use ``sphinx-autobuild`` to auto-reload your docs. Run ``sphinx-autobuild . _build/html`` instead.
 
 Edit your files and rebuild until you like what you see, then commit your changes and push to your public repository.
 Once you have Sphinx documentation in a public repository, you can start using Read the Docs.


### PR DESCRIPTION
Default settings in conf.py has `make html` put the output into _build/html and https://github.com/github/gitignore/blob/master/Python.gitignore defaults to ignoring docs/_build/ so the `sphinx-autobuild` command example should output to the same ignored spot.