### PR TITLE
Show link to docs on a build

### DIFF
--- a/readthedocs/builds/static/builds/css/detail.css
+++ b/readthedocs/builds/static/builds/css/detail.css
@@ -1,25 +1,7 @@
 /* Build detail styles */
 
-div.build-detail div.build-title {
-    margin: .1em 0em .2em 0em;
-}
-
-div.build-detail div.build-title span.build-id {
+div.build-detail div.build-id {
     font-size: 1.5em;
-    font-weight: bold;
-}
-
-div.build-detail div.build-title span.build-id > span.build-state-normal {
-}
-div.build-detail div.build-title span.build-id > span.build-state-failed {
-    color: #a55;
-}
-div.build-detail div.build-title span.build-id > span.build-state-successful {
-    color: #5a5;
-}
-
-div.build-detail div.build-title span.build-state-detail {
-    margin-left: .5em;
 }
 
 div.build-detail div.build-version {
@@ -29,6 +11,28 @@ div.build-detail div.build-version {
 div.build-detail div.build-version span.build-commit {
     color: #887;
     font-style: italic;
+}
+
+div.build-detail div.build-state {
+    margin: .7em 0em 1em 0em;
+    font-size: 1.2em;
+}
+
+div.build-detail div.build-state > span.build-state-successful,
+div.build-detail div.build-state > span.build-state-failed {
+    padding: .3em .5em;
+    border-radius: .3em;
+    -moz-border-radius: .3em;
+    -ms-border-radius: .3em;
+    -webkit-border-radius: .3em;
+    color: white;
+}
+
+div.build-detail div.build-state > span.build-state-failed {
+    background: #a55;
+}
+div.build-detail div.build-state > span.build-state-successful {
+    background: #5a5;
 }
 
 div.build-detail div.build-ideas {

--- a/readthedocs/builds/static/builds/css/detail.css
+++ b/readthedocs/builds/static/builds/css/detail.css
@@ -1,7 +1,25 @@
 /* Build detail styles */
 
-div.build-detail div.build-id {
+div.build-detail div.build-title {
+    margin: .1em 0em .2em 0em;
+}
+
+div.build-detail div.build-title span.build-id {
     font-size: 1.5em;
+    font-weight: bold;
+}
+
+div.build-detail div.build-title span.build-id > span.build-state-normal {
+}
+div.build-detail div.build-title span.build-id > span.build-state-failed {
+    color: #a55;
+}
+div.build-detail div.build-title span.build-id > span.build-state-successful {
+    color: #5a5;
+}
+
+div.build-detail div.build-title span.build-state-detail {
+    margin-left: .5em;
 }
 
 div.build-detail div.build-version {
@@ -11,28 +29,6 @@ div.build-detail div.build-version {
 div.build-detail div.build-version span.build-commit {
     color: #887;
     font-style: italic;
-}
-
-div.build-detail div.build-state {
-    margin: .7em 0em 1em 0em;
-    font-size: 1.2em;
-}
-
-div.build-detail div.build-state > span.build-state-successful,
-div.build-detail div.build-state > span.build-state-failed {
-    padding: .3em .5em;
-    border-radius: .3em;
-    -moz-border-radius: .3em;
-    -ms-border-radius: .3em;
-    -webkit-border-radius: .3em;
-    color: white;
-}
-
-div.build-detail div.build-state > span.build-state-failed {
-    background: #a55;
-}
-div.build-detail div.build-state > span.build-state-successful {
-    background: #5a5;
 }
 
 div.build-detail div.build-ideas {

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -54,8 +54,13 @@ $(document).ready(function () {
         </li>
       {% endif %}
 
+      <div data-bind="visible: finished() && success()">
+        <li>
           <a class="" href="{{ build.version.get_absolute_url }}">
+            {% trans "View docs" %}
           </a>
+        </li>
+      </div>
     </ul>
 
     <div class="build-id">

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -55,10 +55,50 @@ $(document).ready(function () {
       {% endif %}
     </ul>
 
-    <div class="build-id">
-      {% blocktrans with build_id=build.pk %}
-        Build #{{ build_id }}
-      {% endblocktrans %}
+    <div class="build-title">
+
+      <span class="build-id">
+        <span class="build-state-normal"
+              data-bind="visible: !finished()">
+          {% blocktrans with build_id=build.pk %}
+            Build #{{ build_id }}
+          {% endblocktrans %}
+        </span>
+
+        <span class="build-state-successful"
+              data-bind="visible: finished() && success()"
+              style="display: none;">
+          {% blocktrans with build_id=build.pk %}
+            Build #{{ build_id }}
+          {% endblocktrans %}
+        </span>
+
+        <span class="build-state-failed"
+              data-bind="visible: finished() && !success()"
+              style="display: none;">
+          {% blocktrans with build_id=build.pk %}
+            Build #{{ build_id }}
+          {% endblocktrans %}
+        </span>
+      </span>
+
+      <span class="build-state-detail">
+        <span data-bind="visible: !finished(), text: state_display"
+              style="display: none;">
+          {{ build.get_state_display }}
+        </span>
+        <img src="{% static 'core/img/loader.gif' %}"
+            data-bind="visible: !finished()"
+            style="display: none;" />
+
+        <span data-bind="visible: finished() && success()"
+              style="display: none;">
+          <a class="" href="{{ build.version.get_absolute_url }}">
+            {% trans "view docs" %}
+          </a>
+        </span>
+      </span>
+
     </div>
 
     <div class="build-version">
@@ -72,28 +112,6 @@ $(document).ready(function () {
       <span class="build-commit"
             data-bind="visible: commit">
         (<span data-bind="text: commit">{{ build.commit }}</span>)
-      </span>
-    </div>
-
-    <div class="build-state">
-      <span>
-        <span data-bind="visible: !finished(), text: state_display"
-              style="display: none;">
-          {{ build.get_state_display }}
-        </span>
-        <img src="{% static 'core/img/loader.gif' %}"
-            data-bind="visible: !finished()"
-            style="display: none;" />
-      </span>
-      <span class="build-state-successful"
-            data-bind="visible: finished() && success()"
-            style="display: none;">
-        {% trans "Build completed" %}
-      </span>
-      <span class="build-state-failed"
-            data-bind="visible: finished() && !success()"
-            style="display: none;">
-        {% trans "Build failed" %}
       </span>
     </div>
 

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -53,52 +53,15 @@ $(document).ready(function () {
           {{ build.builder }}
         </li>
       {% endif %}
+
+          <a class="" href="{{ build.version.get_absolute_url }}">
+          </a>
     </ul>
 
-    <div class="build-title">
-
-      <span class="build-id">
-        <span class="build-state-normal"
-              data-bind="visible: !finished()">
-          {% blocktrans with build_id=build.pk %}
-            Build #{{ build_id }}
-          {% endblocktrans %}
-        </span>
-
-        <span class="build-state-successful"
-              data-bind="visible: finished() && success()"
-              style="display: none;">
-          {% blocktrans with build_id=build.pk %}
-            Build #{{ build_id }}
-          {% endblocktrans %}
-        </span>
-
-        <span class="build-state-failed"
-              data-bind="visible: finished() && !success()"
-              style="display: none;">
-          {% blocktrans with build_id=build.pk %}
-            Build #{{ build_id }}
-          {% endblocktrans %}
-        </span>
-      </span>
-
-      <span class="build-state-detail">
-        <span data-bind="visible: !finished(), text: state_display"
-              style="display: none;">
-          {{ build.get_state_display }}
-        </span>
-        <img src="{% static 'core/img/loader.gif' %}"
-            data-bind="visible: !finished()"
-            style="display: none;" />
-
-        <span data-bind="visible: finished() && success()"
-              style="display: none;">
-          <a class="" href="{{ build.version.get_absolute_url }}">
-            {% trans "view docs" %}
-          </a>
-        </span>
-      </span>
-
+    <div class="build-id">
+      {% blocktrans with build_id=build.pk %}
+        Build #{{ build_id }}
+      {% endblocktrans %}
     </div>
 
     <div class="build-version">
@@ -112,6 +75,28 @@ $(document).ready(function () {
       <span class="build-commit"
             data-bind="visible: commit">
         (<span data-bind="text: commit">{{ build.commit }}</span>)
+      </span>
+    </div>
+
+    <div class="build-state">
+      <span>
+        <span data-bind="visible: !finished(), text: state_display"
+              style="display: none;">
+          {{ build.get_state_display }}
+        </span>
+        <img src="{% static 'core/img/loader.gif' %}"
+            data-bind="visible: !finished()"
+            style="display: none;" />
+      </span>
+      <span class="build-state-successful"
+            data-bind="visible: finished() && success()"
+            style="display: none;">
+        {% trans "Build completed" %}
+      </span>
+      <span class="build-state-failed"
+            data-bind="visible: finished() && !success()"
+            style="display: none;">
+        {% trans "Build failed" %}
       </span>
     </div>
 


### PR DESCRIPTION
This PR is related to #3398 and #2469

For now, I trying to solve this:

> If we're on a build, use the build version for the view docs link! This gets me every time

I think the `View Docs` button must remain the same on all the _project area_, otherwise it would be confusing.

I don't know much css, so any feedback is more than welcome :).

**Here is how it looks right now**

![build-fail](https://user-images.githubusercontent.com/4975310/34318075-46b7c098-e78c-11e7-8f0f-78ca52314f00.png)
![build-progress](https://user-images.githubusercontent.com/4975310/34318077-46df6d5a-e78c-11e7-970d-b02d52146196.png)
![build-success](https://user-images.githubusercontent.com/4975310/34318078-46fd400a-e78c-11e7-93fa-65caf6fcecba.png)

**And how it will looks like after merging**

![build-fail](https://user-images.githubusercontent.com/4975310/34318061-c0370682-e78b-11e7-9f75-d8eb516344a7.png)
![build-progress](https://user-images.githubusercontent.com/4975310/34318062-c0623fdc-e78b-11e7-8497-042d0e79deb7.png)
![build-success](https://user-images.githubusercontent.com/4975310/34318063-c07e5b90-e78b-11e7-836d-138bb059ad48.png)

**This is still _very_ WIP, so any feedback and suggestion is welcome!**