### PR TITLE
Link to the advertising page from the footer

### DIFF
--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -131,7 +131,8 @@
               <a href="https://docs.readthedocs.io/en/latest/contribute.html">{% trans "Contributing" %}</a>
             </li>
             <li>
-              <a href="https://docs.readthedocs.io/en/latest/ethical-advertising.html">{%  trans "Advertise with Us" %}</a>
+              {% url "advertising" as advertising_url %}
+              <a href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">{%  trans "Advertise with Us" %}</a>
             </li>
             <li>
               <a href="https://readthedocs.com">{%  trans "Commercial Support" %}</a>


### PR DESCRIPTION
Link to the advertise with us page from the footer instead of the ethical ads page. This contains a hardcoded fallback link in case the page isn't available locally.