### PR TITLE
Add `Needed: replication` label

### DIFF
--- a/docs/issue-labels.rst
+++ b/docs/issue-labels.rst
@@ -63,6 +63,10 @@ what they stand for.
     This label indicates that a better test coverage is required to resolve
     the ticket. New tests should be proposed via a pull request on GitHub.
 
+*Needed: replication*
+    This label indicates that a bug has been reported, but has not been
+    successfully replicated by another user or contributor yet.
+
 *Operations*
     Tickets that require changes in the server infrastructure.
 


### PR DESCRIPTION
This was brought up in https://github.com/rtfd/readthedocs.org/issues/2775, and will be useful to add along with the `bug` label.
 
Once this has been merged, we can create the label accordingly.

Note: I mistakenly opened this PR automatically from my CLI with old text. I have since edited it. Sorry about that.