### PR TITLE
Convert default dev cache to local memory

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -202,7 +202,7 @@ class CommunityBaseSettings(Settings):
     # Cache
     CACHES = {
         'default': {
-            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             'PREFIX': 'docs',
         }
     }


### PR DESCRIPTION
This is a basic change that only applies in dev regarding the default cache. This makes caching actually work in development in case anything around caching needs to be verified.

https://docs.djangoproject.com/en/1.8/topics/cache/