### PR TITLE
[Fix #3120] Enable users to delete their own account

### DIFF
--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from builtins import object
 import logging
 
+from django.contrib.auth.models import User
 from haystack.forms import SearchForm
 from haystack.query import SearchQuerySet
 from django import forms
@@ -42,6 +43,22 @@ class UserProfileForm(forms.ModelForm):
             user.last_name = last_name
             user.save()
         return profile
+
+
+class UserDeleteForm(forms.ModelForm):
+    username = CharField(label=_('Username'), help_text=_('Please type your username to confirm.'))
+
+    class Meta(object):
+        model = User
+        fields = ['username']
+
+    def clean_username(self):
+        data = self.cleaned_data['username']
+
+        if self.instance.username != data:
+            raise forms.ValidationError(_("Username does not match!"))
+
+        return data
 
 
 class FacetField(forms.MultipleChoiceField):

--- a/readthedocs/profiles/urls/private.py
+++ b/readthedocs/profiles/urls/private.py
@@ -18,4 +18,5 @@ urlpatterns = [
             'template_name': 'profiles/private/edit_profile.html',
         },
         name='profiles_profile_edit'),
+    url(r'^delete/', views.delete_account, name='delete_account')
 ]

--- a/readthedocs/templates/profiles/base_profile_edit.html
+++ b/readthedocs/templates/profiles/base_profile_edit.html
@@ -49,6 +49,7 @@
           <li class="{% block profile-admin-social-accounts %}{% endblock %}"><a href="{% url 'socialaccount_connections' %}">{% trans "Connected Services" %}</a></li>
           <li class="{% block profile-admin-change-password %}{% endblock %}"><a href="{% url 'account_change_password' %}">{% trans "Change Password" %}</a></li>
           <li class="{% block profile-admin-change-email %}{% endblock %}"><a href="{% url 'account_email' %}">{% trans "Change Email" %}</a></li>
+          <li class="{% block profile-admin-delete-account %}{% endblock %}"><a href="{% url 'delete_account' %}">{% trans "Delete Account" %}</a></li>
           <li class="{% block profile-admin-gold-edit %}{% endblock %}"><a href="{% url 'gold_detail' %}">{% trans "Gold" %}</a></li>
         {% endblock %}
       </ul>

--- a/readthedocs/templates/profiles/private/delete_account.html
+++ b/readthedocs/templates/profiles/private/delete_account.html
@@ -1,0 +1,17 @@
+{% extends "profiles/base_profile_edit.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Delete Account" %}{% endblock %}
+
+{% block profile-admin-delete-account %}active{% endblock %}
+
+{% block edit_content_header %} {% trans "Delete Account" %} {% endblock %}
+
+{% block edit_content %}
+  <form method="POST" action=".">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" name="submit" value="{% trans "Delete Account" %}" id="submit"/>
+  </form>
+{% endblock %}


### PR DESCRIPTION
This will add an option in user settings to let them delete their own account. They need to type their username in the field to confirm the delete so that they do not do it mistakenly. Moroevoer, rather than completely removing the account, we can make the account as `is_active=False` so they can not login anymore.

@ericholscher @agjohnson r?
cc: @RichardLitt