### PR TITLE
Docs: Rename "Good First Bug" to "Good First Issue"

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -209,7 +209,7 @@ few more at hand to further categorize issues.
     have the resources to work on. We encourage community members to work
     on these tickets and to submit a pull request.
 
-*Good First Bug*
+*Good First Issue*
     This label marks tickets that are easy to get started with. The ticket
     should be ideal for beginners to dive into the code base. Better is if the
     fix for the issue only involves touching one part of the code.

--- a/docs/issue-labels.rst
+++ b/docs/issue-labels.rst
@@ -32,7 +32,7 @@ what they stand for.
     idea. See the milestone of the feature overview ticket for all related
     tickets.
 
-*Good First Bug*
+*Good First Issue*
     This label marks tickets that are easy to get started with. The ticket
     should be ideal for beginners to dive into the code base.
 


### PR DESCRIPTION
We use the name "Good First issue", not "Good first bug". I think we should also add a link to the issues, like this: rtfd/readthedocs.org/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Good+First+Issue%22+.

_No idea why my PR tool isn't working. Sorry if an initial email seemed different._