### PR TITLE
Remove RTD Theme workaround

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -19,6 +19,12 @@
 	margin: 0;
 }
 
+
+/* Fix RTD theme versions below 0.2.5 bottom margin */		
+.rst-content .line-block {		
+	margin-bottom: 24px		
+}		
+
 /* Fix for nav bottom padding with flyout */
 nav.wy-nav-side {
     padding-bottom: 3em;

--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -19,12 +19,6 @@
 	margin: 0;
 }
 
-
-/* Fix RTD theme bottom margin */
-.rst-content .line-block {
-	margin-bottom: 24px
-}
-
 /* Fix for nav bottom padding with flyout */
 nav.wy-nav-side {
     padding-bottom: 3em;

--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -20,10 +20,10 @@
 }
 
 
-/* Fix RTD theme versions below 0.2.5 bottom margin */		
-.rst-content .line-block {		
-	margin-bottom: 24px		
-}		
+/* Fix RTD theme versions below 0.2.5 bottom margin */
+.rst-content .line-block {
+	margin-bottom: 24px;
+}
 
 /* Fix for nav bottom padding with flyout */
 nav.wy-nav-side {


### PR DESCRIPTION
This should be merged after https://github.com/rtfd/sphinx_rtd_theme/pull/380 and we use a new release of the theme.