### PR TITLE
Add GLOBAL_PIP_CACHE setting

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -441,6 +441,8 @@ class Project(models.Model):
     @property
     def pip_cache_path(self):
         """Path to pip cache"""
+        if getattr(settings, 'GLOBAL_PIP_CACHE', False):
+            return settings.GLOBAL_PIP_CACHE
         return os.path.join(self.doc_path, '.cache', 'pip')
 
     #


### PR DESCRIPTION
Avoid downloading over and over again the pip packages when you are
developing over a slow internet connection.