### PR TITLE
Strip well-known version component origin/ from remote version

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -72,6 +72,12 @@ class BaseSphinx(BaseBuilder):
         )
         remote_version = self.version.commit_name
 
+        # Replace "/origin" because upstream VCS does not recognize the local
+        # repo remote name
+        # Refs: https://github.com/rtfd/readthedocs.org/issues/3203
+        if remote_version:
+            remote_version = remote_version.replace("origin/", "")
+
         github_user, github_repo = version_utils.get_github_username_repo(
             url=self.project.repo)
         github_version_is_editable = (self.version.type == 'branch')


### PR DESCRIPTION
Fixes #3203

As far as I can tell all "Edit on Github" buttons have broken URLs when they refer to branch names.

Examples:
http://django-wiki.readthedocs.io/en/master/
http://discretize.simpeg.xyz/en/master/

Somehow, if it's just a default `latest` slug pointing to the master branch, then there's no appending of `origin/`. There's some stuff going on in `vcs_support.backends.git` that I can't really say might have a cause of that... and that perhaps the fix should be placed there. Anyways, the generation of a URL is view logic, so I kind of prefer my simple fix, putting the logic where the link is generated.

https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/vcs_support/backends/git.py#L127

Example of non-affected page:
http://django-statsd.readthedocs.io/en/latest/