### PR TITLE
More fixes for logging -> Sentry

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -426,6 +426,14 @@ class BuildEnvironment(object):
                         build_id=self.build['pk']
                     )
                 )
+                log.error(
+                    'Build failed with unhandled exception: %s',
+                    str(self.failure),
+                    extra={
+                        'stack' True,
+                        'data': {'build': self.build['id']},
+                    }
+                )
 
         # Attempt to stop unicode errors on build reporting
         for key, val in list(self.build.items()):

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -429,10 +429,9 @@ class BuildEnvironment(object):
                 log.error(
                     'Build failed with unhandled exception: %s',
                     str(self.failure),
-                    extra={
-                        'stack' True,
-                        'data': {'build': self.build['id']},
-                    }
+                    extra={'stack': True,
+                           'tags': {'build': self.build['id']},
+                           }
                 )
 
         # Attempt to stop unicode errors on build reporting

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -132,7 +132,7 @@ class UpdateDocsTask(Task):
         except Exception as e:  # noqa
             log.exception(
                 'An unhandled exception was raised outside the build environment',
-                extra={'stack': True, 'tags': {'build': build_pk}}
+                extra={'tags': {'build': build_pk}}
             )
             error = _('Unknown error encountered. '
                       'Please include the build id ({build_id}) in any bug reports.'.format(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -134,11 +134,10 @@ class UpdateDocsTask(Task):
                 'An unhandled exception was raised outside the build environment',
                 extra={'tags': {'build': build_pk}}
             )
-            error = _('Unknown error encountered. '
-                      'Please include the build id ({build_id}) in any bug reports.'.format(
-                          build_id=build_pk
-                      ))
-            failure = error
+            failure = _('Unknown error encountered. '
+                        'Please include the build id ({build_id}) in any bug reports.'.format(
+                            build_id=build_pk
+                        ))
 
         # **Always** report build status.
         # This can still fail if the API Is totally down, but should catch more failures

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -132,7 +132,7 @@ class UpdateDocsTask(Task):
         except Exception as e:  # noqa
             log.exception(
                 'An unhandled exception was raised outside the build environment',
-                tags={'build': build_pk},
+                extra={'stack': True, 'tags': {'build': build_pk}}
             )
             error = _('Unknown error encountered. '
                       'Please include the build id ({build_id}) in any bug reports.'.format(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -130,7 +130,12 @@ class UpdateDocsTask(Task):
                 self.run_build(record=record, docker=docker)
             failure = self.setup_env.failure or self.build_env.failure
         except Exception as e:  # noqa
-            log.exception('Top-level build exception has been raised', extra={'build': build_pk})
+            log.exception(
+                'An unhandled exception was raised outside the build environment',
+                extra={
+                    data={'build': build_pk},
+                },
+            )
             failure = str(e)
 
         # **Always** report build status.

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -132,26 +132,24 @@ class UpdateDocsTask(Task):
         except Exception as e:  # noqa
             log.exception(
                 'An unhandled exception was raised outside the build environment',
-                extra={
-                    data={'build': build_pk},
-                },
+                tags={'build': build_pk},
             )
-            failure = str(e)
+            error = _('Unknown error encountered. '
+                      'Please include the build id ({build_id}) in any bug reports.'.format(
+                          build_id=build_pk
+                      ))
+            failure = error
 
         # **Always** report build status.
         # This can still fail if the API Is totally down, but should catch more failures
         result = {}
-        error = _('Unknown error encountered. '
-                  'Please include the build id ({build_id}) in any bug reports.'.format(
-                      build_id=build_pk
-                  ))
         build_updates = {'state': BUILD_STATE_FINISHED}
         build_data = {}
         if hasattr(self, 'build'):
             build_data.update(self.build)
         if failure:
             build_updates['success'] = False
-            build_updates['error'] = error
+            build_updates['error'] = failure
         build_data.update(build_updates)
         result = api_v2.build(build_pk).patch(build_updates)
         return result


### PR DESCRIPTION
* As per the sentry docs, metadata is passed in via extra['data'] argument to
  log.* -- still unclear if this is searchable
* We weren't actually logging unhandled build exceptions on the build
  environments