### PR TITLE
Broken link URL changed fixes #3442

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -152,7 +152,7 @@ If you have any more trouble, don't hesitate to reach out to us. The :doc:`suppo
 .. _install Sphinx: http://sphinx-doc.org/latest/install.html
 .. _install Mkdocs: http://www.mkdocs.org/#installation
 .. _reStructuredText: http://sphinx-doc.org/rest.html
-.. _this template: http://docs.writethedocs.org/writing/beginners-guide-to-docs/#id1
+.. _this template: http://docs.writethedocs.org/guide/writing/beginners-guide-to-docs/#id1
 .. _Sign up: http://readthedocs.org/accounts/signup
 .. _log in: http://readthedocs.org/accounts/login
 .. _dashboard: http://readthedocs.org/dashboard


### PR DESCRIPTION
The existing link was broken. The URL has been updated to the correct one. 