### PR TITLE
Add github linguist build backend

### DIFF
--- a/readthedocs/doc_builder/backends/linguist.py
+++ b/readthedocs/doc_builder/backends/linguist.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import
+import json
+import logging
+import os
+import re
+
+from readthedocs.projects.utils import safe_write
+from ..base import BaseBuilder
+from ..environments import BuildCommand
+
+log = logging.getLogger(__name__)
+
+
+class LinguistBuilder(BaseBuilder):
+
+    """Linguist builder which generates a programming language breakdown."""
+
+    type = 'linguist'
+    builder = 'build'
+    build_dir = '_build/linguist'
+
+    LINGUIST_COMMAND_LOCAL = 'linguist'
+    LINGUIST_COMMAND_DOCKER = 'github-linguist'
+
+    LINGUIST_OUTPUT_REGEX = re.compile(
+        r'^(?P<percentage>\d+\.\d+)\%\s+(?P<language>.+)$',
+        re.MULTILINE,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(LinguistBuilder, self).__init__(*args, **kwargs)
+        self.old_artifact_path = os.path.join(
+            self.version.project.checkout_path(self.version.slug),
+            self.build_dir)
+        self.root_path = self.version.project.checkout_path(self.version.slug)
+
+    def _parse_linguist_output(self, output):
+        data = self.LINGUIST_OUTPUT_REGEX.findall(output)
+        return [(float(perc), lang) for perc, lang in data]
+
+    def _save_linguist_output(self, output):
+        linguist_raw_filepath = os.path.join(self.old_artifact_path, 'linguist.txt')
+        safe_write(linguist_raw_filepath, output)
+
+        # Parse the language breakdown for easier consumption
+        linguist_parsed_filepath = os.path.join(self.old_artifact_path, 'linguist.json')
+        safe_write(linguist_parsed_filepath, json.dumps(self._parse_linguist_output(output)))
+
+    def build(self):
+        if self.build_env.command_class == BuildCommand:
+            command = self.LINGUIST_COMMAND_LOCAL
+        else:
+            command = self.LINGUIST_COMMAND_DOCKER
+
+        cmd_ret = self.run(
+            command,
+            cwd=self.root_path,
+            warn_only=True,
+        )
+
+        if cmd_ret.successful:
+            self._save_linguist_output(cmd_ret.output)
+        else:
+            # Override command failure - do not fail the build
+            cmd_ret.exit_code = 0
+            log.warning('Linguist did not run successfully. This does not fail the build.')
+
+        # We never want to fail a build because Linguist failed or isn't installed
+        return True

--- a/readthedocs/doc_builder/loader.py
+++ b/readthedocs/doc_builder/loader.py
@@ -4,6 +4,8 @@ from importlib import import_module
 
 from django.conf import settings
 
+from .backends import linguist
+
 # Managers
 mkdocs = import_module(
     getattr(settings, 'MKDOCS_BACKEND',
@@ -25,6 +27,8 @@ BUILDER_BY_NAME = {
     # Other markup
     'mkdocs': mkdocs.MkdocsHTML,
     'mkdocs_json': mkdocs.MkdocsJSON,
+    # Linguist programming language breakdown
+    'linguist': linguist.LinguistBuilder,
 }
 
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -471,6 +471,7 @@ class UpdateDocsTask(Task):
             outcomes['localmedia'] = self.build_docs_localmedia()
             outcomes['pdf'] = self.build_docs_pdf()
             outcomes['epub'] = self.build_docs_epub()
+            outcomes['linguist'] = self.build_linguist_breakdown()
 
         after_build.send(sender=self.version)
         return outcomes
@@ -530,6 +531,14 @@ class UpdateDocsTask(Task):
                 not self.project.is_type_sphinx):
             return False
         return self.build_docs_class('sphinx_epub')
+
+    def build_linguist_breakdown(self):
+        """Build Linguist programming language breakdown"""
+        if not self.version or self.version.slug != LATEST:
+            # Only run linguist on the "latest" build
+            # We only care about the latest programming language breakdown
+            return False
+        return self.build_docs_class('linguist')
 
     def build_docs_class(self, builder_class):
         """


### PR DESCRIPTION
The goal of this PR is to get a programming language breakdown similar to what is achieved by an [existing script](https://github.com/rtfd/readthedocs.org/blob/f201d15/readthedocs/core/management/commands/import_github_language.py). The difference is that by integrating [Linguist](https://github.com/github/linguist) we can work with repositories that are not on github (eg. gitlab, etc) and not be limited by rate limits or anything else related to hitting an external API. With this breakdown, RTD.org will better understand the projects it is hosting which comes with a variety of advantages.

Specifically, this PR:
- Adds a linguist build backend which saves programming language breakdown
- Only runs the linguist build on "latest" builds - we don't care about the breakdown on older builds
- Does not break the build even when Linguist fails (eg. isn't installed, etc.)

For running on readthedocs.org, this will require https://github.com/rtfd/readthedocs-docker-images/pull/55.
