### PR TITLE
Use default avatar for User/Orgs in OAuth services

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -31,6 +31,9 @@ class Service(object):
     adapter = None
     url_pattern = None
 
+    default_user_avatar_url = settings.OAUTH_AVATAR_USER_DEFAULT_URL
+    default_org_avatar_url = settings.OAUTH_AVATAR_ORG_DEFAULT_URL
+
     def __init__(self, user, account):
         self.session = None
         self.user = user

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -136,6 +136,8 @@ class BitbucketService(Service):
 
             avatar_url = fields['links']['avatar']['href'] or ''
             repo.avatar_url = re.sub(r'\/16\/$', r'/32/', avatar_url)
+            if not repo.avatar_url:
+                repo.avatar_url = self.default_user_avatar_url
 
             repo.json = json.dumps(fields)
             repo.save()
@@ -157,6 +159,8 @@ class BitbucketService(Service):
         organization.name = fields.get('display_name')
         organization.email = fields.get('email')
         organization.avatar_url = fields['links']['avatar']['href']
+        if not organization.avatar_url:
+            organization.avatar_url = self.default_org_avatar_url
         organization.url = fields['links']['html']['href']
         organization.json = json.dumps(fields)
         organization.account = self.account

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -114,6 +114,8 @@ class GitHubService(Service):
             repo.vcs = 'git'
             repo.account = self.account
             repo.avatar_url = fields.get('owner', {}).get('avatar_url')
+            if not repo.avatar_url:
+                repo.avatar_url = self.default_user_avatar_url
             repo.json = json.dumps(fields)
             repo.save()
             return repo
@@ -143,6 +145,8 @@ class GitHubService(Service):
         organization.name = fields.get('name')
         organization.email = fields.get('email')
         organization.avatar_url = fields.get('avatar_url')
+        if not organization.avatar_url:
+            organization.avatar_url = self.default_org_avatar_url
         organization.json = json.dumps(fields)
         organization.account = self.account
         organization.save()

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -162,7 +162,10 @@ class GitLabService(Service):
 
             owner = fields.get('owner') or {}
             repo.avatar_url = (
-                fields.get('avatar_url') or owner.get('avatar_url'))
+                fields.get('avatar_url') or owner.get('avatar_url')
+            )
+            if not repo.avatar_url:
+                repo.avatar_url = self.default_user_avatar_url
 
             repo.json = json.dumps(fields)
             repo.save()
@@ -201,6 +204,8 @@ class GitLabService(Service):
             path=fields.get('path'),
         )
         organization.avatar_url = fields.get('avatar_url')
+        if not organization.avatar_url:
+            organization.avatar_url = self.default_user_avatar_url
         organization.json = json.dumps(fields)
         organization.save()
         return organization

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -3,6 +3,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import mock
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -42,7 +43,10 @@ class GitHubOAuthTests(TestCase):
         self.assertEqual(repo.name, 'testrepo')
         self.assertEqual(repo.full_name, 'testuser/testrepo')
         self.assertEqual(repo.description, 'Test Repo')
-        self.assertIsNone(repo.avatar_url)
+        self.assertEqual(
+            repo.avatar_url,
+            settings.OAUTH_AVATAR_USER_DEFAULT_URL,
+        )
         self.assertIn(self.user, repo.users.all())
         self.assertEqual(repo.organization, self.org)
         self.assertEqual(

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -314,6 +314,8 @@ class CommunityBaseSettings(Settings):
     # Misc application settings
     GLOBAL_ANALYTICS_CODE = 'UA-17997319-1'
     GRAVATAR_DEFAULT_IMAGE = 'https://media.readthedocs.org/images/silhouette.png'  # NOQA
+    OAUTH_AVATAR_USER_DEFAULT_URL = GRAVATAR_DEFAULT_IMAGE
+    OAUTH_AVATAR_ORG_DEFAULT_URL = GRAVATAR_DEFAULT_IMAGE
     RESTRICTEDSESSIONS_AUTHED_ONLY = True
     RESTRUCTUREDTEXT_FILTER_SETTINGS = {
         'cloak_email_addresses': True,


### PR DESCRIPTION
Example:

![captura de pantalla_2017-12-18_15-01-06](https://user-images.githubusercontent.com/244656/34125467-4cde89a6-e404-11e7-9e1e-da778fcf6b4e.png)


Closes #3353 