### PR TITLE
Fix regex for getting project and user

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -21,8 +21,7 @@ from taggit.managers import TaggableManager
 
 from readthedocs.core.utils import broadcast
 from readthedocs.projects.constants import (
-    BITBUCKET_REGEXS, BITBUCKET_URL, GITHUB_REGEXS, GITHUB_URL, GITLAB_REGEXS,
-    GITLAB_URL, PRIVACY_CHOICES, PRIVATE)
+    BITBUCKET_URL, GITHUB_URL, GITLAB_URL, PRIVACY_CHOICES, PRIVATE)
 from readthedocs.projects.models import APIProject, Project
 
 from .constants import (
@@ -30,6 +29,9 @@ from .constants import (
     NON_REPOSITORY_VERSIONS, STABLE, TAG, VERSION_TYPES)
 from .managers import VersionManager
 from .querysets import BuildQuerySet, RelatedBuildQuerySet, VersionQuerySet
+from .utils import (
+    get_bitbucket_username_repo, get_github_username_repo,
+    get_gitlab_username_repo)
 from .version_slug import VersionSlugField
 
 DEFAULT_VERSION_PRIVACY_LEVEL = getattr(
@@ -277,12 +279,8 @@ class Version(models.Model):
         elif action == 'edit':
             action_string = 'edit'
 
-        for regex in GITHUB_REGEXS:
-            match = regex.search(repo_url)
-            if match:
-                user, repo = match.groups()
-                break
-        else:
+        user, repo = get_github_username_repo(repo_url)
+        if not user and not repo:
             return ''
         repo = repo.rstrip('/')
 
@@ -315,12 +313,8 @@ class Version(models.Model):
         elif action == 'edit':
             action_string = 'edit'
 
-        for regex in GITLAB_REGEXS:
-            match = regex.search(repo_url)
-            if match:
-                user, repo = match.groups()
-                break
-        else:
+        user, repo = get_gitlab_username_repo(repo_url)
+        if not user and not repo:
             return ''
         repo = repo.rstrip('/')
 
@@ -341,12 +335,8 @@ class Version(models.Model):
         if not docroot:
             return ''
 
-        for regex in BITBUCKET_REGEXS:
-            match = regex.search(repo_url)
-            if match:
-                user, repo = match.groups()
-                break
-        else:
+        user, repo = get_bitbucket_username_repo(repo_url)
+        if not user and not repo:
             return ''
         repo = repo.rstrip('/')
 

--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -4,32 +4,13 @@
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
-import re
-
-GH_REGEXS = [
-    re.compile('github.com/(.+)/(.+)(?:\.git){1}$'),
-    re.compile('github.com/(.+)/(.+)'),
-    re.compile('github.com:(.+)/(.+).git$'),
-]
-
-BB_REGEXS = [
-    re.compile('bitbucket.org/(.+)/(.+)/'),
-    re.compile('bitbucket.org/(.+)/(.+)'),
-    re.compile('bitbucket.org:(.+)/(.+)\.git$'),
-]
-
-# TODO: I think this can be different than `gitlab.com`
-# self.adapter.provider_base_url
-GL_REGEXS = [
-    re.compile('gitlab.com/(.+)/(.+)(?:\.git){1}$'),
-    re.compile('gitlab.com/(.+)/(.+)'),
-    re.compile('gitlab.com:(.+)/(.+)\.git$'),
-]
+from readthedocs.projects.constants import (
+    BITBUCKET_REGEXS, GITHUB_REGEXS, GITLAB_REGEXS)
 
 
 def get_github_username_repo(url):
     if 'github' in url:
-        for regex in GH_REGEXS:
+        for regex in GITHUB_REGEXS:
             match = regex.search(url)
             if match:
                 return match.groups()
@@ -38,7 +19,7 @@ def get_github_username_repo(url):
 
 def get_bitbucket_username_repo(url=None):
     if 'bitbucket' in url:
-        for regex in BB_REGEXS:
+        for regex in BITBUCKET_REGEXS:
             match = regex.search(url)
             if match:
                 return match.groups()
@@ -47,7 +28,7 @@ def get_bitbucket_username_repo(url=None):
 
 def get_gitlab_username_repo(url=None):
     if 'gitlab' in url:
-        for regex in GL_REGEXS:
+        for regex in GITLAB_REGEXS:
             match = regex.search(url)
             if match:
                 return match.groups()

--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -7,23 +7,23 @@ from __future__ import (
 import re
 
 GH_REGEXS = [
-    re.compile('github.com/(.+)/(.+)(?:\.git){1}'),
+    re.compile('github.com/(.+)/(.+)(?:\.git){1}$'),
     re.compile('github.com/(.+)/(.+)'),
-    re.compile('github.com:(.+)/(.+).git'),
+    re.compile('github.com:(.+)/(.+).git$'),
 ]
 
 BB_REGEXS = [
     re.compile('bitbucket.org/(.+)/(.+)/'),
     re.compile('bitbucket.org/(.+)/(.+)'),
-    re.compile('bitbucket.org:(.+)/(.+)\.git'),
+    re.compile('bitbucket.org:(.+)/(.+)\.git$'),
 ]
 
 # TODO: I think this can be different than `gitlab.com`
 # self.adapter.provider_base_url
 GL_REGEXS = [
-    re.compile('gitlab.com/(.+)/(.+)(?:\.git){1}'),
+    re.compile('gitlab.com/(.+)/(.+)(?:\.git){1}$'),
     re.compile('gitlab.com/(.+)/(.+)'),
-    re.compile('gitlab.com:(.+)/(.+)\.git'),
+    re.compile('gitlab.com:(.+)/(.+)\.git$'),
 ]
 
 

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -297,6 +297,7 @@ GITHUB_REGEXS = [
     re.compile('github.com:(.+)/(.+).git$'),
 ]
 BITBUCKET_REGEXS = [
+    re.compile('@bitbucket.org/(.+)/(.+)\.git$'),
     re.compile('bitbucket.org/(.+)/(.+)/'),
     re.compile('bitbucket.org/(.+)/(.+)'),
     re.compile('bitbucket.org:(.+)/(.+)\.git$'),

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -292,19 +292,19 @@ PROJECT_PK_REGEX = '(?:[-\w]+)'
 PROJECT_SLUG_REGEX = '(?:[-\w]+)'
 
 GITHUB_REGEXS = [
-    re.compile('github.com/(.+)/(.+)(?:\.git){1}'),
+    re.compile('github.com/(.+)/(.+)(?:\.git){1}$'),
     re.compile('github.com/(.+)/(.+)'),
-    re.compile('github.com:(.+)/(.+).git'),
+    re.compile('github.com:(.+)/(.+).git$'),
 ]
 BITBUCKET_REGEXS = [
-    re.compile('bitbucket.org/(.+)/(.+).git'),
     re.compile('bitbucket.org/(.+)/(.+)/'),
     re.compile('bitbucket.org/(.+)/(.+)'),
+    re.compile('bitbucket.org:(.+)/(.+)\.git$'),
 ]
 GITLAB_REGEXS = [
-    re.compile('gitlab.com/(.+)/(.+)(?:\.git){1}'),
+    re.compile('gitlab.com/(.+)/(.+)(?:\.git){1}$'),
     re.compile('gitlab.com/(.+)/(.+)'),
-    re.compile('gitlab.com:(.+)/(.+).git'),
+    re.compile('gitlab.com:(.+)/(.+)\.git$'),
 ]
 GITHUB_URL = (
     'https://github.com/{user}/{repo}/'

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -294,7 +294,7 @@ PROJECT_SLUG_REGEX = '(?:[-\w]+)'
 GITHUB_REGEXS = [
     re.compile('github.com/(.+)/(.+)(?:\.git){1}$'),
     re.compile('github.com/(.+)/(.+)'),
-    re.compile('github.com:(.+)/(.+).git$'),
+    re.compile('github.com:(.+)/(.+)\.git$'),
 ]
 BITBUCKET_REGEXS = [
     re.compile('@bitbucket.org/(.+)/(.+)\.git$'),

--- a/readthedocs/rtd_tests/tests/test_repo_parsing.py
+++ b/readthedocs/rtd_tests/tests/test_repo_parsing.py
@@ -37,6 +37,13 @@ class TestRepoParsing(TestCase):
         self.pip.repo = 'https://github.com/user/repo.git.git'
         self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo.git/blob/master/docs/file.rst')
 
+    def test_github_ssh(self):
+        self.pip.repo = 'git@github.com:user/repo.git'
+        self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo/blob/master/docs/file.rst')
+
+        self.pip.repo = 'git@github.com:user/repo.github.io.git'
+        self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo.github.io/blob/master/docs/file.rst')
+
     def test_gitlab(self):
         self.pip.repo = 'https://gitlab.com/user/repo'
         self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo/blob/master/foo/bar/file.rst')
@@ -59,6 +66,13 @@ class TestRepoParsing(TestCase):
         self.pip.repo = 'https://gitlab.com/user/repo.git.git'
         self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo.git/blob/master/foo/bar/file.rst')
 
+    def test_gitlab_ssh(self):
+        self.pip.repo = 'git@gitlab.com:user/repo.git'
+        self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo/blob/master/foo/bar/file.rst')
+
+        self.pip.repo = 'git@gitlab.com:user/repo.gitlab.io.git'
+        self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo.gitlab.io/blob/master/foo/bar/file.rst')
+
     def test_bitbucket(self):
         self.pip.repo = 'https://bitbucket.org/user/repo'
         self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo/src/master/foo/bar/file.rst')
@@ -80,3 +94,17 @@ class TestRepoParsing(TestCase):
 
         self.pip.repo = 'https://bitbucket.org/user/repo.git.git'
         self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git.git/src/master/foo/bar/file.rst')
+
+    def test_bitbucket_https(self):
+        self.pip.repo = 'https://user@bitbucket.org/user/repo.git'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo/src/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://user@bitbucket.org/user/repo.gitbucket.io.git'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io/src/master/foo/bar/file.rst')
+
+    def test_bitbucket_ssh(self):
+        self.pip.repo = 'git@bitbucket.org:user/repo.git'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo/src/master/foo/bar/file.rst')
+
+        self.pip.repo = 'git@bitbucket.org:user/repo.gitbucket.io.git'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io/src/master/foo/bar/file.rst')

--- a/readthedocs/rtd_tests/tests/test_repo_parsing.py
+++ b/readthedocs/rtd_tests/tests/test_repo_parsing.py
@@ -22,8 +22,20 @@ class TestRepoParsing(TestCase):
         self.pip.repo = 'https://github.com/user/repo/'
         self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo/blob/master/docs/file.rst')
 
+        self.pip.repo = 'https://github.com/user/repo.github.io'
+        self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo.github.io/blob/master/docs/file.rst')
+
+        self.pip.repo = 'https://github.com/user/repo.github.io/'
+        self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo.github.io/blob/master/docs/file.rst')
+
         self.pip.repo = 'https://github.com/user/repo.git'
         self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo/blob/master/docs/file.rst')
+
+        self.pip.repo = 'https://github.com/user/repo.github.io.git'
+        self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo.github.io/blob/master/docs/file.rst')
+
+        self.pip.repo = 'https://github.com/user/repo.git.git'
+        self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo.git/blob/master/docs/file.rst')
 
     def test_gitlab(self):
         self.pip.repo = 'https://gitlab.com/user/repo'
@@ -32,8 +44,20 @@ class TestRepoParsing(TestCase):
         self.pip.repo = 'https://gitlab.com/user/repo/'
         self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo/blob/master/foo/bar/file.rst')
 
+        self.pip.repo = 'https://gitlab.com/user/repo.gitlab.io'
+        self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo.gitlab.io/blob/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://gitlab.com/user/repo.gitlab.io/'
+        self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo.gitlab.io/blob/master/foo/bar/file.rst')
+
         self.pip.repo = 'https://gitlab.com/user/repo.git'
         self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo/blob/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://gitlab.com/user/repo.gitlab.io.git'
+        self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo.gitlab.io/blob/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://gitlab.com/user/repo.git.git'
+        self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo.git/blob/master/foo/bar/file.rst')
 
     def test_bitbucket(self):
         self.pip.repo = 'https://bitbucket.org/user/repo'
@@ -42,6 +66,17 @@ class TestRepoParsing(TestCase):
         self.pip.repo = 'https://bitbucket.org/user/repo/'
         self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo/src/master/foo/bar/file.rst')
 
-        self.pip.repo = 'https://bitbucket.org/user/repo.git'
-        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo/src/master/foo/bar/file.rst')
+        self.pip.repo = 'https://bitbucket.org/user/repo.gitbucket.io'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io/src/master/foo/bar/file.rst')
 
+        self.pip.repo = 'https://bitbucket.org/user/repo.gitbucket.io/'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io/src/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://bitbucket.org/user/repo.git'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git/src/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://bitbucket.org/user/repo.gitbucket.io.git'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io.git/src/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://bitbucket.org/user/repo.git.git'
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git.git/src/master/foo/bar/file.rst')


### PR DESCRIPTION
Fix #1788 

This happens when a project name contains `.git` in the middle of the name, like `some.github`, `hello.git.hello`.

For the record:

- If you create a repo like `name.git` in GitHub, the name changes to `name`.
- GitLab don't allow to create a repo that ends on `.git'
- Bitbucket allow to create a repo like `name.git`, but the clone url is fine.

I want to add some tests to this, but I don't know where to add them.