### PR TITLE
Fix for build screen in firefox

### DIFF
--- a/readthedocs/builds/static/builds/css/detail.css
+++ b/readthedocs/builds/static/builds/css/detail.css
@@ -114,7 +114,6 @@ div.build-command div.build-command-output {
 div.build-command div.build-command-run > span,
 div.build-command div.build-command-output > span {
     display: block;
-    margin-bottom: -16px;
     font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
     white-space: pre;
     overflow-x: scroll;
@@ -124,7 +123,7 @@ div.build-command div.build-command-output > span {
 div.build-command div.build-command-run > span::-webkit-scrollbar,
 div.build-command div.build-command-output > span::-webkit-scrollbar {
     -webkit-appearance: none;
-    height: 15px;
+    height: 0px;
 }
 
 div.build-command div.build-command-output > span {


### PR DESCRIPTION
This problem is due to the `::-webkit-scrollbar` override specifying a scrollbar height and then trying to hide it with a negative margin.

Removing only the negative margin (as in #2350) results in the scrollbar still being allocated 15px extra. Instead removing both the negative margin and the extra scrollbar sizing of webkit of these brings the two browsers into parity. The only difference is that the scrollbar is visible on Firefox (there's no FF equivalent of `::-webkit-scrollbar`) but that doesn't impact the usability much.

- Fixes #2261
- Replaces #2630

<img width="870" alt="screen shot 2018-02-01 at 12 07 15 pm" src="https://user-images.githubusercontent.com/185043/35700836-faf7aa56-0748-11e8-8d9e-6e9964b0a729.png">

(Chrome 63 in the foreground with Firefox Developer Edition 59 in the background)