### PR TITLE
Do not use double quotes on git command with --format option

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -86,8 +86,8 @@ class Backend(BaseVCS):
         # of annotated tags pointing to tagged commits.
         retcode, stdout, _ = self.run(
             'git', 'for-each-ref',
-            '--format="%(if)%(*objectname)%(then)%(*objectname)'
-            '%(else)%(objectname)%(end) %(refname)"',
+            '--format=%(if)%(*objectname)%(then)%(*objectname)'
+            '%(else)%(objectname)%(end) %(refname)',
             'refs/tags')
         # error (or no tags found)
         if retcode != 0:


### PR DESCRIPTION
Ref: https://github.com/rtfd/readthedocs.org/pull/3302#issuecomment-353451031