### PR TITLE
Extra way to check OOM of a command ran inside Docker

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -224,9 +224,12 @@ class DockerBuildCommand(BuildCommand):
             self.exit_code = cmd_ret['ExitCode']
 
             # Docker will exit with a special exit code to signify the command
-            # was killed due to memory usage, make the error code nicer.
-            if (self.exit_code == DOCKER_OOM_EXIT_CODE and
-                    self.output == 'Killed\n'):
+            # was killed due to memory usage, make the error code
+            # nicer. Sometimes the kernel kills the command and Docker doesn't
+            # not use the specific exit code, so we check if the word `Killed`
+            # is in the last 15 lines of the command's output
+            killed_in_output = 'Killed' in '\n'.join(self.output.splitlines()[-15:])
+            if self.exit_code == DOCKER_OOM_EXIT_CODE or killed_in_output:
                 self.output = _('Command killed due to excessive memory '
                                 'consumption\n')
         except DockerAPIError:

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -229,7 +229,7 @@ class DockerBuildCommand(BuildCommand):
             # not use the specific exit code, so we check if the word `Killed`
             # is in the last 15 lines of the command's output
             killed_in_output = 'Killed' in '\n'.join(self.output.splitlines()[-15:])
-            if self.exit_code == DOCKER_OOM_EXIT_CODE or killed_in_output:
+            if self.exit_code == DOCKER_OOM_EXIT_CODE or (self.exit_code == 1 and killed_in_output):
                 self.output = _('Command killed due to excessive memory '
                                 'consumption\n')
         except DockerAPIError:


### PR DESCRIPTION
Easy way to reproduce this error:

1. Import a project that compiles lxml (Read the Docs, for example)
2. The `pip` command will be killed and Docker won't return a specific
status code, it will just return 1
3. In these cases, the `Killed` word will probably appear in the last
15 lines

----

If I increase the DOCKER_LIMITS memory in my local instance I don't get this error.