### PR TITLE
Switch to Universal Analytics API

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/sphinx.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sphinx.js
@@ -13,11 +13,8 @@ function init() {
     /// Click tracking on flyout
     $(document).on('click', "[data-toggle='rst-current-version']", function() {
       var flyout_state = $("[data-toggle='rst-versions']").hasClass('shift-up') ? 'was_open' : 'was_closed'
-      if (_gaq) {
-        _gaq.push(
-            ['rtfd._setAccount', 'UA-17997319-1'],
-            ['rtfd._trackEvent', 'Flyout', 'Click', flyout_state]
-        );
+      if (ga) {
+        ga('rtfd.send', 'event', 'Flyout', 'Click', flyout_state);
       }
     });
 

--- a/readthedocs/core/static-src/core/js/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/sponsorship.js
@@ -45,11 +45,8 @@ Promo.prototype.create = function () {
 
         // On Click handler
         function promo_click() {
-            if (_gaq) {
-                _gaq.push(
-                    ['rtfd._setAccount', 'UA-17997319-1'],
-                    ['rtfd._trackEvent', 'Promo', 'Click', self.id]
-                );
+            if (ga) {
+                ga('rtfd.send', 'event', 'Promo', 'Click', self.id);
             }
         }
 

--- a/readthedocs/doc_builder/templates/doc_builder/include.js.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/include.js.tmpl
@@ -1,21 +1,19 @@
 // RTD Analytics Code
 
-var _gaq = _gaq || [];
-_gaq.push(['_setAccount', '{{ global_analytics_code }}']);
-_gaq.push(['_trackPageview']);
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', '{{ global_analytics_code }}', 'auto', 'rtfd');
+ga('rtfd.send', 'pageview');
 
 {% if user_analytics_code %}
 // User Analytics Code
-_gaq.push(['user._setAccount', '{{ user_analytics_code }}']);
-_gaq.push(['user._trackPageview']);
+ga('create', '{{ user_analytics_code }}', 'auto', 'user');
+ga('user.send', 'pageview');
 // End User Analytics Code
 {% endif %}
-
-(function() {
-var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-})();
 
 // end RTD Analytics Code
 

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -13,6 +13,18 @@
   <!-- title -->
   <title>{% block title %}{% endblock %}{% block head_title %}{% endblock %} | {% block branding %}Read the Docs {% endblock %}</title>
 
+  <!-- Google Analytics -->
+  <script type="text/javascript">
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ GLOBAL_ANALYTICS_CODE }}', 'auto', 'rtfd');
+    ga('rtfd.send', 'pageview');
+  </script>
+  <!-- End Google Analytics -->
+
   <!-- css -->
   <link rel="stylesheet" href="{{ MEDIA_URL }}css/core.css">
   {% block extra_links %}{% endblock %}
@@ -123,23 +135,7 @@
     <!-- END footer-->
 
 </body>
-
-<!-- BEGIN google analytics -->
 <script type="text/javascript">
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '{{ GLOBAL_ANALYTICS_CODE }}']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
   {% block footerjs %}{% endblock %}
-
 </script>
-<!-- END google analytics -->
-
 </html>


### PR DESCRIPTION
- Switches from legacy `ga.js` to new `analytics.js`, solving #1998 
- Switch to Universal Analytics must be done in [`readthedocs-sphinx-ext`](https://github.com/rtfd/readthedocs-sphinx-ext) at the same time, see rtfd/readthedocs-sphinx-ext#29
- Readthedocs pageviews and events are now all prefixed with `rtfd` tracker name, since setting the `trackingId` on a tracker is only allowed on creation (i.e. you can no longer call `_setAccount` in `sphinx.js` and `sponsorship.js`)
- Google Analytics script element has been moved from the bottom of the page to top of `<head>` as per [Googles instructions](https://developers.google.com/analytics/devguides/collection/analyticsjs/#the_javascript_tracking_snippet)
- Not using the [Alternative async tracking snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet) which should be a bit faster but "can degrade to synchronous loading and execution on IE 9 and older mobile browsers that do not recognise the async script attribute"
- Needs to be tested by someone with access to RTFD Analytics. I've ported the events by referring to the Analytics API docs, but I don't know if they will appear correctly on an Analytics dashboard without changes.