### PR TITLE
Add programming language to API/READTHEDOCS_DATA

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -123,6 +123,7 @@ class BaseMkdocs(BaseBuilder):
             'project': self.version.project.slug,
             'version': self.version.slug,
             'language': self.version.project.language,
+            'programming_language': self.version.project.programming_language,
             'page': None,
             'theme': "readthedocs",
             'builder': "mkdocs",

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -93,6 +93,7 @@ context = {
     'slug': '{{ project.slug }}',
     'name': u'{{ project.name }}',
     'rtd_language': u'{{ project.language }}',
+    'programming_language': u'{{ project.programming_language }}',
     'canonical_url': '{{ project.get_canonical_url }}',
     'analytics_code': '{{ project.analytics_code }}',
     'single_version': {{ project.single_version }},

--- a/readthedocs/restapi/serializers.py
+++ b/readthedocs/restapi/serializers.py
@@ -18,7 +18,7 @@ class ProjectSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'name', 'slug', 'description', 'language',
-            'repo', 'repo_type',
+            'programming_language', 'repo', 'repo_type',
             'default_version', 'default_branch',
             'documentation_type',
             'users',

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -560,6 +560,7 @@ class APIVersionTests(TestCase):
                 'install_project': False,
                 'language': 'en',
                 'name': 'Pip',
+                'programming_language': 'words',
                 'python_interpreter': 'python',
                 'repo': 'https://github.com/pypa/pip',
                 'repo_type': 'git',


### PR DESCRIPTION
This adds the programming language of a given project to the API response as well as puts it into the `READTHEDOCS_DATA` global in the `readthedocs-data.js` file in the generated docs output.