### PR TITLE
Fix issue with CORS headers on subproject projects

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -6,6 +6,7 @@ import logging
 
 from corsheaders import signals
 from django.dispatch import Signal
+from django.db.models import Q
 from future.backports.urllib.parse import urlparse
 
 from readthedocs.projects.models import Project, Domain
@@ -53,8 +54,8 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
             return False
 
         domain = Domain.objects.filter(
-            domain__icontains=host,
-            project=project
+            Q(domain__icontains=host),
+            Q(project=project) | Q(project__subprojects__child=project)
         )
         if domain.exists():
             return True

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -11,7 +11,7 @@ from corsheaders.middleware import CorsMiddleware
 from mock import patch
 
 from readthedocs.core.middleware import SubdomainMiddleware
-from readthedocs.projects.models import Project, Domain
+from readthedocs.projects.models import Project, ProjectRelationship, Domain
 
 from readthedocs.rtd_tests.utils import create_user
 
@@ -112,16 +112,28 @@ class TestCORSMiddleware(TestCase):
         self.middleware = CorsMiddleware()
         self.url = '/api/v2/search'
         self.owner = create_user(username='owner', password='test')
-        self.pip = get(
+        self.project = get(
             Project, slug='pip',
             users=[self.owner], privacy_level='public',
+            mail_language_project=None
         )
-        self.domain = get(Domain, domain='my.valid.domain', project=self.pip)
+        self.subproject = get(
+            Project,
+            users=[self.owner],
+            privacy_level='public',
+            mail_language_project=None,
+        )
+        self.relationship = get(
+            ProjectRelationship,
+            parent=self.project,
+            child=self.subproject
+        )
+        self.domain = get(Domain, domain='my.valid.domain', project=self.project)
 
     def test_proper_domain(self):
         request = self.factory.get(
             self.url,
-            {'project': self.pip.slug},
+            {'project': self.project.slug},
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
@@ -130,7 +142,7 @@ class TestCORSMiddleware(TestCase):
     def test_invalid_domain(self):
         request = self.factory.get(
             self.url,
-            {'project': self.pip.slug},
+            {'project': self.project.slug},
             HTTP_ORIGIN='http://invalid.domain',
         )
         resp = self.middleware.process_response(request, {})
@@ -144,3 +156,18 @@ class TestCORSMiddleware(TestCase):
         )
         resp = self.middleware.process_response(request, {})
         self.assertNotIn('Access-Control-Allow-Origin', resp)
+
+    def test_valid_subproject(self):
+        self.assertTrue(
+            Project.objects.filter(
+                pk=self.project.pk,
+                subprojects__child=self.subproject
+            ).exists()
+        )
+        request = self.factory.get(
+            self.url,
+            {'project': self.subproject.slug},
+            HTTP_ORIGIN='http://my.valid.domain',
+        )
+        resp = self.middleware.process_response(request, {})
+        self.assertIn('Access-Control-Allow-Origin', resp)


### PR DESCRIPTION
We weren't correctly setting CORS headers when querying the documentation search
API from a subproject on and parent project domain. In this case, we were
querying with a project lookup for the subproject, and no domain was assigned to
this project.

This alters the query to find a domain associated with either the project you
are querying, or the parent project of a project you are querying.