### PR TITLE
Added support for --process-dependency-links to pip installs

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -48,6 +48,12 @@ class ConfigWrapper(object):
         return []
 
     @property
+    def process_dependency_links(self):
+        if 'process_dependency_links' in self._yaml_config.get('python', {}):
+            return self._yaml_config['python']['process_dependency_links']
+        return False
+
+    @property
     def python_interpreter(self):
         ver = self.python_version
         if ver in [2, 3]:

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -54,12 +54,18 @@ class PythonEnvironment(object):
                 if self.config.extra_requirements:
                     extra_req_param = '[{0}]'.format(
                         ','.join(self.config.extra_requirements))
+                pip_flags = []
+                if True:
+                    pip_flags.append('--ignore-installed')
+                if True:
+                    pip_flags.append('--cache-dir')
+                if self.config.process_dependency_links:
+                    pip_flags.append('--process-dependency-links')
                 self.build_env.run(
                     'python',
                     self.venv_bin(filename='pip'),
                     'install',
-                    '--ignore-installed',
-                    '--cache-dir',
+                    *pip_flags,
                     self.project.pip_cache_path,
                     '.{0}'.format(extra_req_param),
                     cwd=self.checkout_path,

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -54,20 +54,20 @@ class PythonEnvironment(object):
                 if self.config.extra_requirements:
                     extra_req_param = '[{0}]'.format(
                         ','.join(self.config.extra_requirements))
-                pip_flags = []
+                pip_args = []
                 if True:
-                    pip_flags.append('--ignore-installed')
+                    pip_args.append('--ignore-installed')
                 if True:
-                    pip_flags.append('--cache-dir')
+                    pip_args.append('--cache-dir')
                 if self.config.process_dependency_links:
-                    pip_flags.append('--process-dependency-links')
+                    pip_args.append('--process-dependency-links')
+                pip_args.append(self.project.pip_cache_path)
+                pip_args.append('.{0}'.format(extra_req_param))
                 self.build_env.run(
                     'python',
                     self.venv_bin(filename='pip'),
                     'install',
-                    *pip_flags,
-                    self.project.pip_cache_path,
-                    '.{0}'.format(extra_req_param),
+                    *pip_args,
                     cwd=self.checkout_path,
                     bin_path=self.venv_bin()
                 )

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -172,6 +172,33 @@ class LoadConfigTests(TestCase):
         config = load_yaml_config(self.version)
         self.assertEqual(config.extra_requirements, [])
 
+    def test_process_dependency_links(self, load_config):
+        load_config.side_effect = create_load({
+            'python': {
+                'pip_install': True,
+                'process_dependency_links': True
+            }
+        })
+        config = load_yaml_config(self.version)
+        self.assertTrue(config.process_dependency_links)
+
+        load_config.side_effect = create_load({
+            'python': {
+                'pip_install': True,
+                'process_dependency_links': False
+            }
+        })
+        config = load_yaml_config(self.version)
+        self.assertFalse(config.process_dependency_links)
+
+        load_config.side_effect = create_load({
+            'python': {
+                'pip_install': True,
+            }
+        })
+        config = load_yaml_config(self.version)
+        self.assertFalse(config.process_dependency_links)
+
     def test_conda(self, load_config):
         to_find = 'urls.py'
         load_config.side_effect = create_load({


### PR DESCRIPTION
This adds support for the process-dependency-links pip flag as requested in #3156.  If the user adds a `process-dependency-links: True` entry to the `python` section of their .yml config file, then config.process_dependency_links will evaluate as True (otherwise False).  The pip_flags are then set accordingly, either with or without '--process-dependency-links'.  Since there are now three possible pip_flags, I have a check for each of them (with two of them automatically included since they were there before).  