### PR TITLE
Pin less to latest compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.3",
     "gulp-watch": "^4.3.3",
-    "less": "*",
+    "less": "2.7.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.3",
     "gulp-watch": "^4.3.3",
-    "less": "2.7.3",
+    "less": "^2.7.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },


### PR DESCRIPTION
Gulp is incompatible with the latest release of less.

See https://travis-ci.org/rtfd/readthedocs.org/builds/340312177

2.7.3 is the previous stable

https://github.com/less/less.js/blob/HEAD/CHANGELOG.md#273