### PR TITLE
Add a tastypie XML requirement

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -23,6 +23,7 @@ jsonfield==1.0.3
 requests==2.3.0
 slumber==0.7.1
 lxml==3.3.5
+defusedxml==0.5.0
 
 django-countries==3.4.1
 


### PR DESCRIPTION
[DefusedXML](https://pypi.python.org/pypi/defusedxml) is [required by tastypie](http://django-tastypie.readthedocs.io/en/v0.13.1/#format-support) to support XML serialization.

I believe fixing this will fix the Internal Server Error on https://readthedocs.org/api/v1/ (at least hitting that with the browser and no special headers) as it does for me locally.