### PR TITLE
Display warning banner in latest version

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/version-compare.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/version-compare.js
@@ -6,12 +6,10 @@ function init(data) {
 
     /// Out of date message
 
-    console.log('Stable???')
-    console.log(data.is_stable)
     if (data.is_stable) {
         return;
     }
-  
+
     var message = 'You are not using the most up to date version of the library.';
     if (data.is_highest) {
       message = 'You are not using the stable version of the library.';

--- a/readthedocs/core/static-src/core/js/doc-embed/version-compare.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/version-compare.js
@@ -6,8 +6,15 @@ function init(data) {
 
     /// Out of date message
 
-    if (data.is_highest) {
+    console.log('Stable???')
+    console.log(data.is_stable)
+    if (data.is_stable) {
         return;
+    }
+  
+    var message = 'You are not using the most up to date version of the library.';
+    if (data.is_highest) {
+      message = 'You are not using the stable version of the library.';
     }
 
     var currentURL = window.location.pathname.replace(rtd['version'], data.slug);
@@ -15,8 +22,8 @@ function init(data) {
         '<div class="admonition warning"> ' +
         '<p class="first admonition-title">Note</p> ' +
         '<p class="last"> ' +
-        'You are not using the most up to date version of the library. ' +
-        '<a href="#"></a> is the newest version.' +
+         message + ' ' +
+        '<a href="#"></a> is the stable version.' +
         '</p>' +
         '</div>');
 


### PR DESCRIPTION
Closes #3481 and probably solves #1644

I introduced a new field in the API response: `is_stable`, to indicate if the given version is stable.
Now the highest version is only for the latest version, stable isn't considered highest anymore.

### On stable version

![stable](https://user-images.githubusercontent.com/4975310/35354343-bb201dbe-0117-11e8-9853-c4f3f0a4f307.png)

### On latest version

![latest](https://user-images.githubusercontent.com/4975310/35354345-bb5053f8-0117-11e8-8df0-5116705083b3.png)

### On old version

![old](https://user-images.githubusercontent.com/4975310/35354348-bb76f6f2-0117-11e8-8ea7-e1c95a6bed33.png)
