### PR TITLE
Add rel="noopener noreferrer" in order to prevent leaking the password reset token.

### DIFF
--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -89,7 +89,7 @@
 
 
         {% block footer-content %}
-        <a href="https://github.com/rtfd/readthedocs.org">GitHub</a> | <a href="http://docs.readthedocs.io">{%  trans "Docs" %}</a>.
+        <a href="https://github.com/rtfd/readthedocs.org" rel="noopener noreferrer">GitHub</a> | <a href="http://docs.readthedocs.io">{%  trans "Docs" %}</a>.
 
         {% url "gold_detail" as gold_detail %}
         {% blocktrans %}


### PR DESCRIPTION
If a user clicks on the GitHub link while resetting their password the password reset token is leaked in the Referer header.