### PR TITLE
Move Mercurial dependency to pip.txt

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -34,6 +34,7 @@ dnspython==1.15.0
 
 # VCS
 httplib2==0.7.7
+Mercurial==4.4.2
 
 # Search
 elasticsearch==1.5.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,7 +5,6 @@ pytest-django==3.1.2
 pytest-xdist==1.20.1
 apipkg==1.4
 execnet==1.5.0
-Mercurial==4.4.2
 
 # local debugging tools
 pdbpp


### PR DESCRIPTION
While replicating #3066 I was getting an error because of mercurial missing, a time ago I do this PR #3358 that add mercurial to the tests dependencies, but it's also required for the main project.