### PR TITLE
Use `verbose_name` for stable tag commit name

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -120,6 +120,11 @@ class Version(models.Model):
                 # the underlying commits.
                 if self.identifier.startswith('origin/'):
                     return self.identifier[len('origin/'):]
+            if self.type == TAG:
+                # If this version is a tag, the verbose_name will contain the
+                # actual name. A tag would contain the hash in indentifier,
+                # which is not as pretty as the actual tag name.
+                return self.verbose_name
             return self.identifier
 
         # By now we must have handled all special versions.

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -45,9 +45,8 @@ class VersionCommitNameTests(TestCase):
     def test_stable_version_tag(self):
         version = new(Version,
                       identifier=u'3d92b728b7d7b842259ac2020c2fa389f13aff0d',
-                      slug=STABLE, verbose_name=STABLE, type=TAG)
-        self.assertEqual(version.commit_name,
-                         u'3d92b728b7d7b842259ac2020c2fa389f13aff0d')
+                      slug=STABLE, verbose_name=u'stable_verbose', type=TAG)
+        self.assertEqual(version.commit_name, u'stable_verbose')
 
     def test_hg_latest_branch(self):
         hg_project = get(Project, repo_type=REPO_TYPE_HG)


### PR DESCRIPTION
It is clearer, nicer and human-readable.

It may fix #2563 (see my comments in the issue to understand what is happening).