### PR TITLE
Update Build state at the end of UpdateDocsTask.run

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -142,7 +142,7 @@ class UpdateDocsTask(Task):
                 ))
         finally:
             if unhandled_failure:
-                self.build_env.build['failure'] = unhandled_failure
+                self.build_env.build['error'] = unhandled_failure
             self.build_env.update_build(BUILD_STATE_FINISHED)
 
         return self.get_build(build_pk)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -135,10 +135,11 @@ class UpdateDocsTask(Task):
                 'An unhandled exception was raised outside the build environment',
                 extra={'tags': {'build': build_pk}}
             )
-            unhandled_failure = _('Unknown error encountered. '
-                        'Please include the build id ({build_id}) in any bug reports.'.format(
-                            build_id=build_pk
-                        ))
+            unhandled_failure = _(
+                'Unknown error encountered. '
+                'Please include the build id ({build_id}) in any bug reports.'.format(
+                    build_id=build_pk
+                ))
         finally:
             if unhandled_failure:
                 self.build_env.build['failure'] = unhandled_failure

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -116,8 +116,7 @@ class UpdateDocsTask(Task):
 
         This is fully wrapped in exception handling to account for a number of failure cases.
         """
-        unhandled_failure = False
-
+        unhandled_failure = ''
         try:
             self.project = self.get_project(pk)
             self.version = self.get_version(self.project, version_pk)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -116,6 +116,8 @@ class UpdateDocsTask(Task):
 
         This is fully wrapped in exception handling to account for a number of failure cases.
         """
+        unhandled_failure = False
+
         try:
             self.project = self.get_project(pk)
             self.version = self.get_version(self.project, version_pk)
@@ -128,30 +130,21 @@ class UpdateDocsTask(Task):
             setup_successful = self.run_setup(record=record)
             if setup_successful:
                 self.run_build(record=record, docker=docker)
-            failure = self.setup_env.failure or self.build_env.failure
         except Exception as e:  # noqa
             log.exception(
                 'An unhandled exception was raised outside the build environment',
                 extra={'tags': {'build': build_pk}}
             )
-            failure = _('Unknown error encountered. '
+            unhandled_failure = _('Unknown error encountered. '
                         'Please include the build id ({build_id}) in any bug reports.'.format(
                             build_id=build_pk
                         ))
+        finally:
+            if unhandled_failure:
+                self.build_env.build['failure'] = unhandled_failure
+            self.build_env.update_build(BUILD_STATE_FINISHED)
 
-        # **Always** report build status.
-        # This can still fail if the API Is totally down, but should catch more failures
-        result = {}
-        build_updates = {'state': BUILD_STATE_FINISHED}
-        build_data = {}
-        if hasattr(self, 'build'):
-            build_data.update(self.build)
-        if failure:
-            build_updates['success'] = False
-            build_updates['error'] = failure
-        build_data.update(build_updates)
-        result = api_v2.build(build_pk).patch(build_updates)
-        return result
+        return self.get_build(build_pk)
 
     def run_setup(self, record=True):
         """Run setup in the local environment.

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -145,7 +145,7 @@ class UpdateDocsTask(Task):
                 self.build_env.build['error'] = unhandled_failure
             self.build_env.update_build(BUILD_STATE_FINISHED)
 
-        return self.get_build(build_pk)
+        return self.build_env.build
 
     def run_setup(self, record=True):
         """Run setup in the local environment.


### PR DESCRIPTION
Use the `update_build` method that handles most of the cases but fill
the `failure` with a unhandled exception in case it was risen.

Related to #3292 