### PR TITLE
Update sustainability metrics

### DIFF
--- a/readthedocs/donate/templates/donate/list.html
+++ b/readthedocs/donate/templates/donate/list.html
@@ -19,9 +19,9 @@
   </p>
 
   <ul class="donate-about">
-    <li>Serve over <b>20 million pages</b> of documentation a month</li>
+    <li>Serve over <b>30 million pages</b> of documentation a month</li>
     <li>Have 10 servers and serve over <b>2 TB</b> of documentation a month</li>
-    <li>Host over <b>18,000 projects</b> and support <b>25,000 users</b></li>
+    <li>Host over <b>60,000 projects</b> and support <b>65,000 users</b></li>
     <li>Are supported by two dedicated engineers</li>
   </ul>
 


### PR DESCRIPTION
This pull request updates the sustainability metrics to agree with:

- https://blog.readthedocs.com/read-the-docs-2016-stats/
- http://www.seethestats.com/site/readthedocs.org

There are a few metrics I couldn't easily ascertain such as how many servers exist and how many terabytes of docs are served.