### PR TITLE
Log `git checkout` and expose to users

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -75,7 +75,7 @@ An example in code:
 
 .. code-block:: python
 
-    update_imported_docs(version)
+    update_docs_from_vcs(version)
     if exists('setup.py'):
         run('python setup.py install')
     if project.requirements_file:

--- a/readthedocs/core/management/commands/pull.py
+++ b/readthedocs/core/management/commands/pull.py
@@ -20,8 +20,6 @@ class Command(BaseCommand):
         if args:
             for slug in args:
                 version = utils.version_from_slug(slug, LATEST)
-                tasks.UpdateDocsTask().run(
-                    version.project,
+                tasks.SyncRepositoryTask().run(
                     version.pk,
-                    sync_only=True,
                 )

--- a/readthedocs/core/management/commands/pull.py
+++ b/readthedocs/core/management/commands/pull.py
@@ -19,6 +19,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if args:
             for slug in args:
-                tasks.update_imported_docs(
-                    utils.version_from_slug(slug, LATEST).pk
+                version = utils.version_from_slug(slug, LATEST)
+                tasks.UpdateDocsTask().run(
+                    version.project,
+                    version.pk,
+                    sync_only=True,
                 )

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -12,7 +12,7 @@ from readthedocs.core.utils import trigger_build
 from readthedocs.builds.constants import LATEST
 from readthedocs.projects import constants
 from readthedocs.projects.models import Project, Feature
-from readthedocs.projects.tasks import UpdateDocsTask
+from readthedocs.projects.tasks import SyncRepositoryTask
 
 import logging
 
@@ -123,15 +123,11 @@ def _build_url(url, projects, branches):
     for project in projects:
         (built, not_building) = build_branches(project, branches)
         if not built:
-            # Call UpdateDocsTask with ``sync_only`` to update tag/branch info
+            # Call SyncRepositoryTask to update tag/branch info
             version = project.versions.get(slug=LATEST)
-            update_docs = UpdateDocsTask()
-            update_docs.apply_async(
-                args=(project.pk,),
-                kwargs={
-                    'version_pk': version.pk,
-                    'sync_only': True,
-                },
+            sync_repository = SyncRepositoryTask()
+            sync_repository.apply_async(
+                args=(version.pk,),
             )
             msg = '(URL Build) Syncing versions for %s' % project.slug
             log.info(msg)

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -473,12 +473,11 @@ class BuildEnvironment(BaseEnvironment):
         })
         return super(BuildEnvironment, self).run(*cmd, **kwargs)
 
-    def run_command_class(self, *cmd, **kwargs):
+    def run_command_class(self, *cmd, **kwargs):  # pylint: disable=arguments-differ
         kwargs.update({
             'build_env': self,
         })
         return super(BuildEnvironment, self).run_command_class(*cmd, **kwargs)
-
 
     @property
     def successful(self):

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -270,9 +270,10 @@ class DockerBuildCommand(BuildCommand):
 
 class BaseEnvironment(object):
 
-    def __init__(self, project=None):
+    def __init__(self, project, environment=None):
         # TODO: maybe we can remove this Project dependency also
         self.project = project
+        self.environment = environment or {}
 
     def record_command(self, command):
         pass

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -273,6 +273,12 @@ class DockerBuildCommand(BuildCommand):
 
 class BaseEnvironment(object):
 
+    """
+    Base environment class.
+
+    Used to run arbitrary commands outside a build.
+    """
+
     def __init__(self, project, environment=None):
         # TODO: maybe we can remove this Project dependency also
         self.project = project
@@ -550,7 +556,7 @@ class BuildEnvironment(BaseEnvironment):
 
 class LocalBuildEnvironment(BuildEnvironment):
 
-    """Local execution environment."""
+    """Local execution build environment."""
 
     command_class = BuildCommand
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -274,6 +274,7 @@ class BaseEnvironment(object):
         # TODO: maybe we can remove this Project dependency also
         self.project = project
         self.environment = environment or {}
+        self.commands = []
 
     def record_command(self, command):
         pass
@@ -373,7 +374,9 @@ class BuildEnvironment(BaseEnvironment):
         self.environment = environment or {}
         self.update_on_success = update_on_success
 
+        # TODO: remove this one, comes from super
         self.commands = []
+
         self.failure = None
         self.start_time = datetime.utcnow()
 
@@ -409,6 +412,10 @@ class BuildEnvironment(BaseEnvironment):
             if not issubclass(exc_type, BuildEnvironmentWarning):
                 self.failure = exc_value
             return True
+
+    def record_command(self, command):
+        if self.record:
+            command.save()
 
     def run(self, *cmd, **kwargs):
         kwargs.update({

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -409,16 +409,12 @@ class BuildEnvironment(BaseEnvironment):
 
     def __init__(self, project=None, version=None, build=None, config=None,
                  record=True, environment=None, update_on_success=True):
-        self.project = project
+        super(BuildEnvironment, self).__init__(project, environment)
         self.version = version
         self.build = build
         self.config = config
         self.record = record
-        self.environment = environment or {}
         self.update_on_success = update_on_success
-
-        # TODO: remove this one, comes from super
-        self.commands = []
 
         self.failure = None
         self.start_time = datetime.utcnow()

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Documentation Builder Environments."""
 
 from __future__ import absolute_import
@@ -14,7 +16,7 @@ from datetime import datetime
 
 from readthedocs.core.utils import slugify
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _, ugettext_noop
+from django.utils.translation import ugettext_lazy as _
 from docker import Client
 from docker.utils import create_host_config
 from docker.errors import APIError as DockerAPIError, DockerException
@@ -40,7 +42,8 @@ log = logging.getLogger(__name__)
 __all__ = (
     'api_v2',
     'BuildCommand', 'DockerBuildCommand',
-    'BuildEnvironment', 'LocalBuildEnvironment', 'DockerBuildEnvironment',
+    'LocalEnvironment',
+    'LocalBuildEnvironment', 'DockerBuildEnvironment',
 )
 
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -288,6 +288,13 @@ class BaseEnvironment(object):
     def record_command(self, command):
         pass
 
+    def _log_warn_only(self, msg):
+        log.warning(LOG_TEMPLATE.format(
+            project=self.project.slug,
+            version='latest',
+            msg=msg,
+        ))
+
     def run(self, *cmd, **kwargs):
         """Shortcut to run command from environment."""
         return self.run_command_class(cls=self.command_class, cmd=cmd, **kwargs)
@@ -333,11 +340,7 @@ class BaseEnvironment(object):
                 msg += u':\n{out}'.format(out=build_cmd.output)
 
             if warn_only:
-                # TODO: remove version dependency to log here
-                log.warning(LOG_TEMPLATE
-                            .format(project=self.project.slug,
-                                    version=self.version.slug,
-                                    msg=msg))
+                self._log_warn_only(msg)
             else:
                 raise BuildEnvironmentWarning(msg)
         return build_cmd
@@ -434,6 +437,14 @@ class BuildEnvironment(BaseEnvironment):
     def record_command(self, command):
         if self.record:
             command.save()
+
+    def _log_warn_only(self, msg):
+        # :'(
+        log.warning(LOG_TEMPLATE.format(
+            project=self.project.slug,
+            version=self.version.slug,
+            msg=msg,
+        ))
 
     def run(self, *cmd, **kwargs):
         kwargs.update({

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -306,7 +306,16 @@ class BaseEnvironment(object):
         build_cmd.run()
 
         # TODO: I don't like how it's handled this entry point here
-        self.record_command(build_cmd)
+        if not warn_only:
+            # TODO: maybe receive ``record`` as an attribute for skip/record
+            # just specific commands but not all of them ran under the
+            # *BuildEnvironment
+
+            # TODO: do we want to save commands that FAILED but not raised and
+            # exception?  This will cause the first `git status` (when
+            # importing) to fail and be marked with RED in the Build command
+            # details
+            self.record_command(build_cmd)
 
         if build_cmd.failed:
             msg = u'Command {cmd} failed'.format(cmd=build_cmd.get_command())

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -270,9 +270,6 @@ class DockerBuildCommand(BuildCommand):
 
 class BaseEnvironment(object):
 
-    # TODO: BuildCommand name doesn't make sense here, should be just Command
-    command_class = BuildCommand
-
     def __init__(self, project=None):
         # TODO: maybe we can remove this Project dependency also
         self.project = project
@@ -324,6 +321,12 @@ class BaseEnvironment(object):
             else:
                 raise BuildEnvironmentWarning(msg)
         return build_cmd
+
+
+class LocalEnvironment(BaseEnvironment):
+
+    # TODO: BuildCommand name doesn't make sense here, should be just Command
+    command_class = BuildCommand
 
 
 class BuildEnvironment(BaseEnvironment):

--- a/readthedocs/projects/apps.py
+++ b/readthedocs/projects/apps.py
@@ -7,6 +7,7 @@ class ProjectsConfig(AppConfig):
     name = 'readthedocs.projects'
 
     def ready(self):
-        from readthedocs.projects.tasks import UpdateDocsTask
+        from readthedocs.projects import tasks
         from readthedocs.worker import app
-        app.tasks.register(UpdateDocsTask)
+        app.tasks.register(tasks.SyncRepositoryTask)
+        app.tasks.register(tasks.UpdateDocsTask)

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -613,7 +613,6 @@ class Project(models.Model):
         :param version: version slug for the backend (``LATEST`` by default)
         :type version: str
         """
-
         # TODO: this seems to be the only method that receives a
         # ``version.slug`` instead of a ``Version`` instance (I prefer an
         # instance here)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -227,7 +227,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     def run(self, pk, version_pk=None, build_pk=None, record=True,
             docker=False, search=True, force=False, localmedia=True, **__):
         """
-        Run a documentation sync or sync n' build.
+        Run a documentation sync n' build.
 
         This is fully wrapped in exception handling to account for a number of
         failure cases. We first run a few commands in a local build environment,
@@ -235,13 +235,12 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         build output page where the build is marked as finished in between the
         local environment steps and the docker build steps.
 
-        If a failure is raised, or the build is not successful, return ``False``,
-        otherwise, ``True``.
+        If a failure is raised, or the build is not successful, return
+        ``False``, otherwise, ``True``.
 
         Unhandled exceptions raise a generic user facing error, which directs
         the user to bug us. It is therefore a benefit to have as few unhandled
         errors as possible.
-
 
         :param pk int: Project id
         :param version_pk int: Project Version id (latest if None)
@@ -251,7 +250,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         :param search bool: update search
         :param force bool: force Sphinx build
         :param localmedia bool: update localmedia
+
         :returns: whether build was successful or not
+
         :rtype: bool
         """
         try:

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -45,8 +45,8 @@ from readthedocs.core.symlink import PublicSymlink, PrivateSymlink
 from readthedocs.core.utils import send_email, broadcast
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.constants import DOCKER_LIMITS
-from readthedocs.doc_builder.environments import (LocalEnvironment,
-                                                  DockerEnvironment)
+from readthedocs.doc_builder.environments import (LocalBuildEnvironment,
+                                                  DockerBuildEnvironment)
 from readthedocs.doc_builder.exceptions import BuildEnvironmentError
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.doc_builder.python_environments import Virtualenv, Conda
@@ -186,7 +186,7 @@ class UpdateDocsTask(Task):
 
         Return True if successful.
         """
-        self.setup_env = LocalEnvironment(
+        self.setup_env = LocalBuildEnvironment(
             project=self.project,
             version=self.version,
             build=self.build,
@@ -241,9 +241,9 @@ class UpdateDocsTask(Task):
         env_vars = self.get_env_vars()
 
         if docker or settings.DOCKER_ENABLE:
-            env_cls = DockerEnvironment
+            env_cls = DockerBuildEnvironment
         else:
-            env_cls = LocalEnvironment
+            env_cls = LocalBuildEnvironment
         self.build_env = env_cls(project=self.project, version=self.version, config=self.config,
                                  build=self.build, record=record, environment=env_vars)
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -335,7 +335,7 @@ class UpdateDocsTask(Task):
         self.setup_env.update_build(state=BUILD_STATE_CLONING)
 
         self._log(msg='Updating docs from VCS')
-        update_imported_docs(self.version.pk)
+        update_imported_docs(self.version.pk, self.setup_env)
         commit = self.project.vcs_repo(self.version.slug).commit
         if commit:
             self.build['commit'] = commit
@@ -550,7 +550,7 @@ class UpdateDocsTask(Task):
 
 
 @app.task()
-def update_imported_docs(version_pk):
+def update_imported_docs(version_pk, env=None):
     """
     Check out or update the given project's repository.
 
@@ -593,7 +593,7 @@ def update_imported_docs(version_pk):
                 version_slug = version.slug
                 version_repo = project.vcs_repo(version_slug)
 
-                ret_dict['checkout'] = version_repo.checkout(version.identifier)
+                ret_dict['checkout'] = version_repo.checkout(version.identifier, env)
             else:
                 # Does this ever get called?
                 log.info(LOG_TEMPLATE.format(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -65,9 +65,7 @@ HTML_ONLY = getattr(settings, 'HTML_ONLY_PROJECTS', ())
 
 class SyncRepositoryMixin(object):
 
-    """
-    Mixin that handles the VCS sync/update.
-    """
+    """Mixin that handles the VCS sync/update."""
 
     @staticmethod
     def get_version(project=None, version_pk=None):
@@ -91,9 +89,7 @@ class SyncRepositoryMixin(object):
         return APIVersion(**version_data)
 
     def sync_repo(self):
-        """
-        Checkout/update the project's repository and hit ``sync_versions`` API.
-        """
+        """Update the project's repository and hit ``sync_versions`` API."""
         # Make Dirs
         if not os.path.exists(self.project.doc_path):
             os.makedirs(self.project.doc_path)
@@ -158,15 +154,13 @@ class SyncRepositoryMixin(object):
 
 class SyncRepositoryTask(SyncRepositoryMixin, Task):
 
-    """
-    Entry point to synchronize the VCS documentation.
-    """
+    """Entry point to synchronize the VCS documentation."""
 
     max_retries = 5
     default_retry_delay = (7 * 60)
     name = __name__ + '.sync_repository'
 
-    def run(self, version_pk):
+    def run(self, version_pk):  # pylint: disable=arguments-differ
         """
         Run the VCS synchronization.
 
@@ -272,7 +266,6 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             setup_successful = self.run_setup(record=record)
             if not setup_successful:
                 return False
-
 
         # Catch unhandled errors in the setup step
         except Exception as e:  # noqa

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -9,7 +9,7 @@ from django_dynamic_fixture import fixture
 
 from readthedocs.projects.models import Project
 from readthedocs.doc_builder.config import ConfigWrapper
-from readthedocs.doc_builder.environments import LocalEnvironment
+from readthedocs.doc_builder.environments import LocalBuildEnvironment
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.projects.tasks import UpdateDocsTask
@@ -41,7 +41,7 @@ class BuildEnvironmentTests(TestCase):
         })
         self.mocks.patches['html_build'].stop()
 
-        build_env = LocalEnvironment(project=project, version=version, build={})
+        build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
@@ -65,7 +65,7 @@ class BuildEnvironmentTests(TestCase):
                       versions=[fixture()])
         version = project.versions.all()[0]
 
-        build_env = LocalEnvironment(project=project, version=version, build={})
+        build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
@@ -90,7 +90,7 @@ class BuildEnvironmentTests(TestCase):
                       versions=[fixture()])
         version = project.versions.all()[0]
 
-        build_env = LocalEnvironment(project=project, version=version, build={})
+        build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
@@ -114,7 +114,7 @@ class BuildEnvironmentTests(TestCase):
                       versions=[fixture()])
         version = project.versions.all()[0]
 
-        build_env = LocalEnvironment(project=project, version=version, build={})
+        build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load({
             'formats': ['epub']
@@ -136,7 +136,7 @@ class BuildEnvironmentTests(TestCase):
                       allow_comments=True,
                       versions=[fixture()])
         version = project.versions.all()[0]
-        build_env = LocalEnvironment(version=version, project=project, build={})
+        build_env = LocalBuildEnvironment(version=version, project=project, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         builder_class = get_builder_class(project.documentation_type)
         builder = builder_class(build_env, python_env)
@@ -149,7 +149,7 @@ class BuildEnvironmentTests(TestCase):
                       allow_comments=False,
                       versions=[fixture()])
         version = project.versions.all()[0]
-        build_env = LocalEnvironment(version=version, project=project, build={})
+        build_env = LocalBuildEnvironment(version=version, project=project, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         builder_class = get_builder_class(project.documentation_type)
         builder = builder_class(build_env, python_env)
@@ -171,7 +171,7 @@ class BuildEnvironmentTests(TestCase):
         version = project.versions.all()[0]
         assert project.conf_dir() == '/tmp/rtd'
 
-        build_env = LocalEnvironment(project=project, version=version, build={})
+        build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
@@ -213,7 +213,7 @@ class BuildEnvironmentTests(TestCase):
         version = project.versions.all()[0]
         assert project.conf_dir() == '/tmp/rtd'
 
-        build_env = LocalEnvironment(project=project, version=version, build={})
+        build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
         task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django_dynamic_fixture import get
 from mock import patch, MagicMock
 
-from readthedocs.builds.constants import BUILD_STATE_INSTALLING, BUILD_STATE_FINISHED
+from readthedocs.builds.constants import BUILD_STATE_INSTALLING, BUILD_STATE_FINISHED, LATEST
 from readthedocs.builds.models import Build
 from readthedocs.projects.models import Project
 from readthedocs.projects import tasks
@@ -115,11 +115,11 @@ class TestCeleryBuilding(RTDTestCase):
                 intersphinx=False)
         self.assertTrue(result.successful())
 
-    def test_update_imported_doc(self):
+    def test_sync_repository(self):
+        version = self.project.versions.get(slug=LATEST)
         with mock_api(self.repo):
-            update_docs = tasks.UpdateDocsTask()
-            result = update_docs.apply_async(
-                args=(self.project.pk,),
-                kwargs={'sync_only': True},
+            sync_repository = tasks.SyncRepositoryTask()
+            result = sync_repository.apply_async(
+                args=(version.pk,),
             )
         self.assertTrue(result.successful())

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -64,7 +64,7 @@ class TestCeleryBuilding(RTDTestCase):
         self.assertTrue(result.successful())
         self.assertFalse(exists(directory))
 
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_environment', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_python_environment', new=MagicMock)
     @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs', new=MagicMock)
     @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs', new=MagicMock)
     def test_update_docs(self):
@@ -79,7 +79,7 @@ class TestCeleryBuilding(RTDTestCase):
                 intersphinx=False)
         self.assertTrue(result.successful())
 
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_environment', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_python_environment', new=MagicMock)
     @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs', new=MagicMock)
     @patch('readthedocs.doc_builder.environments.BuildEnvironment.update_build', new=MagicMock)
     @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs')
@@ -97,7 +97,7 @@ class TestCeleryBuilding(RTDTestCase):
                 intersphinx=False)
         self.assertTrue(result.successful())
 
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_environment', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_python_environment', new=MagicMock)
     @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs', new=MagicMock)
     @patch('readthedocs.doc_builder.environments.BuildEnvironment.update_build', new=MagicMock)
     @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs')

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -117,5 +117,9 @@ class TestCeleryBuilding(RTDTestCase):
 
     def test_update_imported_doc(self):
         with mock_api(self.repo):
-            result = tasks.update_imported_docs.delay(self.project.pk)
+            update_docs = tasks.UpdateDocsTask()
+            result = update_docs.apply_async(
+                args=(self.project.pk,),
+                kwargs={'sync_only': True},
+            )
         self.assertTrue(result.successful())

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -24,7 +24,7 @@ from readthedocs.builds.constants import BUILD_STATE_CLONING
 from readthedocs.builds.models import Version
 from readthedocs.doc_builder.config import ConfigWrapper
 from readthedocs.doc_builder.environments import (
-    BuildCommand, DockerBuildCommand, DockerEnvironment, LocalEnvironment)
+    BuildCommand, DockerBuildCommand, DockerBuildEnvironment, LocalBuildEnvironment)
 from readthedocs.doc_builder.exceptions import BuildEnvironmentError
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.projects.models import Project
@@ -36,7 +36,7 @@ SAMPLE_UNICODE = u'HérÉ îß sömê ünïçó∂é'
 SAMPLE_UTF8_BYTES = SAMPLE_UNICODE.encode('utf-8')
 
 
-class TestLocalEnvironment(TestCase):
+class TestLocalBuildEnvironment(TestCase):
 
     """Test execution and exception handling in environment."""
     fixtures = ['test_data']
@@ -58,7 +58,7 @@ class TestLocalEnvironment(TestCase):
         })
         type(self.mocks.process).returncode = PropertyMock(return_value=0)
 
-        build_env = LocalEnvironment(
+        build_env = LocalBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -92,12 +92,12 @@ class TestLocalEnvironment(TestCase):
     def test_incremental_state_update_with_no_update(self):
         """Build updates to a non-finished state when update_on_success=True."""
         build_envs = [
-            LocalEnvironment(
+            LocalBuildEnvironment(
                 version=self.version,
                 project=self.project,
                 build={'id': DUMMY_BUILD_ID},
             ),
-            LocalEnvironment(
+            LocalBuildEnvironment(
                 version=self.version,
                 project=self.project,
                 build={'id': DUMMY_BUILD_ID},
@@ -130,7 +130,7 @@ class TestLocalEnvironment(TestCase):
         })
         type(self.mocks.process).returncode = PropertyMock(return_value=1)
 
-        build_env = LocalEnvironment(
+        build_env = LocalBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -164,7 +164,7 @@ class TestLocalEnvironment(TestCase):
 
     def test_failing_execution_with_caught_exception(self):
         """Build in failing state with BuildEnvironmentError exception."""
-        build_env = LocalEnvironment(
+        build_env = LocalBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -197,7 +197,7 @@ class TestLocalEnvironment(TestCase):
 
     def test_failing_execution_with_unexpected_exception(self):
         """Build in failing state with exception from code."""
-        build_env = LocalEnvironment(
+        build_env = LocalBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -230,7 +230,7 @@ class TestLocalEnvironment(TestCase):
         })
 
 
-class TestDockerEnvironment(TestCase):
+class TestDockerBuildEnvironment(TestCase):
 
     """Test docker build environment."""
 
@@ -248,7 +248,7 @@ class TestDockerEnvironment(TestCase):
 
     def test_container_id(self):
         """Test docker build command."""
-        docker = DockerEnvironment(
+        docker = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -257,7 +257,7 @@ class TestDockerEnvironment(TestCase):
 
     def test_environment_successful_build(self):
         """A successful build exits cleanly and reports the build output."""
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -286,7 +286,7 @@ class TestDockerEnvironment(TestCase):
 
     def test_environment_successful_build_without_update(self):
         """A successful build exits cleanly and doesn't update build."""
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -304,7 +304,7 @@ class TestDockerEnvironment(TestCase):
 
     def test_environment_failed_build_without_update_but_with_error(self):
         """A failed build exits cleanly and doesn't update build."""
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -336,7 +336,7 @@ class TestDockerEnvironment(TestCase):
     def test_connection_failure(self):
         """Connection failure on to docker socket should raise exception."""
         self.mocks.configure_mock('docker', {'side_effect': DockerException})
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -379,7 +379,7 @@ class TestDockerEnvironment(TestCase):
                     'Failure creating container')
             })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -418,7 +418,7 @@ class TestDockerEnvironment(TestCase):
                     'Failure creating container'),
             })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -454,7 +454,7 @@ class TestDockerEnvironment(TestCase):
             'kill.side_effect': BuildEnvironmentError('Failed')
         })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -492,7 +492,7 @@ class TestDockerEnvironment(TestCase):
             'kill.side_effect': BuildEnvironmentError('Outer failed')
         })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -527,7 +527,7 @@ class TestDockerEnvironment(TestCase):
                 'exec_inspect.return_value': {'ExitCode': 1},
             })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -576,7 +576,7 @@ class TestDockerEnvironment(TestCase):
                 )
             })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -615,7 +615,7 @@ class TestDockerEnvironment(TestCase):
                 'exec_inspect.return_value': {'ExitCode': 0},
             })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},
@@ -667,7 +667,7 @@ class TestDockerEnvironment(TestCase):
                 'exec_inspect.return_value': {'ExitCode': 0},
             })
 
-        build_env = DockerEnvironment(
+        build_env = DockerBuildEnvironment(
             version=self.version,
             project=self.project,
             build={'id': DUMMY_BUILD_ID},

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Bazaar-related utilities."""
 
 from __future__ import absolute_import
@@ -21,7 +22,7 @@ class Backend(BaseVCS):
 
     def update(self):
         super(Backend, self).update()
-        retcode = self.run('bzr', 'status')[0]
+        retcode = self.run('bzr', 'status', warn_only=True)[0]
         if retcode == 0:
             self.up()
         else:
@@ -44,7 +45,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout = self.run('bzr', 'tags')[:2]
+        retcode, stdout = self.run('bzr', 'tags', warn_only=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -45,7 +45,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout = self.run('bzr', 'tags', force_success=True)[:2]
+        retcode, stdout = self.run('bzr', 'tags', record_as_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -22,7 +22,7 @@ class Backend(BaseVCS):
 
     def update(self):
         super(Backend, self).update()
-        retcode = self.run('bzr', 'status', warn_only=True)[0]
+        retcode = self.run('bzr', 'status', record=False)[0]
         if retcode == 0:
             self.up()
         else:
@@ -45,7 +45,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout = self.run('bzr', 'tags', warn_only=True)[:2]
+        retcode, stdout = self.run('bzr', 'tags', force_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -65,16 +65,16 @@ class Backend(BaseVCS):
             branch = self.default_branch or self.fallback_branch
             revision = 'origin/%s' % branch
 
-        code, out, err = self.run('git', 'checkout',
-                           '--force', revision)
+        code, out, err = self.run(
+            'git', 'checkout', '--force', revision)
         if code != 0:
             log.warning("Failed to checkout revision '%s': %s",
                         revision, code)
         return [code, out, err]
 
     def clone(self):
-        code, _, _ = self.run('git', 'clone', '--recursive',
-                           self.repo_url, '.')
+        code, _, _ = self.run(
+            'git', 'clone', '--recursive', self.repo_url, '.')
         if code != 0:
             raise RepositoryError
 

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -66,14 +66,14 @@ class Backend(BaseVCS):
             revision = 'origin/%s' % branch
 
         code, out, err = self.run('git', 'checkout',
-                           '--force', '--quiet', revision)
+                           '--force', revision)
         if code != 0:
             log.warning("Failed to checkout revision '%s': %s",
                         revision, code)
         return [code, out, err]
 
     def clone(self):
-        code, _, _ = self.run('git', 'clone', '--recursive', '--quiet',
+        code, _, _ = self.run('git', 'clone', '--recursive',
                            self.repo_url, '.')
         if code != 0:
             raise RepositoryError

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -52,7 +52,7 @@ class Backend(BaseVCS):
         self.checkout()
 
     def repo_exists(self):
-        code, _, _ = self.run('git', 'status')
+        code, _, _ = self.run('git', 'status', warn_only=True)
         return code == 0
 
     def fetch(self):
@@ -65,18 +65,16 @@ class Backend(BaseVCS):
             branch = self.default_branch or self.fallback_branch
             revision = 'origin/%s' % branch
 
-        command = self.run('git', 'checkout',
+        code, out, err = self.run('git', 'checkout',
                            '--force', '--quiet', revision)
-        code, out, err = command.exit_code, command.output, command.error
         if code != 0:
             log.warning("Failed to checkout revision '%s': %s",
                         revision, code)
         return [code, out, err]
 
     def clone(self):
-        command = self.run('git', 'clone', '--recursive', '--quiet',
+        code, _, _ = self.run('git', 'clone', '--recursive', '--quiet',
                            self.repo_url, '.')
-        code, _, _ = command.exit_code, command.output, command.error
         if code != 0:
             raise RepositoryError
 

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -80,7 +80,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout, _ = self.run('git', 'show-ref', '--tags')
+        retcode, stdout, _ = self.run('git', 'show-ref', '--tags', warn_only=True)
         # error (or no tags found)
         if retcode != 0:
             return []

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -80,7 +80,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout, _ = self.run('git', 'show-ref', '--tags', force_success=True)
+        retcode, stdout, _ = self.run('git', 'show-ref', '--tags', record_as_success=True)
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -205,7 +205,7 @@ class Backend(BaseVCS):
         return ref
 
     def ref_exists(self, ref):
-        code, _, _ = self.run('git', 'show-ref', ref, force_success=True)
+        code, _, _ = self.run('git', 'show-ref', ref, record_as_success=True)
         return code == 0
 
     @property

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -81,10 +81,16 @@ class Backend(BaseVCS):
         return [code, out, err]
 
     def clone(self, env=None):
-
-        # TODO: use env if it exists
-        code, _, _ = self.run('git', 'clone', '--recursive', '--quiet',
-                              self.repo_url, '.')
+        if env:
+            build_cmd = env.run(
+                'git', 'clone', '--recursive', '--quiet',
+                self.repo_url, '.',
+                cwd=self.working_dir,
+            )
+            code, out, err = build_cmd.exit_code, build_cmd.output, build_cmd.error
+        else:
+            code, _, _ = self.run('git', 'clone', '--recursive', '--quiet',
+                                  self.repo_url, '.')
         if code != 0:
             raise RepositoryError
 
@@ -180,7 +186,7 @@ class Backend(BaseVCS):
             self.fetch()
         else:
             self.make_clean_working_dir()
-            self.clone()
+            self.clone(env)
 
         # Find proper identifier
         if not identifier:

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -52,7 +52,7 @@ class Backend(BaseVCS):
         self.checkout()
 
     def repo_exists(self):
-        code, _, _ = self.run('git', 'status', warn_only=True)
+        code, _, _ = self.run('git', 'status', record=False)
         return code == 0
 
     def fetch(self):
@@ -80,7 +80,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout, _ = self.run('git', 'show-ref', '--tags', warn_only=True)
+        retcode, stdout, _ = self.run('git', 'show-ref', '--tags', force_success=True)
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -205,7 +205,7 @@ class Backend(BaseVCS):
         return ref
 
     def ref_exists(self, ref):
-        code, _, _ = self.run('git', 'show-ref', ref)
+        code, _, _ = self.run('git', 'show-ref', ref, force_success=True)
         return code == 0
 
     @property

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -38,7 +38,7 @@ class Backend(BaseVCS):
 
     @property
     def branches(self):
-        retcode, stdout = self.run('hg', 'branches', force_success=True)[:2]
+        retcode, stdout = self.run('hg', 'branches', record_as_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -51,7 +51,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout = self.run('hg', 'tags', force_success=True)[:2]
+        retcode, stdout = self.run('hg', 'tags', record_as_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -15,7 +15,7 @@ class Backend(BaseVCS):
 
     def update(self):
         super(Backend, self).update()
-        retcode = self.run('hg', 'status', warn_only=True)[0]
+        retcode = self.run('hg', 'status', record=False)[0]
         if retcode == 0:
             return self.pull()
         return self.clone()
@@ -38,7 +38,7 @@ class Backend(BaseVCS):
 
     @property
     def branches(self):
-        retcode, stdout = self.run('hg', 'branches', warn_only=True)[:2]
+        retcode, stdout = self.run('hg', 'branches', force_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -51,7 +51,7 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
-        retcode, stdout = self.run('hg', 'tags', warn_only=True)[:2]
+        retcode, stdout = self.run('hg', 'tags', force_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -94,7 +94,7 @@ class Backend(BaseVCS):
         super(Backend, self).checkout()
         if not identifier:
             identifier = 'tip'
-        retcode = self.run('hg', 'status', warn_only=True)[0]
+        retcode = self.run('hg', 'status', record=False)[0]
         if retcode == 0:
             self.run('hg', 'pull')
         else:

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Subversion-related utilities."""
 
 from __future__ import absolute_import
@@ -33,7 +34,7 @@ class Backend(BaseVCS):
         super(Backend, self).update()
         # For some reason `svn status` gives me retcode 0 in non-svn
         # directories that's why I use `svn info` here.
-        retcode = self.run('svn', 'info')[0]
+        retcode = self.run('svn', 'info', warn_only=True)[0]
         if retcode == 0:
             self.up()
         else:
@@ -56,7 +57,7 @@ class Backend(BaseVCS):
             url = self.base_url + identifier
         else:
             url = self.repo_url
-        retcode, out, err = self.run('svn', 'checkout', '--quiet', url, '.')
+        retcode, out, err = self.run('svn', 'checkout', url, '.')
         if retcode != 0:
             raise RepositoryError
         return retcode, out, err
@@ -64,7 +65,7 @@ class Backend(BaseVCS):
     @property
     def tags(self):
         retcode, stdout = self.run('svn', 'list', '%s/tags/'
-                                   % self.base_url)[:2]
+                                   % self.base_url, warn_only=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -98,7 +99,7 @@ class Backend(BaseVCS):
 
     def checkout(self, identifier=None):
         super(Backend, self).checkout()
-        retcode = self.run('svn', 'info')[0]
+        retcode = self.run('svn', 'info', warn_only=True)[0]
         if retcode == 0:
             result = self.up()
         else:

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -34,7 +34,7 @@ class Backend(BaseVCS):
         super(Backend, self).update()
         # For some reason `svn status` gives me retcode 0 in non-svn
         # directories that's why I use `svn info` here.
-        retcode = self.run('svn', 'info', force_success=True)[0]
+        retcode = self.run('svn', 'info', record_as_success=True)[0]
         if retcode == 0:
             self.up()
         else:
@@ -65,7 +65,7 @@ class Backend(BaseVCS):
     @property
     def tags(self):
         retcode, stdout = self.run('svn', 'list', '%s/tags/'
-                                   % self.base_url, force_success=True)[:2]
+                                   % self.base_url, record_as_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -34,7 +34,7 @@ class Backend(BaseVCS):
         super(Backend, self).update()
         # For some reason `svn status` gives me retcode 0 in non-svn
         # directories that's why I use `svn info` here.
-        retcode = self.run('svn', 'info', warn_only=True)[0]
+        retcode = self.run('svn', 'info', force_success=True)[0]
         if retcode == 0:
             self.up()
         else:
@@ -65,7 +65,7 @@ class Backend(BaseVCS):
     @property
     def tags(self):
         retcode, stdout = self.run('svn', 'list', '%s/tags/'
-                                   % self.base_url, warn_only=True)[:2]
+                                   % self.base_url, force_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []
@@ -99,7 +99,7 @@ class Backend(BaseVCS):
 
     def checkout(self, identifier=None):
         super(Backend, self).checkout()
-        retcode = self.run('svn', 'info', warn_only=True)[0]
+        retcode = self.run('svn', 'info', record=False)[0]
         if retcode == 0:
             result = self.up()
         else:

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -37,7 +37,7 @@ class BaseVCS(object):
     """
     Base for VCS Classes.
 
-    VCS commands are ran inside a ``LocalEnvironment``.
+    VCS commands are ran inside a ``LocalBuildEnvironment``.
     """
 
     supports_tags = False  # Whether this VCS supports tags or not.
@@ -55,21 +55,8 @@ class BaseVCS(object):
         self.repo_url = project.clean_repo
         self.working_dir = project.checkout_path(version_slug)
 
-        if environment:
-            self.environment = environment
-        else:
-            from readthedocs.doc_builder.environments import LocalEnvironment
-
-            try:
-                # TODO: it's supposed that we will always have the `latest`
-                # version on a Project since it's created at the Project.save()
-                # method, but there are a couple of tests that have inconsistent
-                # data
-                version = project.versions.get(slug=version_slug)
-                self.environment = LocalEnvironment(
-                    project, version, record=False, update_on_success=False)
-            except Exception:
-                log.exception('Project has no version: %s', version_slug)
+        from readthedocs.doc_builder.environments import LocalEnvironment
+        self.environment = environment or LocalEnvironment(project)
 
     def check_working_dir(self):
         if not os.path.exists(self.working_dir):

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -56,8 +56,10 @@ class BaseVCS(object):
         self.working_dir = project.checkout_path(version_slug)
 
         from readthedocs.doc_builder.environments import LocalEnvironment
-        self.environment = environment or LocalEnvironment(
-            project, environment=self.env)
+        self.environment = environment or LocalEnvironment(project)
+
+        # Update the env variables with the proper VCS env variables
+        self.environment.environment.update(self.env)
 
     def check_working_dir(self):
         if not os.path.exists(self.working_dir):
@@ -70,7 +72,12 @@ class BaseVCS(object):
 
     @property
     def env(self):
-        return os.environ.copy()
+        environment = os.environ.copy()
+
+        # TODO: kind of a hack
+        del environment['PATH']
+
+        return environment
 
     def update(self):
         """

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -56,7 +56,8 @@ class BaseVCS(object):
         self.working_dir = project.checkout_path(version_slug)
 
         from readthedocs.doc_builder.environments import LocalEnvironment
-        self.environment = environment or LocalEnvironment(project)
+        self.environment = environment or LocalEnvironment(
+            project, environment=self.env)
 
     def check_working_dir(self):
         if not os.path.exists(self.working_dir):
@@ -84,7 +85,6 @@ class BaseVCS(object):
         kwargs.update({
             'cwd': self.working_dir,
             'shell': False,
-            'environment': self.env,
         })
 
         build_cmd = self.environment.run(*cmd, **kwargs)

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -80,6 +80,7 @@ class BaseVCS(object):
         kwargs.update({
             'cwd': self.working_dir,
             'shell': False,
+            'environment': self.env,
         })
 
         build_cmd = self.environment.run(*cmd, **kwargs)

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -67,6 +67,10 @@ class BaseVCS(object):
         shutil.rmtree(self.working_dir, ignore_errors=True)
         self.check_working_dir()
 
+    @property
+    def env(self):
+        return os.environ.copy()
+
     def update(self):
         """
         Update a local copy of the repository in self.working_dir.

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -1,12 +1,11 @@
+# -*- coding: utf-8 -*-
+
 """Base classes for VCS backends."""
 from __future__ import absolute_import
 from builtins import object
 import logging
 import os
 import shutil
-import subprocess
-from collections import namedtuple
-from os.path import basename
 
 
 log = logging.getLogger(__name__)
@@ -33,60 +32,12 @@ class VCSVersion(object):
                                        self.verbose_name)
 
 
-class VCSProject(namedtuple("VCSProject",
-                            "name default_branch working_dir repo_url")):
-
-    """Transient object to encapsulate a projects stuff"""
-
-    pass
-
-
-class BaseCLI(object):
-
-    """Helper class for CLI-heavy classes."""
-
-    log_tmpl = u'VCS[{name}:{ident}]: {args}'
-
-    def __call__(self, *args):
-        return self.run(args)
-
-    def run(self, *args):
-        """:param bits: list of command and args. See `subprocess` docs"""
-        process = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE,
-                                   cwd=self.working_dir, shell=False,
-                                   env=self.env)
-        try:
-            log.info(self.log_tmpl.format(ident=basename(self.working_dir),
-                                          name=self.name,
-                                          args=' '.join(args)))
-        except UnicodeDecodeError:
-            # >:x
-            pass
-        stdout, stderr = process.communicate()
-        try:
-            log.info(self.log_tmpl.format(ident=basename(self.working_dir),
-                                          name=self.name,
-                                          args=stdout))
-        except UnicodeDecodeError:
-            # >:x
-            pass
-        return (
-            process.returncode,
-            stdout.decode('utf-8'),
-            stderr.decode('utf-8'))
-
-    @property
-    def env(self):
-        return os.environ.copy()
-
-
-class BaseVCS(BaseCLI):
+class BaseVCS(object):
 
     """
     Base for VCS Classes.
 
-    Built on top of the BaseCLI.
+    VCS commands are ran inside a ``LocalEnvironment``.
     """
 
     supports_tags = False  # Whether this VCS supports tags or not.
@@ -98,11 +49,27 @@ class BaseVCS(BaseCLI):
 
     # Defining a base API, so we'll have unused args
     # pylint: disable=unused-argument
-    def __init__(self, project, version, **kwargs):
+    def __init__(self, project, version_slug, environment=None, **kwargs):
         self.default_branch = project.default_branch
         self.name = project.name
-        self.repo_url = project.repo_url
-        self.working_dir = project.working_dir
+        self.repo_url = project.clean_repo
+        self.working_dir = project.checkout_path(version_slug)
+
+        if environment:
+            self.environment = environment
+        else:
+            from readthedocs.doc_builder.environments import LocalEnvironment
+
+            try:
+                # TODO: it's supposed that we will always have the `latest`
+                # version on a Project since it's created at the Project.save()
+                # method, but there are a couple of tests that have inconsistent
+                # data
+                version = project.versions.get(slug=version_slug)
+                self.environment = LocalEnvironment(
+                    project, version, record=False, update_on_success=False)
+            except Exception:
+                log.exception('Project has no version: %s', version_slug)
 
     def check_working_dir(self):
         if not os.path.exists(self.working_dir):
@@ -121,6 +88,16 @@ class BaseVCS(BaseCLI):
         update the repository, else create a new local copy of the repository.
         """
         self.check_working_dir()
+
+    def run(self, *cmd, **kwargs):
+        kwargs.update({
+            'cwd': self.working_dir,
+            'shell': False,
+        })
+
+        build_cmd = self.environment.run(*cmd, **kwargs)
+        # Return a tuple to keep compatibility
+        return (build_cmd.exit_code, build_cmd.output, build_cmd.error)
 
     # =========================================================================
     # Tag / Branch related methods

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -37,7 +37,7 @@ class BaseVCS(object):
     """
     Base for VCS Classes.
 
-    VCS commands are ran inside a ``LocalBuildEnvironment``.
+    VCS commands are ran inside a ``LocalEnvironment``.
     """
 
     supports_tags = False  # Whether this VCS supports tags or not.


### PR DESCRIPTION
I've been taking a look at the code and I found some consideration that we need to take a look:

1. `BaseVCS` class has it owns `run` method that works in a similar way than `BuildEnvironment.run`
   * the `log_tmpl` string differs
   * it adds some configurations automatically, like the `cwd` path
1. All commands ran by `BaseVCS` are not logged as a `BuildCommand`
1. `BuildCommand` needs to be instantiated with `build_env` to make be able to `.save()`/record the command for the current `Build` object.
1. `build_env` could be `LocalEnvironment` or `DockerEnvironment`

Depending on how much we want to refactor, a minimalistic _solution_ would involve:

1. pass `setup_env` to `update_imported_docs`
1. pass this env to `version_repo.checkout`
1. under `checkout` consider use if that `env` if not `None`
1. `env.run` with proper `cwd`

This is the what this PR implements but, this leaves a mix of calls to `run` method between `BaseVCS` and `LocalEnvironment` for the same purpose: update the repository's code. So, maybe we should consider to just pass the `setup_env` to the init of `BaseVCS` and execute everything under `setup_env`.

The problem of using always the `setup_env` (or maybe a new one called `vcs_env`) is that the `record` affects all the commands ran under that env and we want to record only `clone` and `checkout` commands --the `run` method could receive an optional `record` to override the default behaviour.

It's a good starting point to discuss a little about this.

> This PR only affects to the `git` backend, that's why I think we need to think in a general solution under the `BaseVCS` class.

Closes #3397 