### PR TITLE
Fix mkdocs search.

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -191,4 +191,4 @@ class MkdocsJSON(BaseMkdocs):
             user_config,
             open(os.path.join(self.root_path, 'mkdocs.yml'), 'w')
         )
-        super(MkdocsJSON, self).build()
+        return super(MkdocsJSON, self).build()


### PR DESCRIPTION
The mkdocs search builder was not passing its return code back up,
which meant `search=False`,
which means that the JSON files weren't syncing or being indexed.