### PR TITLE
Typo: intergrations -> integrations

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -144,7 +144,7 @@ def github_build(request):  # noqa: D205
     GitHub webhook consumer
 
     .. warning:: **DEPRECATED**
-        Use :py:cls:`readthedocs.restapi.views.intergrations.GitHubWebhookView`
+        Use :py:cls:`readthedocs.restapi.views.integrations.GitHubWebhookView`
         instead of this view function
 
     This will search for projects matching either a stripped down HTTP or SSH
@@ -198,7 +198,7 @@ def gitlab_build(request):  # noqa: D205
     """GitLab webhook consumer
 
     .. warning:: **DEPRECATED**
-        Use :py:cls:`readthedocs.restapi.views.intergrations.GitLabWebhookView`
+        Use :py:cls:`readthedocs.restapi.views.integrations.GitLabWebhookView`
         instead of this view function
 
     Search project repository URLs using the site URL from GitLab webhook payload.
@@ -231,7 +231,7 @@ def bitbucket_build(request):
     """Consume webhooks from multiple versions of Bitbucket's API
 
     .. warning:: **DEPRECATED**
-        Use :py:cls:`readthedocs.restapi.views.intergrations.BitbucketWebhookView`
+        Use :py:cls:`readthedocs.restapi.views.integrations.BitbucketWebhookView`
         instead of this view function
 
     New webhooks are set up with v2, but v1 webhooks will still point to this
@@ -299,7 +299,7 @@ def generic_build(request, project_id_or_slug=None):
     """Generic webhook build endpoint
 
     .. warning:: **DEPRECATED**
-        Use :py:cls:`readthedocs.restapi.views.intergrations.GenericWebhookView`
+        Use :py:cls:`readthedocs.restapi.views.integrations.GenericWebhookView`
         instead of this view function
     """
     try:

--- a/readthedocs/templates/projects/integration_list.html
+++ b/readthedocs/templates/projects/integration_list.html
@@ -35,7 +35,7 @@
         {% empty %}
           <li class="module-item">
             <p class="quiet">
-              {% trans 'No intergrations are currently configured' %}
+              {% trans 'No integrations are currently configured' %}
             </p>
           </li>
         {% endfor %}


### PR DESCRIPTION
This PR corrects a typo (intergrations -> integrations) in UI text, as well as in documentation that refers to the name of Python classes.
I'm assuming the text in `readthedocs/locale/*/LC_MESSAGES/django.po` is automatically collected and updated. If not, this text needs to be updated as well.