### PR TITLE
Add additional signals around sphinx context data

### DIFF
--- a/readthedocs/doc_builder/signals.py
+++ b/readthedocs/doc_builder/signals.py
@@ -1,0 +1,9 @@
+"""Signals for adding custom context data"""
+
+from __future__ import absolute_import
+
+import django.dispatch
+
+finalize_sphinx_context_data = django.dispatch.Signal(
+    providing_args=['buildenv', 'context', 'response_data']
+)

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -117,6 +117,10 @@ context = {
     'commit': '{{ commit }}',
     {% endif %}
 }
+
+{# Provide block for extending context data from child template #}
+{% block extra_context %}{% endblock %}
+
 if 'html_context' in globals():
     html_context.update(context)
 else:


### PR DESCRIPTION
For instances where we need to extend context data to templates, a signal and
extendable template works for now. Eventually, we'll want this to instead be a
single step, with more properly structured data for the context.