### PR TITLE
Send custom dimensions for mkdocs

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/include.js.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/include.js.tmpl
@@ -6,6 +6,12 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
 ga('create', '{{ global_analytics_code }}', 'auto', 'rtfd');
+ga('rtfd.set', 'dimension1', READTHEDOCS_DATA.project);
+ga('rtfd.set', 'dimension2', READTHEDOCS_DATA.version);
+ga('rtfd.set', 'dimension3', READTHEDOCS_DATA.language);
+ga('rtfd.set', 'dimension4', READTHEDOCS_DATA.theme);
+ga('rtfd.set', 'dimension5', READTHEDOCS_DATA.programming_language);
+ga('rtfd.set', 'dimension6', READTHEDOCS_DATA.builder);
 ga('rtfd.send', 'pageview');
 
 {% if user_analytics_code %}


### PR DESCRIPTION
This attaches data to our Google Analytics pageviews and events to allow some nice aggregation. The data is not attached to any user analytics settings.

The data includes data about the project and the docs build:
* project name
* version
* language (eg. "en", "fr")
* theme ("readthedocs", "alabaster")
* programming language
* builder (always "mkdocs" here)

There will be a separate PR in https://github.com/rtfd/readthedocs-sphinx-ext for handling the same for sphinx. Hopefully this all gets replaced in the future by doing analytics with a server side include rather than a generated file in the documentation build output. 
