### PR TITLE
Document binary files for no line ending changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,13 @@
-*		text eol=lf
+# Document global line endings settings
+# https://help.github.com/articles/dealing-with-line-endings/
+*       text eol=lf
+
+
+# Denote all files that are truly binary and should not be modified.
+*.ai    binary
+*.jpg   binary
+*.otf   binary
+*.png   binary
+*.ttf   binary
+*.whl   binary
+*.woff  binary


### PR DESCRIPTION
The `.gitattributes` file from #3053 caused some issues on a clean clone of the repository for me. These issues involved modifying the line endings of binary files and manifested themselves in the form of binary files showing as modified in `git status` with warnings like:

    warning: CRLF will be replaced by LF in deploy/wheels/Jinja2-2.7.1-py2-none-any.whl.

At first I was very confused as I would think CRLF endings were only for Windows users. However, I realized that binary files could contain CRLFs. When I looked at the `.gitattributes` file, it denotes everything as text with Unix line endings. Based on [github's useful docs on the subject](https://help.github.com/articles/dealing-with-line-endings/), I think that documenting binary files will clear this up.

**STEPS TO REPRODUCE**
For me, a fresh clone of the latest master would immediately show files as modified.

    git clone git@github.com:rtfd/readthedocs.org.git
    git status

**SYSTEM INFORMATION**
OS: MacOS 10.12.6
Git: 2.14.1