### PR TITLE
Fix regex for public bitbucket repo

### DIFF
--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -299,8 +299,7 @@ GITHUB_REGEXS = [
 BITBUCKET_REGEXS = [
     re.compile('bitbucket.org/(.+)/(.+)\.git$'),
     re.compile('@bitbucket.org/(.+)/(.+)\.git$'),
-    re.compile('bitbucket.org/(.+)/(.+)/'),
-    re.compile('bitbucket.org/(.+)/(.+)'),
+    re.compile('bitbucket.org/(.+)/(.+)/?'),
     re.compile('bitbucket.org:(.+)/(.+)\.git$'),
 ]
 GITLAB_REGEXS = [

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -297,6 +297,7 @@ GITHUB_REGEXS = [
     re.compile('github.com:(.+)/(.+)\.git$'),
 ]
 BITBUCKET_REGEXS = [
+    re.compile('bitbucket.org/(.+)/(.+)\.git$'),
     re.compile('@bitbucket.org/(.+)/(.+)\.git$'),
     re.compile('bitbucket.org/(.+)/(.+)/'),
     re.compile('bitbucket.org/(.+)/(.+)'),

--- a/readthedocs/rtd_tests/tests/test_repo_parsing.py
+++ b/readthedocs/rtd_tests/tests/test_repo_parsing.py
@@ -87,13 +87,13 @@ class TestRepoParsing(TestCase):
         self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io/src/master/foo/bar/file.rst')
 
         self.pip.repo = 'https://bitbucket.org/user/repo.git'
-        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git/src/master/foo/bar/file.rst')
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo/src/master/foo/bar/file.rst')
 
         self.pip.repo = 'https://bitbucket.org/user/repo.gitbucket.io.git'
-        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io.git/src/master/foo/bar/file.rst')
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.gitbucket.io/src/master/foo/bar/file.rst')
 
         self.pip.repo = 'https://bitbucket.org/user/repo.git.git'
-        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git.git/src/master/foo/bar/file.rst')
+        self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git/src/master/foo/bar/file.rst')
 
     def test_bitbucket_https(self):
         self.pip.repo = 'https://user@bitbucket.org/user/repo.git'


### PR DESCRIPTION
I just realized that on #3501 I forgot to test a bitbucket repo as a logout user.

When you are login, the clone url is

![screenshot-2018-1-18 stsewd test bucktet git bitbucket](https://user-images.githubusercontent.com/4975310/35110779-9e9221e4-fc47-11e7-9d7c-089b24144c24.png)

But when you are log out look like this

![bitbucket](https://user-images.githubusercontent.com/4975310/35110882-e3ad21e8-fc47-11e7-88a9-3e5f17c61917.png)

This ends with `.git`

Sorry for the bug :(