### PR TITLE
Update style and copy on abandonment docs

### DIFF
--- a/docs/abandoned-projects.rst
+++ b/docs/abandoned-projects.rst
@@ -3,14 +3,12 @@ Policy for Abandoned Projects
 
 This policy describes the process by which a Read the Docs project name may be changed.
 
-
 Rationale
 ---------
 
 Conflict between the current use of the name and a different suggested use of
 the same name occasionally arise.  This document aims to provide general
 guidelines for solving the most typical cases of such conflicts.
-
 
 Specification
 -------------
@@ -19,22 +17,19 @@ The main idea behind this policy is that Read the Docs serves the community.  Ev
 user is invited to upload content under the Terms of Use, understanding that it
 is at the sole risk of the user.
 
-While Read the Docs is not a backup service, the maintainers do their best to keep that
-content accessible indefinitely in its published form.  However, in certain
+While Read the Docs is not a backup service, the core team of Read the Docs does their best to keep that
+content accessible indefinitely in its published form. However, in certain
 edge cases the greater community's needs might outweigh the individual's
 expectation of ownership of a project name.
 
 The use cases covered by this policy are:
 
-* Abandoned projects:
+Abandoned projects
+    Renaming a project so that the original project name can be used by a
+    different project
 
-    * renaming a project so that the original project name can be used by a
-      different project.
-
-* Active projects:
-
-    * resolving disputes over a name.
-
+Active projects
+    Resolving disputes over a name
 
 Implementation
 --------------
@@ -42,60 +37,56 @@ Implementation
 Reachability
 ~~~~~~~~~~~~
 
-The user of Read the Docs is solely responsible for being reachable by the maintainers
-for matters concerning projects that the user owns.  In every case where
-contacting the user is necessary, the maintainers will try to do so at least
+The user of Read the Docs is solely responsible for being reachable by the core team
+for matters concerning projects that the user owns. In every case where
+contacting the user is necessary, the core team will try to do so at least
 three times, using the following means of contact:
 
-* e-mail address on file in the user's profile;
-* e-mail addresses found in the given project's documentation; and
-* e-mail address on the project's home page.
+* E-mail address on file in the user's profile
+* E-mail addresses found in the given project's documentation
+* E-mail address on the project's home page
 
-The maintainers will stop trying to reach the user after six weeks and the user
+The core team will stop trying to reach the user after six weeks and the user
 will be considered *unreachable*.
-
 
 Abandoned projects
 ~~~~~~~~~~~~~~~~~~
 
 A project is considered *abandoned* when ALL of the following are met:
 
-* owner is unreachable (see Reachability above);
-* The project has no proper documentation being served (no successful builds); or
-* no releases within the past twelve months; and
-* no activity from the owner on the project's home page (or no home page
+* Owner is unreachable (see `Reachability`_)
+* The project has no proper documentation being served (no successful builds) or
+  does not have any releases within the past twelve months
+* No activity from the owner on the project's home page (or no home page
   found).
 
 All other projects are considered *active*.
-
 
 Renaming of an abandoned project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Projects are never renamed solely on the basis of abandonment.
 
-An *abandoned* project can be renamed (by appending "-abandoned" and a
+An *abandoned* project can be renamed (by appending ``-abandoned`` and a
 uniquifying integer if needed) for purposes of reusing the name when ALL of the
 following are met:
 
-* the project has been determined *abandoned* by the rules described above;
-* the candidate is able to demonstrate their own failed attempts to contact the
-  existing owner;
-* the candidate is able to demonstrate that the project suggested to reuse the
-  name already exists and meets notability requirements;
-* the candidate is able to demonstrate why a fork under a different name is not
-  an acceptable workaround;
-* the project has fewer than 100 monthly pageviews; and
-* the maintainers do not have any additional reservations.
-
+* The project has been determined *abandoned* by the rules described above
+* The candidate is able to demonstrate their own failed attempts to contact the
+  existing owner
+* The candidate is able to demonstrate that the project suggested to reuse the
+  name already exists and meets notability requirements
+* The candidate is able to demonstrate why a fork under a different name is not
+  an acceptable workaround
+* The project has fewer than 100 monthly pageviews
+* The core team does not have any additional reservations.
 
 Name conflict resolution for active projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The maintainers of Read the Docs are not arbiters in disputes around *active* projects.
-The maintainers recommend users to get in touch with each other and solve the
+The core team of Read the Docs are not arbiters in disputes around *active* projects.
+The core team recommends users to get in touch with each other and solve the
 issue by respectful communication.
-
 
 Prior art
 ---------


### PR DESCRIPTION
I went to look up our new policy and got confused :)

"Maintainers" is a term I attribute to project maintainers, not the core team of
Read the Docs. Because we refer to "core team" regularly, I updated that here.

This also alters the style of the lists to be less formal legal structure and
adds a couple pieces of reST that fit better.