### PR TITLE
Do not 404 on double clicks and views

### DIFF
--- a/readthedocs/donate/views.py
+++ b/readthedocs/donate/views.py
@@ -135,7 +135,6 @@ def click_proxy(request, promo_id, hash):
             )
         )
         cache.incr(promo.cache_key(type=CLICKS, hash=hash))
-        raise Http404('Invalid click. This has been logged.')
     return redirect(promo.link)
 
 
@@ -165,7 +164,6 @@ def view_proxy(request, promo_id, hash):
             )
         )
         cache.incr(promo.cache_key(type=VIEWS, hash=hash))
-        raise Http404('Invalid click. This has been logged.')
     return redirect(promo.image)
 
 


### PR DESCRIPTION
Removes the 404s from double clicks and views. Instead, they will just redirect as they should although they will not count toward the ad stats.

Fixes #2799.