### PR TITLE
Task to remove orphan symlinks

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -820,13 +820,12 @@ def remove_orphan_symlinks():
     """
     for symlink in [PublicSymlink, PrivateSymlink]:
         for domain_path in [symlink.PROJECT_CNAME_ROOT, symlink.CNAME_ROOT]:
-            for domain in os.listdir(domain_path):
-                try:
-                    Domain.objects.get(domain=domain)
-                except Domain.DoesNotExist:
-                    orphan_domain_path = os.path.join(domain_path, domain)
-                    log.info('Unlinking orphan CNAME: %s', orphan_domain_path)
-                    os.unlink(orphan_domain_path)
+            valid_cnames = set(Domain.objects.all().values_list('domain', flat=True))
+            orphan_cnames = set(os.listdir(domain_path)) - valid_cnames
+            for cname in orphan_cnames:
+                orphan_domain_path = os.path.join(domain_path, cname)
+                log.info('Unlinking orphan CNAME: %s', orphan_domain_path)
+                os.unlink(orphan_domain_path)
 
 
 @app.task(queue='web')

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -811,6 +811,25 @@ def symlink_domain(project_pk, domain_pk, delete=False):
 
 
 @app.task(queue='web')
+def remove_orphan_symlinks():
+    """
+    Remove orphan symlinks.
+
+    List CNAME_ROOT for Public and Private symlinks, check that all the listed
+    cname exist in the database and if doesn't exist, they are un-linked.
+    """
+    for symlink in [PublicSymlink, PrivateSymlink]:
+        for domain_path in [symlink.PROJECT_CNAME_ROOT, symlink.CNAME_ROOT]:
+            for domain in os.listdir(domain_path):
+                try:
+                    Domain.objects.get(domain=domain)
+                except Domain.DoesNotExist:
+                    orphan_domain_path = os.path.join(domain_path, domain)
+                    log.info('Unlinking orphan CNAME: %s', orphan_domain_path)
+                    os.unlink(orphan_domain_path)
+
+
+@app.task(queue='web')
 def symlink_subproject(project_pk):
     project = Project.objects.get(pk=project_pk)
     for symlink in [PublicSymlink, PrivateSymlink]:

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -829,6 +829,16 @@ def remove_orphan_symlinks():
 
 
 @app.task(queue='web')
+def broadcast_remove_orphan_symlinks():
+    """
+    Broadcast the task ``remove_orphan_symlinks`` to all our web servers.
+
+    This task is executed by CELERY BEAT.
+    """
+    broadcast(type='web', task=remove_orphan_symlinks)
+
+
+@app.task(queue='web')
 def symlink_subproject(project_pk):
     project = Project.objects.get(pk=project_pk)
     for symlink in [PublicSymlink, PrivateSymlink]:

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -835,7 +835,7 @@ def broadcast_remove_orphan_symlinks():
 
     This task is executed by CELERY BEAT.
     """
-    broadcast(type='web', task=remove_orphan_symlinks)
+    broadcast(type='web', task=remove_orphan_symlinks, args=[])
 
 
 @app.task(queue='web')

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -14,7 +14,7 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project, Domain
-from readthedocs.projects.tasks import symlink_project
+from readthedocs.projects.tasks import remove_orphan_symlinks, symlink_project
 from readthedocs.core.symlink import PublicSymlink, PrivateSymlink
 
 
@@ -165,6 +165,79 @@ class BaseSymlinkCnames(TempSiterootCase):
             filesystem['public_web_root'] = private_root
             filesystem['private_web_root'] = public_root
         self.assertFilesystem(filesystem)
+
+    def test_symlink_remove_orphan_symlinks(self):
+        self.domain = get(Domain, project=self.project, domain='woot.com',
+                          url='http://woot.com', cname=True)
+        self.symlink.symlink_cnames()
+
+        # Editing the Domain and calling save will symlink the new domain and
+        # leave the old one as orphan.
+        self.domain.domain = 'foobar.com'
+        self.domain.save()
+
+        filesystem = {
+            'private_cname_project': {
+                'foobar.com': {'type': 'link', 'target': 'user_builds/kong'},
+                'woot.com': {'type': 'link', 'target': 'user_builds/kong'},
+            },
+            'private_cname_root': {
+                'foobar.com': {'type': 'link', 'target': 'private_web_root/kong'},
+                'woot.com': {'type': 'link', 'target': 'private_web_root/kong'},
+            },
+            'private_web_root': {'kong': {'en': {}}},
+            'public_cname_project': {
+                'foobar.com': {'type': 'link', 'target': 'user_builds/kong'},
+                'woot.com': {'type': 'link', 'target': 'user_builds/kong'},
+            },
+            'public_cname_root': {
+                'foobar.com': {'type': 'link', 'target': 'public_web_root/kong'},
+                'woot.com': {'type': 'link', 'target': 'public_web_root/kong'},
+            },
+            'public_web_root': {
+                'kong': {'en': {'latest': {
+                    'type': 'link',
+                    'target': 'user_builds/kong/rtd-builds/latest',
+                }}}
+            }
+        }
+        if self.privacy == 'private':
+            public_root = filesystem['public_web_root'].copy()
+            private_root = filesystem['private_web_root'].copy()
+            filesystem['public_web_root'] = private_root
+            filesystem['private_web_root'] = public_root
+        self.assertFilesystem(filesystem)
+
+        remove_orphan_symlinks()
+        filesystem = {
+            'private_cname_project': {
+                'foobar.com': {'type': 'link', 'target': 'user_builds/kong'},
+            },
+            'private_cname_root': {
+                'foobar.com': {'type': 'link', 'target': 'private_web_root/kong'},
+            },
+            'private_web_root': {'kong': {'en': {}}},
+            'public_cname_project': {
+                'foobar.com': {'type': 'link', 'target': 'user_builds/kong'},
+            },
+            'public_cname_root': {
+                'foobar.com': {'type': 'link', 'target': 'public_web_root/kong'},
+            },
+            'public_web_root': {
+                'kong': {'en': {'latest': {
+                    'type': 'link',
+                    'target': 'user_builds/kong/rtd-builds/latest',
+                }}},
+            },
+        }
+        if self.privacy == 'private':
+            public_root = filesystem['public_web_root'].copy()
+            private_root = filesystem['private_web_root'].copy()
+            filesystem['public_web_root'] = private_root
+            filesystem['private_web_root'] = public_root
+
+        self.assertFilesystem(filesystem)
+
 
     def test_symlink_cname_dont_link_missing_domains(self):
         """Domains should be relinked after deletion"""

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -14,7 +14,7 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project, Domain
-from readthedocs.projects.tasks import remove_orphan_symlinks, symlink_project
+from readthedocs.projects.tasks import broadcast_remove_orphan_symlinks, remove_orphan_symlinks, symlink_project
 from readthedocs.core.symlink import PublicSymlink, PrivateSymlink
 
 
@@ -238,6 +238,15 @@ class BaseSymlinkCnames(TempSiterootCase):
 
         self.assertFilesystem(filesystem)
 
+    def test_broadcast_remove_orphan_symlinks(self):
+        """Broadcast orphan symlinks is called with the proper attributes."""
+        with mock.patch('readthedocs.projects.tasks.broadcast') as broadcast:
+            broadcast_remove_orphan_symlinks()
+
+        broadcast.assert_called_with(
+            type='web',
+            task=remove_orphan_symlinks,
+        )
 
     def test_symlink_cname_dont_link_missing_domains(self):
         """Domains should be relinked after deletion"""

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -246,6 +246,7 @@ class BaseSymlinkCnames(TempSiterootCase):
         broadcast.assert_called_with(
             type='web',
             task=remove_orphan_symlinks,
+            args=[],
         )
 
     def test_symlink_cname_dont_link_missing_domains(self):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -247,7 +247,7 @@ class CommunityBaseSettings(Settings):
     CELERYBEAT_SCHEDULE = {
         # Ran every hour on minute 30
         'hourly-remove-orphan-symlinks': {
-            'task': 'readthedocs.projects.tasks.remove_orphan_symlinks',
+            'task': 'readthedocs.projects.tasks.broadcast_remove_orphan_symlinks',
             'schedule': crontab(minute=30),
             'options': {'queue': 'web'},
         },

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -8,6 +8,9 @@ import os
 
 from readthedocs.core.settings import Settings
 
+from celery.schedules import crontab
+
+
 try:
     import readthedocsext  # noqa
     ext = True
@@ -241,6 +244,14 @@ class CommunityBaseSettings(Settings):
     CELERY_CREATE_MISSING_QUEUES = True
 
     CELERY_DEFAULT_QUEUE = 'celery'
+    CELERYBEAT_SCHEDULE = {
+        # Ran every hour on minute 30
+        'hourly-remove-orphan-symlinks': {
+            'task': 'readthedocs.projects.tasks.remove_orphan_symlinks',
+            'schedule': crontab(minute=30),
+            'options': {'queue': 'web'},
+        },
+    }
 
     # Docker
     DOCKER_ENABLE = False


### PR DESCRIPTION
This is an initial implementation of this task to remove orpahn symlinks, which should be ran periodically every 1h aprox.

In the ticket, I also suggested that the `Edit` action doesn't make sense to me and should be reconsidered.

Finally, if we consider to remove the `Edit` action, this task should be run just once and should be enough.

Closes #3493 
