### PR TITLE
Add supervisord contrib example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .ropeproject/
 _build
 bower_components/
+contrib/supervisord.log
 deploy/.vagrant
 dist/*
 local_settings.py

--- a/contrib/readme.rst
+++ b/contrib/readme.rst
@@ -1,0 +1,30 @@
+Running Read the Docs via Supervisord
+=====================================
+
+This is the easiest way to start all of the commands you'll need for development
+in an environment relatively close to the production evironment. All you need is
+``supervisord`` and ``redis-server``. Installation of ``redis-server`` is
+outside the scope of this documentation, but once installed, all you need to run
+from ``supervisord`` is::
+
+    pip install supervisord
+    cd contrib/
+    supervisord
+
+This will bring up a web instance for the dashboard, a web instance for
+documentation serving, two celery instances, and redis-server.
+
+Debugging
+---------
+
+Because supervisord doesn't redirect stdin to the various processes, ``ipdb``
+and ``pdb`` will hang. You can still use ``pdb`` through telnet though!:
+
+    def method_you_want_to_test(self):
+        ...
+        from celery.contrib import rdb; rdb.set_trace()
+        ...
+
+This will pause and give you a telnet port to connect to. Then simply::
+
+    % telnet 127.0.0.1 6900

--- a/contrib/readme.rst
+++ b/contrib/readme.rst
@@ -12,19 +12,17 @@ from ``supervisord`` is::
     supervisord
 
 This will bring up a web instance for the dashboard, a web instance for
-documentation serving, two celery instances, and redis-server.
+documentation serving, two celery instances, and redis-server. 
+
+If you already are running redis-server, this will complain about the port
+already being in use, but will still load.
 
 Debugging
 ---------
 
-Because supervisord doesn't redirect stdin to the various processes, ``ipdb``
-and ``pdb`` will hang. You can still use ``pdb`` through telnet though!:
+To debug, set trace points like normal, with ``pdb``/``ipdb``. Then you can
+connect to the process by bringing it to the foreground::
 
-    def method_you_want_to_test(self):
-        ...
-        from celery.contrib import rdb; rdb.set_trace()
-        ...
+    supervisorctl fg main
 
-This will pause and give you a telnet port to connect to. Then simply::
-
-    % telnet 127.0.0.1 6900
+You'll still see logging to STDERR on the main supervisord process page.

--- a/contrib/supervisord.conf
+++ b/contrib/supervisord.conf
@@ -35,11 +35,10 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:build]
-command = celery worker -A readthedocs -Q default,celery,web,builder -l DEBUG
+command = celery worker -A readthedocs -Q default,celery,web,builder -l DEBUG -c 2
 process_name = build-%(process_num)s
 directory = ../
 priority = 100
-numprocs = 2
 stopasgroup=True
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/contrib/supervisord.conf
+++ b/contrib/supervisord.conf
@@ -1,0 +1,47 @@
+[supervisord]
+nodaemon = True
+directory = ../
+loglevel = error
+strip_ansi = False
+environment = PYTHONUNBUFFERED=1
+
+[program:redis]
+command = redis-server
+directory = ../
+priority = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:main]
+command = python manage.py runserver 8000
+directory = ../
+priority = 100
+stopasgroup=True
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:serve]
+command = python manage.py runserver 8001
+directory = ../
+priority = 100
+stopasgroup=True
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:build]
+command = celery worker -A readthedocs -Q default,celery,web,builder -l DEBUG
+process_name = build-%(process_num)s
+directory = ../
+priority = 100
+numprocs = 2
+stopasgroup=True
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/contrib/supervisord.conf
+++ b/contrib/supervisord.conf
@@ -3,44 +3,40 @@ nodaemon = True
 directory = ../
 loglevel = error
 strip_ansi = False
-environment = PYTHONUNBUFFERED=1
+environment = PYTHONUNBUFFERED=1,READTHEDOCS_INSTANCE=readthedocs.org
+
+[inet_http_server]
+port = 127.0.0.1:9001
+username = 🍔
+password = 🍟
+
+[supervisorctl]
+username = 🍔
+password = 🍟
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:redis]
 command = redis-server
 directory = ../
 priority = 0
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+startretries = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:main]
 command = python manage.py runserver 8000
 directory = ../
 priority = 100
-stopasgroup=True
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+stopasgroup = True
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
-[program:serve]
-command = python manage.py runserver 8001
+[program:celery]
+command = celery worker -A readthedocsinc -Q default,celery,web,builder -l DEBUG -c 2
 directory = ../
 priority = 100
-stopasgroup=True
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-
-[program:build]
-command = celery worker -A readthedocs -Q default,celery,web,builder -l DEBUG -c 2
-process_name = build-%(process_num)s
-directory = ../
-priority = 100
-stopasgroup=True
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+stopasgroup = True
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0


### PR DESCRIPTION
Useful for running a development instance really quickly.

Doesn't yet support:

* ipdb/pdb, but still supports rdb
* color log output