### PR TITLE
[Fix #3087] Permission denied in building with docker on local VM

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -640,6 +640,7 @@ class DockerEnvironment(BuildEnvironment):
                 detach=True,
                 environment=self.environment,
                 mem_limit=self.container_mem_limit,
+                user=str(os.getuid())
             )
             client.start(container=self.container_id)
         except DockerAPIError as e:


### PR DESCRIPTION
This is a common problem of Docker container. The build in docker container is running with root permission and creating the file as root. So the local user does not have permission to access the directory.
passing `user` while creating the container should fix the issue. So in the container, all the command will run as the `uid` of host user, and the host user will have the permission to access the directory.
@agjohnson r?