### PR TITLE
Update build from database at __exit__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ private_*
 readthedocs/htmlcov
 tags
 .python-version
+*.pyo

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -556,7 +556,6 @@ class DockerEnvironment(BuildEnvironment):
                       exc_info=True)
         self.container = None
         self.build['state'] = BUILD_STATE_FINISHED
-        self.update_build(BUILD_STATE_FINISHED)
         log.info(LOG_TEMPLATE
                  .format(project=self.project.slug,
                          version=self.version.slug,

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -556,6 +556,7 @@ class DockerEnvironment(BuildEnvironment):
                       exc_info=True)
         self.container = None
         self.build['state'] = BUILD_STATE_FINISHED
+        self.update_build(BUILD_STATE_FINISHED)
         log.info(LOG_TEMPLATE
                  .format(project=self.project.slug,
                          version=self.version.slug,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -196,6 +196,7 @@ class UpdateDocsTask(Task):
             if not isinstance(self.setup_env.failure, vcs_support_utils.LockTimeout):
                 self.send_notifications()
 
+            self.setup_env.update_build(state=BUILD_STATE_FINISHED)
             return False
 
         if self.setup_env.successful and not self.project.has_valid_clone:
@@ -257,6 +258,8 @@ class UpdateDocsTask(Task):
 
         if self.build_env.failed:
             self.send_notifications()
+
+        self.build_env.update_build(state=BUILD_STATE_FINISHED)
         build_complete.send(sender=Build, build=self.build_env.build)
 
     @staticmethod


### PR DESCRIPTION
When an exception happens and it's handled by __exit__ our Build in
the database is not updated and it stay in 'Installing' forever. So,
when something bad happens we force a call to `update_build` with the
FINISHED state

Attempt to fix #3285