### PR TITLE
Link to the advertising page from advertisements themselves

### DIFF
--- a/readthedocs/core/static-src/core/js/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/sponsorship.js
@@ -36,7 +36,7 @@ Promo.prototype.create = function () {
         var promo_about = $('<div />')
             .attr('class', 'rtd-pro-about');
         var promo_about_link = $('<a />')
-            .attr('href', 'http://docs.readthedocs.io/en/latest/ethical-advertising.html')
+            .attr('href', 'https://readthedocs.org/sustainability/advertising/')
             .appendTo(promo_about);
         var promo_about_icon = $('<i />')
             .attr('class', 'fa fa-info-circle')


### PR DESCRIPTION
This changes the info button next to the advertisements to link to the advertising page.

<img width="562" alt="screen shot 2017-10-27 at 10 30 48 pm" src="https://user-images.githubusercontent.com/185043/32131585-b9a71614-bb66-11e7-8fe4-57648c852208.png">
