### PR TITLE
Upgrade setuptools to 36.5.0

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -116,7 +116,7 @@ class Virtualenv(PythonEnvironment):
         """Install basic Read the Docs requirements into the virtualenv."""
         requirements = [
             'Pygments==2.2.0',
-            'setuptools==36.4.0',
+            'setuptools==36.5.0',
             'docutils==0.13.1',
             'mock==1.0.1',
             'pillow==2.6.1',

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -116,7 +116,7 @@ class Virtualenv(PythonEnvironment):
         """Install basic Read the Docs requirements into the virtualenv."""
         requirements = [
             'Pygments==2.2.0',
-            'setuptools==28.8.0',
+            'setuptools==36.4.0',
             'docutils==0.13.1',
             'mock==1.0.1',
             'pillow==2.6.1',


### PR DESCRIPTION
This allows projects to specify their metadata in setup.cfg instead of setup.py.