### PR TITLE
Search for slug with case insensivitiy.

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -98,6 +98,7 @@ class BaseSphinx(BaseBuilder):
         data = {
             'current_version': self.version.verbose_name,
             'project': self.project,
+            'version': self.version,
             'settings': settings,
             'static_path': SPHINX_STATIC_DIR,
             'template_path': SPHINX_TEMPLATE_DIR,

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -77,7 +77,8 @@ if globals().get('websupport2_base_url', False):
 context = {
     'using_theme': using_rtd_theme,
     'html_theme': html_theme,
-    'current_version': "{{ current_version }}",
+    'current_version': "{{ version.verbose_name }}",
+    'version_slug': "{{ version.slug }}",
     'MEDIA_URL': "{{ settings.MEDIA_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
     'versions': [{% for version in versions %}

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -81,7 +81,7 @@ def footer_html(request):
     version = get_object_or_404(
         Version.objects.public(
             request.user, project=project, only_active=False),
-        slug=version_slug)
+        slug__iexact=version_slug)
     main_project = project.main_language_project or project
 
     if page_slug and page_slug != 'index':
@@ -94,13 +94,6 @@ def footer_html(request):
             path = page_slug + '.html'
     else:
         path = ''
-
-    if version.type == TAG and version.project.has_pdf(version.slug):
-        print_url = (
-            'https://keminglabs.com/print-the-docs/quote?project={project}&version={version}'  # noqa
-            .format(project=project.slug, version=version.slug))
-    else:
-        print_url = None
 
     version_compare_data = get_version_compare_data(project, version)
 
@@ -118,7 +111,6 @@ def footer_html(request):
         'new_theme': new_theme,
         'settings': settings,
         'subproject': subproject,
-        'print_url': print_url,
         'github_edit_url': version.get_github_url(
             docroot,
             page_slug,


### PR DESCRIPTION
This is because of #3311,
I notice that we are sending the `verbose_name` for the version slug.
We don't actually _have_ the version slug in the doc page,
so we need to start including that as well.