### PR TITLE
Change stable version switching to respect `active`

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -707,7 +707,7 @@ class Project(models.Model):
             if current_stable:
                 identifier_updated = (
                     new_stable.identifier != current_stable.identifier)
-                if identifier_updated and current_stable.machine:
+                if identifier_updated and current_stable.active:
                     log.info(
                         "Update stable version: {project}:{version}".format(
                             project=self.slug,

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -176,7 +176,6 @@ def project_version_detail(request, project_slug, version_slug):
                 log.info('Removing files for version %s', version.slug)
                 broadcast(type='app', task=tasks.clear_artifacts, args=[version.pk])
                 version.built = False
-                version.machine = False
                 version.save()
         url = reverse('project_version_list', args=[project.slug])
         return HttpResponseRedirect(url)

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -349,6 +349,9 @@ class TestStableVersion(TestCase):
         self.assertEqual(version_stable.identifier, '1.0.0')
 
     def test_update_inactive_stable_version(self):
+        """
+        Test that stable doesn't get updated when it isn't active
+        """
         version_post_data = {
             'branches': [
                 {
@@ -388,7 +391,7 @@ class TestStableVersion(TestCase):
 
         version_stable = Version.objects.get(slug=STABLE)
         self.assertFalse(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0.0')
+        self.assertEqual(version_stable.identifier, '0.9')
 
     def test_stable_version_tags_over_branches(self):
         version_post_data = {


### PR DESCRIPTION
This previously used the `machine` tag that was turned off when a user de-activated the version,
but never turned back on when they re-activated it.

This changes to just use the `active` flag on the Version,
so we will update the stable version if the existing one is `active`,
and not if it isn't,
which makes _way_ more sense.

Refs #3268