### PR TITLE
Bump setuptools version.

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -116,7 +116,7 @@ class Virtualenv(PythonEnvironment):
         """Install basic Read the Docs requirements into the virtualenv."""
         requirements = [
             'Pygments==2.2.0',
-            'setuptools==28.8.0',
+            'setuptools==36.6.0',
             'docutils==0.13.1',
             'mock==1.0.1',
             'pillow==2.6.1',


### PR DESCRIPTION
Similar to #2547, setuptools is out of date again, and is causing builds such as https://readthedocs.org/projects/mozilla-balrog/builds/6136328/ to fail.