### PR TITLE
Make manage.py test work for the donate app

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --reuse-db
+python_files = tests.py test_*.py *_tests.py

--- a/readthedocs/donate/tests.py
+++ b/readthedocs/donate/tests.py
@@ -11,10 +11,10 @@ from django.core.cache import cache
 from django.test.client import RequestFactory
 from django_dynamic_fixture import get
 
-from .core.middleware import FooterNoSessionMiddleware
+from ..core.middleware import FooterNoSessionMiddleware
 from .models import SupporterPromo, GeoFilter, Country
 from .constants import (CLICKS, VIEWS, OFFERS,
-                        INCLUDE, EXCLUDE)
+                        INCLUDE, EXCLUDE, READTHEDOCS_THEME)
 from .signals import show_to_geo, get_promo, choose_promo, show_to_programming_language
 from readthedocs.projects.models import Project
 
@@ -29,9 +29,11 @@ class PromoTests(TestCase):
         self.pip = get(Project, slug='pip', allow_promos=True)
 
     def test_clicks(self):
-        cache.set(self.promo.cache_key(type=CLICKS, hash='random_hash'), 0)
+        hash_key = 'random_hash'
+        cache.set(self.promo.cache_key(type=CLICKS, hash=hash_key), 0)
+        self.assertEqual(cache.get(self.promo.cache_key(type=CLICKS, hash=hash_key)), 0)
         resp = self.client.get(
-            'http://testserver/sustainability/click/%s/random_hash/' % self.promo.id)
+            'http://testserver/sustainability/click/%s/%s/' % (self.promo.id, hash_key))
         self.assertEqual(resp._headers['location'][1], 'http://example.com')
         promo = SupporterPromo.objects.get(pk=self.promo.pk)
         impression = promo.impressions.first()
@@ -61,8 +63,8 @@ class PromoTests(TestCase):
             self.promo.incr(VIEWS)
         for x in range(3):
             self.promo.incr(CLICKS)
-        self.assertEqual(self.promo.view_ratio(), 0.4)
-        self.assertEqual(self.promo.click_ratio(), 0.15)
+        self.assertAlmostEqual(self.promo.view_ratio(), 40.0)
+        self.assertEqual(self.promo.click_ratio(), '15.000')
 
     def test_multiple_hash_usage(self):
         cache.set(self.promo.cache_key(type=VIEWS, hash='random_hash'), 0)
@@ -90,131 +92,13 @@ class PromoTests(TestCase):
         self.assertEqual(resp._headers['location'][1], 'http://media.example.com/img.png')
 
 
-class FooterTests(TestCase):
-
-    def setUp(self):
-        self.promo = get(SupporterPromo,
-                         live=True,
-                         slug='promo-slug',
-                         display_type='doc',
-                         link='http://example.com',
-                         image='http://media.example.com/img.png')
-        self.pip = get(Project, slug='pip', allow_promos=True)
-
-    def test_footer(self):
-        r = self.client.get(
-            '/api/v2/footer_html/?project=pip&version=latest&page=index'
-        )
-        resp = json.loads(r.content)
-        self.assertEqual(
-            resp['promo_data']['link'],
-            '//readthedocs.org/sustainability/click/%s/%s/' % (
-                self.promo.pk, resp['promo_data']['hash']
-            )
-        )
-        impression = self.promo.impressions.first()
-        self.assertEqual(impression.offers, 1)
-
-    def test_integration(self):
-        # Get footer promo
-        r = self.client.get(
-            '/api/v2/footer_html/?project=pip&version=latest&page=index'
-        )
-        resp = json.loads(r.content)
-        self.assertEqual(
-            resp['promo_data']['link'],
-            '//readthedocs.org/sustainability/click/%s/%s/' % (
-                self.promo.pk, resp['promo_data']['hash'])
-        )
-        impression = self.promo.impressions.first()
-        self.assertEqual(impression.offers, 1)
-        self.assertEqual(impression.views, 0)
-        self.assertEqual(impression.clicks, 0)
-
-        # Assert view
-
-        r = self.client.get(
-            reverse(
-                'donate_view_proxy',
-                kwargs={'promo_id': self.promo.pk, 'hash': resp['promo_data']['hash']}
-            )
-        )
-        impression = self.promo.impressions.first()
-        self.assertEqual(impression.offers, 1)
-        self.assertEqual(impression.views, 1)
-        self.assertEqual(impression.clicks, 0)
-
-        # Click
-
-        r = self.client.get(
-            reverse(
-                'donate_click_proxy',
-                kwargs={'promo_id': self.promo.pk, 'hash': resp['promo_data']['hash']}
-            )
-        )
-        impression = self.promo.impressions.first()
-        self.assertEqual(impression.offers, 1)
-        self.assertEqual(impression.views, 1)
-        self.assertEqual(impression.clicks, 1)
-
-    def test_footer_setting(self):
-        """Test that the promo doesn't show with USE_PROMOS is False"""
-        with self.settings(USE_PROMOS=False):
-            r = self.client.get(
-                '/api/v2/footer_html/?project=pip&version=latest&page=index'
-            )
-            resp = json.loads(r.content)
-            self.assertEqual(resp['promo'], False)
-
-    def test_footer_no_obj(self):
-        """Test that the promo doesn't get set with no SupporterPromo objects"""
-        self.promo.delete()
-        r = self.client.get(
-            '/api/v2/footer_html/?project=pip&version=latest&page=index'
-        )
-        resp = json.loads(r.content)
-        self.assertEqual(resp['promo'], False)
-
-    def test_project_disabling(self):
-        """Test that the promo doesn't show when the project has it disabled"""
-        self.pip.allow_promos = False
-        self.pip.save()
-        r = self.client.get(
-            '/api/v2/footer_html/?project=pip&version=latest&page=index'
-        )
-        resp = json.loads(r.content)
-        self.assertEqual(resp['promo'], False)
-
-    def test_user_disabling(self):
-        """Test that the promo doesn't show when the project has it disabled"""
-        user = User.objects.get(username='test')
-        user.profile.allow_ads = False
-        user.profile.save()
-
-        # No ads for logged in user
-        self.login('test', 'test')
-        r = self.client.get(
-            '/api/v2/footer_html/?project=pip&version=latest&page=index'
-        )
-        resp = json.loads(r.content)
-        self.assertEqual(resp['promo'], False)
-
-        # Ads for logged out user
-        self.logout()
-        r = self.client.get(
-            '/api/v2/footer_html/?project=pip&version=latest&page=index'
-        )
-        resp = json.loads(r.content)
-        self.assertTrue(resp['promo'] is not False)
-
-
 class FilterTests(TestCase):
 
     def setUp(self):
-        us = get(Country, country='US')
-        ca = get(Country, country='CA')
-        mx = get(Country, country='MX')
-        az = get(Country, country='AZ')
+        us = Country.objects.all().filter(country='US').get()
+        ca = Country.objects.all().filter(country='CA').get()
+        mx = Country.objects.all().filter(country='MX').get()
+        az = Country.objects.all().filter(country='AZ').get()
 
         # Only show in US,CA
         self.promo = get(SupporterPromo,
@@ -266,23 +150,24 @@ class FilterTests(TestCase):
         ret = show_to_geo(self.promo, 'FO')
         self.assertFalse(ret)
 
+        # Country FO is not excluded
         ret2 = show_to_geo(self.promo2, 'FO')
-        self.assertFalse(ret2)
+        self.assertTrue(ret2)
 
     def test_get_promo(self):
-        ret = get_promo('US')
-        self.assertTrue(ret in [self.promo, self.promo2])
+        ret = get_promo('US', 'py', READTHEDOCS_THEME)
+        self.assertEqual(ret, self.promo)
 
-        ret = get_promo('MX')
-        self.assertTrue(ret in [self.promo, self.promo2])
+        ret = get_promo('MX', 'py', READTHEDOCS_THEME)
+        self.assertEqual(ret, self.promo)
 
-        ret = get_promo('FO')
+        ret = get_promo('FO', 'js', READTHEDOCS_THEME)
         self.assertEqual(ret, self.promo2)
 
-        ret = get_promo('AZ')
+        ret = get_promo('AZ', 'js', READTHEDOCS_THEME)
         self.assertEqual(ret, None)
 
-        ret = get_promo('RANDOM')
+        ret = get_promo('RANDOM', 'js', READTHEDOCS_THEME)
         self.assertEqual(ret, self.promo2)
 
     def test_programming_language(self):
@@ -292,11 +177,12 @@ class FilterTests(TestCase):
         ret = show_to_programming_language(self.promo, 'js')
         self.assertFalse(ret)
 
+        # This promo is JS only
         ret = show_to_programming_language(self.promo2, 'py')
-        self.assertTrue(ret)
+        self.assertFalse(ret)
 
         ret = show_to_programming_language(self.promo2, 'js')
-        self.assertFalse(ret)
+        self.assertTrue(ret)
 
 
 class ProbabilityTests(TestCase):
@@ -324,8 +210,8 @@ class ProbabilityTests(TestCase):
     def test_choose(self):
         # US view
 
-        promo_prob = self.promo.views_needed()
-        promo2_prob = self.promo2.views_needed()
+        promo_prob = self.promo.views_needed_today()
+        promo2_prob = self.promo2.views_needed_today()
         total = promo_prob + promo2_prob
 
         with mock.patch('random.randint') as randint:

--- a/readthedocs/donate/tests.py
+++ b/readthedocs/donate/tests.py
@@ -31,7 +31,6 @@ class PromoTests(TestCase):
     def test_clicks(self):
         hash_key = 'random_hash'
         cache.set(self.promo.cache_key(type=CLICKS, hash=hash_key), 0)
-        self.assertEqual(cache.get(self.promo.cache_key(type=CLICKS, hash=hash_key)), 0)
         resp = self.client.get(
             'http://testserver/sustainability/click/%s/%s/' % (self.promo.id, hash_key))
         self.assertEqual(resp._headers['location'][1], 'http://example.com')


### PR DESCRIPTION
The goal of this PR is to make the tests run and pass. These can be run as follows:

    python manage.py test readthedocs.donate --settings=readthedocs.settings.test

It doesn't look like these tests have been run in a while so perhaps a larger discussion is warranted around do we need these tests at all or should they live with the CI tests in `rtd_tests`.

Here are some specifics fixes:

- fixed import error
- removed the footer tests which seem invalid with the v2 api
- fixed method names and numbers of params type issues
- fixed a few tests logically

