### PR TITLE
Fix Edit links if version is referenced by annotated tag

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -98,7 +98,8 @@ class Backend(BaseVCS):
         # of annotated tags pointing to tagged commits.
         retcode, stdout, _ = self.run(
             'git', 'for-each-ref',
-            '--format="%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end) %(refname)"',
+            '--format="%(if)%(*objectname)%(then)%(*objectname)'
+            '%(else)%(objectname)%(end) %(refname)"',
             'refs/tags')
         # error (or no tags found)
         if retcode != 0:

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -92,7 +92,14 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout, _ = self.run('git', 'show-ref', '--tags')
+        # Hash for non-annotated tag is its commit hash, but for annotated tag it
+        # points to tag itself, so we need to dereference annotated tags.
+        # The output format is the same as `git show-ref --tags`, but with hashes
+        # of annotated tags pointing to tagged commits.
+        retcode, stdout, _ = self.run(
+            'git', 'for-each-ref',
+            '--format="%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end) %(refname)"',
+            'refs/tags')
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -100,7 +107,7 @@ class Backend(BaseVCS):
 
     def parse_tags(self, data):
         """
-        Parses output of show-ref --tags, eg:
+        Parses output of `git show-ref --tags`, eg:
 
             3b32886c8d3cb815df3793b3937b2e91d0fb00f1 refs/tags/2.0.0
             bd533a768ff661991a689d3758fcfe72f455435d refs/tags/2.0.1


### PR DESCRIPTION
A better version of #3238 that fixes #1637, #1820 etc. thanks to responses from git ML.

https://public-inbox.org/git/CAPkN8x+MELCnttE+xptKzYXsYPWqbiE59LABrwNBhFroayc+wQ@mail.gmail.com/

Annotated tags in Git are special. GitHub is unable to find commit corresponding to tag hash, because annotated tags are pointing to tag meta data and need to be dereferenced first.