### PR TITLE
Show the proper version in the project dashboard

### DIFF
--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -28,14 +28,14 @@
         {% if version.uploaded or version.built %}
           {# Link to the docs #}
           <a class="module-item-title" href="{{ version.get_absolute_url }}">
-            {% blocktrans with version.slug as slug %} {{ slug }} {% endblocktrans %}
+            {{ version.slug }}
           {% if request.user in project.users.all %}
             <span class="right-menu quiet">{{ version.get_privacy_level_display }}</span>
           {% endif %}
           </a>
         {% else %}
           <a class="module-item-title" href="{{ version.project.get_builds_url }}">
-            {{ slug }}
+            {{ version.slug }}
           </a>
         {% endif %}
           {% if request.user|is_admin:project %}


### PR DESCRIPTION
The bug was introduced at

https://github.com/rtfd/readthedocs.org/pull/2944/files#diff-9a10ae0511ab8eb72096c4a0510a364eL38

Since the {% blocktrans %} was removed, the `slug` name was
undefined. Besides, there is no need to translate the slug, so the
first one was also removed

Fixes #3187 