### PR TITLE
Use relative path for docroot on mkdocs

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -96,6 +96,7 @@ class BaseMkdocs(BaseBuilder):
         # Handle custom docs dirs
         user_docs_dir = user_config.get('docs_dir')
         docs_dir = self.docs_dir(docs_dir=user_docs_dir)
+        docs_dir = os.path.relpath(docs_dir, self.root_path)
         self.create_index(extension='md')
         user_config['docs_dir'] = docs_dir
 

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -96,7 +96,6 @@ class BaseMkdocs(BaseBuilder):
         # Handle custom docs dirs
         user_docs_dir = user_config.get('docs_dir')
         docs_dir = self.docs_dir(docs_dir=user_docs_dir)
-        docs_dir = os.path.relpath(docs_dir, self.root_path)
         self.create_index(extension='md')
         user_config['docs_dir'] = docs_dir
 
@@ -112,11 +111,16 @@ class BaseMkdocs(BaseBuilder):
             '%scss/readthedocs-doc-embed.css' % static_url,
         ])
 
-        docs_path = os.path.join(self.root_path, docs_dir)
+        # The docs path is relative to the location
+        # of the mkdocs configuration file.
+        docs_path = os.path.join(
+            os.path.dirname(self.yaml_file),
+            docs_dir
+        )
 
         # RTD javascript writing
         rtd_data = self.generate_rtd_data(
-            docs_dir=docs_dir,
+            docs_dir=os.path.relpath(docs_path, self.root_path),
             mkdocs_config=user_config
         )
         with open(os.path.join(docs_path, 'readthedocs-data.js'), 'w') as f:

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -335,3 +335,31 @@ class MkdocsBuilderTest(TestCase):
             config['theme_dir'],
             'not-readthedocs'
         )
+
+    @patch('readthedocs.doc_builder.backends.mkdocs.BaseMkdocs.generate_rtd_data')
+    @patch('readthedocs.doc_builder.base.BaseBuilder.run')
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_write_js_data_docs_dir(self, checkout_path, run, generate_rtd_data):
+        tmpdir = tempfile.mkdtemp()
+        os.mkdir(os.path.join(tmpdir, 'docs'))
+        yaml_file = os.path.join(tmpdir, 'mkdocs.yml')
+        yaml.safe_dump(
+            {
+                'site_name': 'mkdocs',
+                'docs_dir': 'docs',
+            },
+            open(yaml_file, 'w')
+        )
+        checkout_path.return_value = tmpdir
+        generate_rtd_data.return_value = ''
+
+        self.searchbuilder = MkdocsHTML(
+            build_env=self.build_env,
+            python_env=None
+        )
+        self.searchbuilder.append_conf()
+
+        generate_rtd_data.assert_called_with(
+            docs_dir='docs',
+            mkdocs_config=mock.ANY
+        )

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -353,9 +353,14 @@ class MkdocsBuilderTest(TestCase):
         checkout_path.return_value = tmpdir
         generate_rtd_data.return_value = ''
 
+        python_env = Virtualenv(
+            version=self.version,
+            build_env=self.build_env,
+            config=None,
+        )
         self.searchbuilder = MkdocsHTML(
             build_env=self.build_env,
-            python_env=None
+            python_env=python_env,
         )
         self.searchbuilder.append_conf()
 


### PR DESCRIPTION
While replicating #3515, I noticed that the other "edit" link (at the float version menu) was wrong https://github.com/rtfd/readthedocs.org/issues/3515#issuecomment-358110500

Fixes #1917