### PR TITLE
Allow to import public repositories on corporate site

### DIFF
--- a/readthedocs/oauth/models.py
+++ b/readthedocs/oauth/models.py
@@ -22,8 +22,6 @@ from readthedocs.projects.models import Project
 
 from .querysets import RemoteOrganizationQuerySet, RemoteRepositoryQuerySet
 
-DEFAULT_PRIVACY_LEVEL = getattr(settings, 'DEFAULT_PRIVACY_LEVEL', 'public')
-
 
 @python_2_unicode_compatible
 class RemoteOrganization(models.Model):

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -14,8 +14,6 @@ from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 from requests.exceptions import RequestException
 from requests_oauthlib import OAuth2Session
 
-DEFAULT_PRIVACY_LEVEL = getattr(settings, 'DEFAULT_PRIVACY_LEVEL', 'public')
-
 log = logging.getLogger(__name__)
 
 
@@ -158,8 +156,7 @@ class Service(object):
     def sync(self):
         raise NotImplementedError
 
-    def create_repository(
-            self, fields, privacy=DEFAULT_PRIVACY_LEVEL, organization=None):
+    def create_repository(self, fields, privacy=None, organization=None):
         raise NotImplementedError
 
     def create_organization(self, fields):

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -19,8 +19,6 @@ from ..models import RemoteOrganization, RemoteRepository
 from .base import Service
 
 
-DEFAULT_PRIVACY_LEVEL = getattr(settings, 'DEFAULT_PRIVACY_LEVEL', 'public')
-
 log = logging.getLogger(__name__)
 
 
@@ -87,8 +85,7 @@ class BitbucketService(Service):
             raise Exception('Could not sync your Bitbucket team repositories, '
                             'try reconnecting your account')
 
-    def create_repository(self, fields, privacy=DEFAULT_PRIVACY_LEVEL,
-                          organization=None):
+    def create_repository(self, fields, privacy=None, organization=None):
         """
         Update or create a repository from Bitbucket API response.
 
@@ -103,6 +100,7 @@ class BitbucketService(Service):
         :type organization: RemoteOrganization
         :rtype: RemoteRepository
         """
+        privacy = privacy or settings.DEFAULT_PRIVACY_LEVEL
         if (
                 (privacy == 'private') or
                 (fields['is_private'] is False and privacy == 'public')

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -103,8 +103,10 @@ class BitbucketService(Service):
         :type organization: RemoteOrganization
         :rtype: RemoteRepository
         """
-        if (fields['is_private'] is True and privacy == 'private' or
-                fields['is_private'] is False and privacy == 'public'):
+        if (
+                (privacy == 'private') or
+                (fields['is_private'] is False and privacy == 'public')
+        ):
             repo, _ = RemoteRepository.objects.get_or_create(
                 full_name=fields['full_name'],
                 account=self.account,

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -19,9 +19,6 @@ from readthedocs.restapi.client import api
 from ..models import RemoteOrganization, RemoteRepository
 from .base import Service
 
-
-DEFAULT_PRIVACY_LEVEL = getattr(settings, 'DEFAULT_PRIVACY_LEVEL', 'public')
-
 log = logging.getLogger(__name__)
 
 
@@ -70,8 +67,7 @@ class GitHubService(Service):
             raise Exception('Could not sync your GitHub organizations, '
                             'try reconnecting your account')
 
-    def create_repository(self, fields, privacy=DEFAULT_PRIVACY_LEVEL,
-                          organization=None):
+    def create_repository(self, fields, privacy=None, organization=None):
         """
         Update or create a repository from GitHub API response.
 
@@ -81,9 +77,11 @@ class GitHubService(Service):
         :type organization: RemoteOrganization
         :rtype: RemoteRepository
         """
+        privacy = privacy or settings.DEFAULT_PRIVACY_LEVEL
         if (
                 (privacy == 'private') or
-                (fields['private'] is False and privacy == 'public')):
+                (fields['private'] is False and privacy == 'public')
+        ):
             try:
                 repo = RemoteRepository.objects.get(
                     full_name=fields['full_name'],

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -15,7 +15,7 @@ from requests.exceptions import RequestException
 from readthedocs.integrations.models import Integration
 
 from ..models import RemoteOrganization, RemoteRepository
-from .base import DEFAULT_PRIVACY_LEVEL, Service
+from .base import Service
 
 try:
     from urlparse import urljoin, urlparse
@@ -108,8 +108,7 @@ class GitLabService(Service):
     def is_owned_by(self, owner_id):
         return self.account.extra_data['id'] == owner_id
 
-    def create_repository(
-            self, fields, privacy=DEFAULT_PRIVACY_LEVEL, organization=None):
+    def create_repository(self, fields, privacy=None, organization=None):
         """
         Update or create a repository from GitLab API response.
 
@@ -119,6 +118,7 @@ class GitLabService(Service):
         :type organization: RemoteOrganization
         :rtype: RemoteRepository
         """
+        privacy = privacy or settings.DEFAULT_PRIVACY_LEVEL
         repo_is_public = fields['visibility'] == 'public'
         if privacy == 'private' or (repo_is_public and privacy == 'public'):
             try:

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -278,8 +278,7 @@ class BitbucketOAuthTests(TestCase):
         """
         data = self.repo_response_data.copy()
         data['is_private'] = False
-        repo = self.service.create_repository(
-            data, organization=self.org, privacy=self.privacy)
+        repo = self.service.create_repository(data, organization=self.org)
         self.assertIsNotNone(repo)
 
     def test_make_organization(self):

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -6,6 +6,7 @@ import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 from readthedocs.oauth.services import (
@@ -269,6 +270,17 @@ class BitbucketOAuthTests(TestCase):
         repo = self.service.create_repository(
             data, organization=self.org, privacy=self.privacy)
         self.assertIsNone(repo)
+
+    @override_settings(DEFAULT_PRIVACY_LEVEL='private')
+    def test_make_private_project(self):
+        """
+        Test ability to import ``public`` repositories under ``private`` level.
+        """
+        data = self.repo_response_data.copy()
+        data['is_private'] = False
+        repo = self.service.create_repository(
+            data, organization=self.org, privacy=self.privacy)
+        self.assertIsNotNone(repo)
 
     def test_make_organization(self):
         org = self.service.create_organization(self.team_response_data)

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -132,6 +132,24 @@ class GitHubOAuthTests(TestCase):
         self.assertEqual(github_project, github_project_5)
         self.assertEqual(github_project_2, github_project_6)
 
+    @override_settings(DEFAULT_PRIVACY_LEVEL='private')
+    def test_make_private_project(self):
+        """
+        Test ability to import ``public`` repositories under ``private`` level.
+        """
+        repo_json = {
+            'name': 'testrepo',
+            'full_name': 'testuser/testrepo',
+            'description': 'Test Repo',
+            'git_url': 'git://github.com/testuser/testrepo.git',
+            'private': False,
+            'ssh_url': 'ssh://git@github.com:testuser/testrepo.git',
+            'html_url': 'https://github.com/testuser/testrepo',
+            'clone_url': 'https://github.com/testuser/testrepo.git',
+        }
+        repo = self.service.create_repository(repo_json, organization=self.org)
+        self.assertIsNotNone(repo)
+
 
 class BitbucketOAuthTests(TestCase):
 
@@ -455,3 +473,15 @@ class GitLabOAuthTests(TestCase):
             'https://secure.gravatar.com/avatar/test',
         )
         self.assertEqual(org.url, 'https://gitlab.com/testorga')
+
+    @override_settings(DEFAULT_PRIVACY_LEVEL='private')
+    def test_make_private_project(self):
+        """
+        Test ability to import ``public`` repositories under ``private`` level.
+        """
+        data = self.repo_response_data.copy()
+        data['visibility'] = 'public'
+        with mock.patch('readthedocs.oauth.services.gitlab.GitLabService.is_owned_by') as m:  # yapf: disable
+            m.return_value = True
+            repo = self.service.create_repository(data, organization=self.org)
+        self.assertIsNotNone(repo)


### PR DESCRIPTION
When the DEFAULT_PRIVACY_LEVEL is ``private`` we allow to import
public _and_ private repositories from Bitbucket service.

This handles an issue under `.com`, https://github.com/readthedocs/readthedocs-corporate/issues/225