### PR TITLE
Remove outline reset to bring back outline

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -12,8 +12,6 @@ blockquote, q {quotes:"" "";}
 a img {border:none;}
 ol,ul{list-style:none}
 hr { height: 1px; border: 0; border: none; width: 100%; background: #bfbfbf; color: #bfbfbf; margin: 15px 0; padding: 0; }
-*:focus { outline: none; }
-
 
 /* general layout */
 


### PR DESCRIPTION
This PR removes the outline reset for the main site. 

This is needed to improve accessibility of the site. Outline is much needed for a lot of keyboard-only users and should not be removed. It's only allowed to be reset if you actually restyle it. 

Read more: http://www.outlinenone.com/
