### PR TITLE
Revert "Do not split before first argument (#3333)"

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -145,7 +145,7 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN=True
 
 # If an argument / parameter list is going to be split, then split
 # before the first argument.
-SPLIT_BEFORE_FIRST_ARGUMENT=False
+SPLIT_BEFORE_FIRST_ARGUMENT=True
 
 # Set to True to prefer splitting before 'and' or 'or' rather than
 # after.


### PR DESCRIPTION
This reverts commit 1b38e92ae7056e60631f6c777d99db1e8d2a60d1.

It turns out this causes more problems with line continuations