### PR TITLE
Link to version detail page from build detail page

### DIFF
--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -1,6 +1,7 @@
 {% extends "projects/base_project.html" %}
 
 {% load i18n %}
+{% load privacy_tags %}
 {% load static %}
 
 {% block title %}{{ build.project.name }}{% endblock %}
@@ -62,7 +63,11 @@ $(document).ready(function () {
 
     <div class="build-version">
       <span class="build-version-slug">
-        {{ build.version.slug }}
+        {% if request.user|is_admin:project %}
+          <a href="{% url "project_version_detail" build.version.project.slug build.version.slug %}">{{ build.version.slug }}</a>
+        {% else  %}
+          {{ build.version.slug }}
+        {% endif %}
       </span>
       <span class="build-commit"
             data-bind="visible: commit">


### PR DESCRIPTION
On a build detail page, link the version detail page that it's being built if the user is the admin of the project, otherwise just show the slug as usual.

Related to #3417 