### PR TITLE
Doc builder template should check for mkdocs_page_input_path before using it

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
@@ -6,5 +6,8 @@ var doc_slug = "{{ slug }}";
 var page_name = "{{ pagename }}";
 var html_theme = "{{ html_theme }}";
 
-READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
-    0, mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix));
+// mkdocs_page_input_path isn't available on all pages (e.g. search result)
+if (mkdocs_page_input_path) {
+  READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
+      0, mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix));
+}

--- a/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
@@ -6,8 +6,9 @@ var doc_slug = "{{ slug }}";
 var page_name = "{{ pagename }}";
 var html_theme = "{{ html_theme }}";
 
-// mkdocs_page_input_path isn't available on all pages (e.g. search result)
-if (mkdocs_page_input_path) {
+// mkdocs_page_input_path is only defined on the RTD mkdocs theme but it isn't 
+// available on all pages (e.g. missing in search result)
+if (typeof mkdocs_page_input_path !== "undefined") {
   READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
       0, mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix));
 }


### PR DESCRIPTION
`mkdocs_page_input_path` isn't available on all pages.