### PR TITLE
Use `id` attribute instead of `pk` for build

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -426,7 +426,7 @@ class BuildEnvironment(object):
                 self.build['error'] = ugettext_noop(
                     "There was a problem with Read the Docs while building your documentation. "
                     "Please report this to us with your build id ({build_id}).".format(
-                        build_id=self.build['pk']
+                        build_id=self.build['id']
                     )
                 )
                 log.error(


### PR DESCRIPTION
`pk` exists only for Builds that are retrieved from the database, but
when it's retrieved using the API, the `id` must be used.

Using the `id` is compatible with both instances.

Related to #2963