### PR TITLE
Update CI requeriments

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,7 +1,7 @@
 -r pip.txt
 
-py<1.5,>=1.4.33
+pytest<4,>=3.3.0
 pytest-django==3.1.2
-pytest-xdist==1.16.0
+pytest-xdist==1.20.1
 apipkg==1.4
-execnet==1.4.1
+execnet==1.5.0


### PR DESCRIPTION
This should fix:

- https://travis-ci.org/rtfd/readthedocs.org/builds/308558295?utm_source=github_status&utm_medium=notification

```
pluggy.PluginValidationError: Plugin 'xdist' could not be loaded: (py 1.4.34 (/home/travis/build/rtfd/readthedocs.org/.tox/py27/lib/python2.7/site-packages), Requirement.parse('py>=1.5.0'), set(['pytest']))!

ERROR: InvocationError: '/home/travis/build/rtfd/readthedocs.org/.tox/py27/bin/py.test'
```