### PR TITLE
Fix python usage around oauth pagination

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -140,7 +140,7 @@ class Service(object):
             except ValueError:
                 debug_data = resp.content
             log.debug('paginate failed at %s with response: %s', url, debug_data)
-        finally:
+        else:
             return []
 
     def sync(self):


### PR DESCRIPTION
Because of a python quirk, we are currently returning an empty list during
pagination against oauth proviers. The quirk breaks down to this:

```python
def foo():
    try:
        return 'duck'
    except Exception:
        return 'duck'
    finally:
        return 'goose'

assert foo() == 'goose'
```

I didn't realize `finally` behaved in this manner with respect to `return`, so
hey, The More You Know™