### PR TITLE
Remove unused NGINX_X_ACCEL_REDIRECT

### DIFF
--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -43,8 +43,6 @@ class CommunityDevSettings(CommunityBaseSettings):
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
     FILE_SYNCER = 'readthedocs.builds.syncers.LocalSyncer'
 
-    NGINX_X_ACCEL_REDIRECT = True
-
     # For testing locally. Put this in your /etc/hosts:
     # 127.0.0.1 test
     # and navigate to http://test:8000


### PR DESCRIPTION
Following #1415, remove this deprecated settings. That seems to have been wiped out by b1221a65770f1919ffff5cb02bd54f06e9c2b400 but turned up again.

It is unused in the project, so it seems safe to remove that.