### PR TITLE
Update changelog more consistently

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -6,8 +6,9 @@ from __future__ import division, print_function, unicode_literals
 import os
 import textwrap
 
+from dateutil.parser import parse
 from future.moves.configparser import RawConfigParser
-from invoke import task
+from invoke import task, Exit
 
 
 @task
@@ -24,6 +25,13 @@ def prepare(ctx, version):
     updated.  New entries will end up at the top of the file, under a heading
     for the new version.
     """
+    # Ensure we're on the master branch first
+    git_rev_parse = ctx.run('git rev-parse --abbrev-ref HEAD', hide=True)
+    current_branch = git_rev_parse.stdout.strip()
+    if current_branch != 'rel':
+        print('You must be on master branch!')
+        raise Exit(1)
+
     print('Updating release version in setup.cfg')
     setupcfg_path = os.path.join(os.path.dirname(__file__), 'setup.cfg')
     config = RawConfigParser()
@@ -33,6 +41,11 @@ def prepare(ctx, version):
         config.write(configfile)
 
     print('Installing github-changelog')
+    # Get last modified date from Git instead of assuming the file metadata is
+    # correct. This can change depending on git reset, etc.
+    git_log = ctx.run('git log -1 --format="%ad" -- CHANGELOG.rst')
+    last_modified = parse(git_log.stdout.strip()).strftime('%Y-%m-%d')
+    # Install and run
     ctx.run('npm install git+https://github.com/agjohnson/github-changelog.git')
     changelog_path = os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')
     template_path = os.path.join(
@@ -44,12 +57,14 @@ def prepare(ctx, version):
         'gh-changelog '
         '-o rtfd -r readthedocs.org '
         '--file {changelog_path} '
+        '--since {last_modified} '
         '--template {template_path} '
         '--header "Version {version}"'
     ).format(
         version=version,
         template_path=template_path,
         changelog_path=changelog_path,
+        last_modified=last_modified,
     )  # yapf: disable
     try:
         token = os.environ['GITHUB_TOKEN']
@@ -76,6 +91,5 @@ def release(ctx, version):
     Do this after prepare task and manual cleanup/commit
     """
     ctx.run(
-        ('git checkout master && '
-         'git tag {version} && '
+        ('git tag {version} && '
          'git push --tags').format(version=version))


### PR DESCRIPTION
* Get the last modified date from git, not local file as normally expected
* Make sure we're on master to run
* Don't do reset to master on release