### PR TITLE
Rearrange development docs ToC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,18 +92,18 @@ Information about development is also available:
    :maxdepth: 2
    :caption: Developer Documentation
 
-   install
-   api/index
    changelog
+   install
+   architecture
    tests
    docs
-   architecture
    development/standards
    development/buildenvironments
    symlinks
    settings
    i18n
    issue-labels
+   api/index
 
 .. _business-docs:
 


### PR DESCRIPTION
This is to make architecture the top link after changelog
and installation instructions. Also moves API to the bottom,
because it stands out of the reading flow, which is:

- see if the development thing you think about is already done
- launch installation if you're going to fix anything
- (or) read about archtecture
- about testing, probably installation is ready
- how to sync docs
- standards, etc.
- components (should be linked from archtecture)
- everything else
- leave API pages open