### PR TITLE
Allow installation of the project without a setup.py

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -47,8 +47,8 @@ class PythonEnvironment(object):
             shutil.rmtree(build_dir)
 
     def install_package(self):
-        setup_path = os.path.join(self.checkout_path, 'setup.py')
-        if os.path.isfile(setup_path) and self.config.install_project:
+        if self.config.install_project:
+            setup_path = os.path.join(self.checkout_path, 'setup.py')
             if self.config.pip_install or getattr(settings, 'USE_PIP_INSTALL', False):
                 extra_req_param = ''
                 if self.config.extra_requirements:
@@ -65,7 +65,7 @@ class PythonEnvironment(object):
                     cwd=self.checkout_path,
                     bin_path=self.venv_bin()
                 )
-            else:
+            elif os.path.isfile(setup_path):
                 self.build_env.run(
                     'python',
                     'setup.py',

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -48,7 +48,6 @@ class PythonEnvironment(object):
 
     def install_package(self):
         if self.config.install_project:
-            setup_path = os.path.join(self.checkout_path, 'setup.py')
             if self.config.pip_install or getattr(settings, 'USE_PIP_INSTALL', False):
                 extra_req_param = ''
                 if self.config.extra_requirements:
@@ -65,7 +64,7 @@ class PythonEnvironment(object):
                     cwd=self.checkout_path,
                     bin_path=self.venv_bin()
                 )
-            elif os.path.isfile(setup_path):
+            else:
                 self.build_env.run(
                     'python',
                     'setup.py',


### PR DESCRIPTION
With PEP 517, projects may no longer even have one in the future.