### PR TITLE
Refactor project documentation syncing tasks

### DIFF
--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -156,8 +156,9 @@ class ProjectViewSet(viewsets.ModelViewSet):
         })
 
 
-class VersionViewSet(viewsets.ReadOnlyModelViewSet):
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+class VersionViewSet(viewsets.ModelViewSet):
+
+    permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = VersionSerializer
     model = Version


### PR DESCRIPTION
This updates the syncing tasks to execute in a guaranteed fashion. Before this
change, it was possible for broadcast tasks and symlink deletion tasks to
execute concurrently. This changes all the broadcast task calls into function
calls from a singular broadcast task.

In more detail:

* The `finish_build` task was executed as a task from the webs, and kicked off
  broadcast tasks to update files. Instead, Version update operations were move
  to the build process, through the API. The webs only the one broadcast task
* Version API was given the same APIRestrictedPermission as other end points, it
  can now be updated by staff