### PR TITLE
Use CSRF token on forms to trigger a new builds

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -6,11 +6,12 @@ import logging
 
 from django.shortcuts import get_object_or_404
 from django.views.generic import ListView, DetailView
-from django.http import HttpResponsePermanentRedirect
+from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from readthedocs.builds.models import Build, Version
+from readthedocs.core.utils import trigger_build
 from readthedocs.projects.models import Project
 
 from redis import Redis, ConnectionError
@@ -33,7 +34,24 @@ class BuildBase(object):
         return queryset
 
 
-class BuildList(BuildBase, ListView):
+class BuildTriggerMixin(object):
+    def post(self, request, project_slug):
+        project = get_object_or_404(
+            Project.objects.protected(self.request.user),
+            slug=project_slug
+        )
+        version_slug = request.POST.get('version_slug')
+        version = get_object_or_404(
+            Version,
+            project=project,
+            slug=version_slug,
+        )
+
+        trigger_build(project=project, version=version)
+        return HttpResponseRedirect(reverse('builds_project_list', args=[project.slug]))
+
+
+class BuildList(BuildBase, BuildTriggerMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(BuildList, self).get_context_data(**kwargs)

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -37,7 +37,7 @@ class BuildBase(object):
 class BuildTriggerMixin(object):
     def post(self, request, project_slug):
         project = get_object_or_404(
-            Project.objects.protected(self.request.user),
+            Project.objects.for_admin_user(self.request.user),
             slug=project_slug
         )
         version_slug = request.POST.get('version_slug')

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -8,7 +8,9 @@ from django.shortcuts import get_object_or_404
 from django.views.generic import ListView, DetailView
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
+from django.utils.decorators import method_decorator
 
 from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import trigger_build
@@ -35,6 +37,8 @@ class BuildBase(object):
 
 
 class BuildTriggerMixin(object):
+
+    @method_decorator(login_required)
     def post(self, request, project_slug):
         project = get_object_or_404(
             Project.objects.for_admin_user(self.request.user),

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -26,6 +26,7 @@ import requests
 from .base import ProjectOnboardMixin
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version
+from readthedocs.builds.views import BuildTriggerMixin
 from readthedocs.projects.models import Project, ImportedFile
 from readthedocs.search.indexes import PageIndex
 from readthedocs.search.views import LOG_TEMPLATE
@@ -67,7 +68,7 @@ class ProjectIndex(ListView):
 project_index = ProjectIndex.as_view()
 
 
-class ProjectDetailView(ProjectOnboardMixin, DetailView):
+class ProjectDetailView(BuildTriggerMixin, ProjectOnboardMixin, DetailView):
 
     """Display project onboard steps"""
 

--- a/readthedocs/templates/builds/build_list.html
+++ b/readthedocs/templates/builds/build_list.html
@@ -40,7 +40,8 @@
             {% if versions %}
             <div class="module-header">
               <div style="float:right;">
-                <form method="post" action="{% url "generic_build" project.pk %}">
+                <form method="post" action="{% url "builds_project_list" project.slug %}">
+                  {% csrf_token %}
                   <ul class="build_a_version">
                     <li style="display: inline-block">
                       <input style="display: inline-block" type="submit" value="{% trans "Build Version:" %}">

--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -59,7 +59,8 @@
   <div class="build_a_version">
     <h3>{% trans "Build a version" %}</h3>
     <div class="version_right">
-      <form method="post" action="{% url "generic_build" project.pk %}">
+      <form method="post" action="{% url "projects_detail" project.slug %}">
+        {% csrf_token %}
         <select id="id_version" name="version_slug">
         {% for version in versions|sort_version_aware %}
           <option value="{{ version.slug }}">{{ version.slug }}</option>

--- a/readthedocs/templates/projects/onboard_detail.html
+++ b/readthedocs/templates/projects/onboard_detail.html
@@ -16,7 +16,8 @@
         {% endblocktrans %}
       </p>
 
-      <form method="post" action="{% url "generic_build" project.pk %}">
+      <form method="post" action="{% url "projects_detail" project.slug %}">
+        {% csrf_token %}
         <input type="hidden" name="version_slug" value="latest" />
         <input type="submit" value="{% trans "Build latest version" %}" />
       </form>


### PR DESCRIPTION
Avoid "This endpoint is deprecated" raised when hitting and old
endpoint with security issues.

Now, each view that shows a form with the "Build" button uses the
BuildTriggerMixin to handle the POST request and trigger the new build.

Closes #3253