### PR TITLE
Hack in a fix for missing version slug deploy that went out a while back

### DIFF
--- a/readthedocs/core/management/commands/symlink.py
+++ b/readthedocs/core/management/commands/symlink.py
@@ -22,8 +22,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         projects = options['projects']
         if 'all' in projects:
-            queryset = Project.objects.all()
+            pks = Project.objects.values_list('pk', flat=True)
         else:
-            queryset = Project.objects.filter(slug__in=projects)
-        for proj in queryset:
-            tasks.symlink_project(project_pk=proj.pk)
+            pks = Project.objects.filter(slug__in=projects).values_list('pk', flat=True)
+        for proj in pks:
+            tasks.symlink_project(project_pk=proj)

--- a/readthedocs/core/management/commands/symlink.py
+++ b/readthedocs/core/management/commands/symlink.py
@@ -26,4 +26,7 @@ class Command(BaseCommand):
         else:
             pks = Project.objects.filter(slug__in=projects).values_list('pk', flat=True)
         for proj in pks:
-            tasks.symlink_project(project_pk=proj)
+            try:
+                tasks.symlink_project(project_pk=proj)
+            except Exception:
+                log.exception('Failed symlink management command')

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -75,6 +75,10 @@ def footer_html(request):
     subproject = request.GET.get('subproject', False)
     source_suffix = request.GET.get('source_suffix', '.rst')
 
+    # Hack in a fix for missing version slug deploy that went out a while back
+    if version_slug == '':
+        version_slug = 'latest'
+
     new_theme = (theme == 'sphinx_rtd_theme')
     using_theme = (theme == 'default')
     project = get_object_or_404(Project, slug=project_slug)

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -77,7 +77,7 @@ def footer_html(request):
 
     # Hack in a fix for missing version slug deploy that went out a while back
     if version_slug == '':
-        version_slug = 'latest'
+        version_slug = LATEST
 
     new_theme = (theme == 'sphinx_rtd_theme')
     using_theme = (theme == 'default')


### PR DESCRIPTION
Also has some updates to `symlink` command, so we can properly rebuild web05 without running out of memory. 