### PR TITLE
Wrap versions' list to look more consistent

### DIFF
--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -46,9 +46,11 @@
         </li>
 
       {% empty %}
-      <p>
-      {% trans "No active versions." %}
-      </p>
+        <li class="module-item">
+          <p class="quiet">
+            {% trans "No active versions." %}
+          </p>
+        </li>
       {% endfor %}
       </ul>
     </div>

--- a/readthedocs/templates/core/project_downloads.html
+++ b/readthedocs/templates/core/project_downloads.html
@@ -26,7 +26,9 @@
   {% endif %}
 
 {% empty %}
-    <p>
-    {% trans "No downloads for this project." %}
+  <li class="module-item">
+    <p class="quiet">
+      {% trans "No downloads for this project." %}
     </p>
+  </li>
 {% endfor %}

--- a/readthedocs/templates/projects/integration_list.html
+++ b/readthedocs/templates/projects/integration_list.html
@@ -23,7 +23,7 @@
     </ul>
   </div>
 
-  <div class="module">
+  <div class="module-list">
     <div class="module-list-wrapper">
       <ul>
         {% for integration in object_list %}

--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -21,45 +21,52 @@ Versions
 
     <div class="module project-versions-active">
       <div class="module-wrapper">
-        <h1>{% trans "Active Versions" %}</h1>
-        <div class="module-list-wrapper">
-          <ul>
-            {% for version in active_versions|sort_version_aware %}
-              {% block active-versions %}
-              <li class="module-item">
-                {# Link to the docs #}
-                <a class="module-item-title" href="{{ version.get_absolute_url }}">{{ version.slug }}</a>
 
-                {% if request.user|is_admin:project %}
-                  <span class="right-menu">
-                    {{ version.get_privacy_level_display }}
-                  </span>
-                {% endif %}
-
-                {% if not version.slug in version.identifier %}
-                  <span class="right-menu quiet version-branch">{{ version.identifier_friendly|truncatechars:24 }}</span>
-                {% endif %}
-
-                {% if request.user|is_admin:project %}
-                  <ul class="module-item-menu">
-                    <li><a href="{% url "project_version_detail" project.slug version.slug %}">{% trans "Edit" %}</a></li>
-                  </ul>
-                {% else %}
-                  <ul class="module-item-menu">
-                    <li><a href="{{ version.get_absolute_url }}">{% trans "View Docs" %}</a></li>
-                  </ul>
-                {% endif %}
-
-              </li>
-              {% endblock active-versions %}
-
-            {% empty %}
-            <p>
-            {% trans "No active versions." %}
-            </p>
-            {% endfor %}
-          </ul>
+        <div class="module-header">
+          <h1>{% trans "Active Versions" %}</h1>
         </div>
+
+        <div class="module-list">
+          <div class="module-list-wrapper">
+            <ul>
+              {% for version in active_versions|sort_version_aware %}
+                {% block active-versions %}
+                  <li class="module-item">
+                    {# Link to the docs #}
+                    <a class="module-item-title" href="{{ version.get_absolute_url }}">{{ version.slug }}</a>
+
+                    {% if request.user|is_admin:project %}
+                      <span class="right-menu">
+                        {{ version.get_privacy_level_display }}
+                      </span>
+                    {% endif %}
+
+                    {% if not version.slug in version.identifier %}
+                      <span class="right-menu quiet version-branch">{{ version.identifier_friendly|truncatechars:24 }}</span>
+                    {% endif %}
+
+                    {% if request.user|is_admin:project %}
+                      <ul class="module-item-menu">
+                        <li><a href="{% url "project_version_detail" project.slug version.slug %}">{% trans "Edit" %}</a></li>
+                      </ul>
+                    {% else %}
+                      <ul class="module-item-menu">
+                        <li><a href="{{ version.get_absolute_url }}">{% trans "View Docs" %}</a></li>
+                      </ul>
+                    {% endif %}
+
+                  </li>
+                {% endblock active-versions %}
+
+              {% empty %}
+                <p>
+                  {% trans "No active versions." %}
+                </p>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+
       </div>
     </div>
 
@@ -68,42 +75,46 @@ Versions
       <div class="module-wrapper">
 
         {% if inactive_versions %}
-          <h1>{% trans "Inactive Versions" %}</h1>
-          <div class="module-list-wrapper">
-            <ul>
-              {% for version in inactive_versions|sort_version_aware %}
+          <div class="module-header">
+            <h1>{% trans "Inactive Versions" %}</h1>
+          </div>
 
-              {% block inactive-versions %}
-                <li class="module-item">
-                  {# Link to the docs #}
-                  <span class="quiet">{{ version.slug }}</span>
+          <div class="module-list">
+            <div class="module-list-wrapper">
+              <ul>
+                {% for version in inactive_versions|sort_version_aware %}
+
+                  {% block inactive-versions %}
+                    <li class="module-item">
+                      {# Link to the docs #}
+                      <span class="quiet">{{ version.slug }}</span>
 
 
-                  {% if request.user|is_admin:project %}
-                    <span class="right-menu">
-                      {{ version.get_privacy_level_display }}
-                    </span>
-                  {% endif %}
-
-                  {% if not version.slug in version.identifier_friendly %}
-                    <span class="right-menu quiet version-branch">{{ version.identifier_friendly|truncatechars:24 }}</span>
-                  {% endif %}
-
-                  {% if request.user|is_admin:project %}
-                    <ul class="module-item-menu">
-                      {% if version.built %}
-                          <li><a href="{% url "project_version_delete_html" project.slug version.slug %}">{% trans "Clean" %}</a></li>
+                      {% if request.user|is_admin:project %}
+                        <span class="right-menu">
+                          {{ version.get_privacy_level_display }}
+                        </span>
                       {% endif %}
-                      <li><a href="{% url "project_version_detail" project.slug version.slug %}">{% trans "Edit" %}</a></li>
-                    </ul>
-                  {% endif %}
 
-                  
-                </li>
-              {% endblock inactive-versions %}
-              
-              {% endfor %}
-            </ul>
+                      {% if not version.slug in version.identifier_friendly %}
+                        <span class="right-menu quiet version-branch">{{ version.identifier_friendly|truncatechars:24 }}</span>
+                      {% endif %}
+
+                      {% if request.user|is_admin:project %}
+                        <ul class="module-item-menu">
+                          {% if version.built %}
+                            <li><a href="{% url "project_version_delete_html" project.slug version.slug %}">{% trans "Clean" %}</a></li>
+                          {% endif %}
+                          <li><a href="{% url "project_version_detail" project.slug version.slug %}">{% trans "Edit" %}</a></li>
+                        </ul>
+                      {% endif %}
+
+                    </li>
+                  {% endblock inactive-versions %}
+                
+                {% endfor %}
+              </ul>
+            </div>
           </div>
         {% endif %}
 

--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -59,9 +59,11 @@ Versions
                 {% endblock active-versions %}
 
               {% empty %}
-                <p>
-                  {% trans "No active versions." %}
-                </p>
+                <li class="module-item">
+                  <p class="quiet">
+                    {% trans "No active versions." %}
+                  </p>
+                </li>
               {% endfor %}
             </ul>
           </div>


### PR DESCRIPTION
I just noted that the `Versions` section looks different to the others.

**Here is how it looks right now**

![active-before](https://user-images.githubusercontent.com/4975310/34316969-a38f7de4-e771-11e7-8245-f99b551f4bb2.png)

![no-active-before](https://user-images.githubusercontent.com/4975310/34316971-a5819bdc-e771-11e7-8e42-6a6f8fcd5e17.png)

**And how it will look like after merging**

![no-active](https://user-images.githubusercontent.com/4975310/34316976-bfc95e9e-e771-11e7-9e86-41cd3ddd499f.png)

![only-active](https://user-images.githubusercontent.com/4975310/34316975-bf9398f4-e771-11e7-87a2-2ec673207285.png)
