### PR TITLE
Pass more data into the redirects.

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -958,6 +958,8 @@ def update_static_metadata(project_pk, path=None):
         'language': project.language,
         'languages': list(languages),
         'single_version': project.single_version,
+        'subdomain': project.subdomain(),
+        'canonical_url': project.get_canonical_url(),
     }
     try:
         fh = open(path, 'w+')


### PR DESCRIPTION
This will let us force a CNAME in the base-level `foo.rtd.org` redirect case.

Refs #1916