### PR TITLE
Consistent version format

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/version-compare.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/version-compare.js
@@ -23,7 +23,7 @@ function init(data) {
     warning
       .find('a')
       .attr('href', currentURL)
-      .text(data.version);
+      .text(data.slug);
 
     var body = $("div.body");
     if (!body.length) {

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -43,7 +43,7 @@ def get_version_compare_data(project, base_version=None):
     }
     if highest_version_obj:
         ret_val['url'] = highest_version_obj.get_absolute_url()
-        ret_val['slug'] = (highest_version_obj.slug,)
+        ret_val['slug'] = highest_version_obj.slug
     if base_version and base_version.slug != LATEST:
         try:
             base_version_comparable = parse_version_failsafe(

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -104,7 +104,7 @@ class TestVersionCompareFooter(TestCase):
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
             'url': '/dashboard/pip/version/0.8.1/',
-            'slug': ('0.8.1',),
+            'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': True,
         }
@@ -116,7 +116,7 @@ class TestVersionCompareFooter(TestCase):
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
             'url': '/dashboard/pip/version/0.8.1/',
-            'slug': ('0.8.1',),
+            'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': False,
         }
@@ -129,7 +129,7 @@ class TestVersionCompareFooter(TestCase):
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
             'url': '/dashboard/pip/version/0.8.1/',
-            'slug': ('0.8.1',),
+            'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': True,
         }
@@ -157,7 +157,7 @@ class TestVersionCompareFooter(TestCase):
         valid_data = {
             'project': 'Version 1.0.0 of Pip ({})'.format(version.pk),
             'url': '/dashboard/pip/version/1.0.0/',
-            'slug': ('1.0.0',),
+            'slug': '1.0.0',
             'version': '1.0.0',
             'is_highest': False,
         }
@@ -171,7 +171,7 @@ class TestVersionCompareFooter(TestCase):
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
             'url': '/dashboard/pip/version/0.8.1/',
-            'slug': ('0.8.1',),
+            'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': True,
         }
@@ -182,7 +182,7 @@ class TestVersionCompareFooter(TestCase):
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
             'url': '/dashboard/pip/version/0.8.1/',
-            'slug': ('0.8.1',),
+            'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': False,
         }
@@ -199,7 +199,7 @@ class TestVersionCompareFooter(TestCase):
         valid_data = {
             'project': 'Version 2.0.0 of Pip ({})'.format(version.pk),
             'url': '/dashboard/pip/version/2.0.0/',
-            'slug': ('2.0.0',),
+            'slug': '2.0.0',
             'version': '2.0.0',
             'is_highest': False,
         }


### PR DESCRIPTION
This closes #2357 

A time ago travis failed, so this #3402 was proposed. Now while looking at #2357 I think we only need to return a single value (a version only have a single unique slug).

The js, didn't break because of some weird js implicit cast.

```js
var currentURL = window.location.pathname.replace('rtfd', ['hi'])
console.log(currentURL)
// This works!
```

But as mentioned on the spec, must be a string not a list https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace.

Note: Thanks @lethosor for his initial work on this https://github.com/lethosor/readthedocs.org/commit/7d84130471885905a3f663324af602b7be1f7f64