### PR TITLE
Move project description to the top

### DIFF
--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -14,6 +14,16 @@
   <!-- END onboard -->
   {% endif %}
 
+  <div id="project_description">
+    {% if project.description %}
+      <h3>{% trans "Description" %}</h3>
+      <div id="project_description">
+        <p>
+          {{ project.description|restructuredtext }}
+        </p>
+      </div>
+    {% endif %}
+  </div>
 
   <div class="module-header">
     <h3>{% trans "Versions" %}</h3>
@@ -72,17 +82,6 @@
   </div>
 {% endif %}
 {% endblock %}
-
-<div id="project_description">
-{% if project.description %}
-  <h3>{% trans "Description" %}</h3>
-  <div id="project_description">
-  <p>
-    {{ project.description|restructuredtext }}
-  </p>
-  </div>
-{% endif %}
-</div>
 
 
 </div>{# END .module #}


### PR DESCRIPTION
When there are many versions, is difficult to see the project description.

For example: http://readthedocs.org/projects/django-cms/

This is how the change looks
![screenshot-2018-1-12 blog read the docs](https://user-images.githubusercontent.com/4975310/34896538-33ccd068-f7b8-11e7-9e0a-2893ef318195.png)

Probably _could be_ a problem, if the project contains a very large description, which I haven't seen till now.
