### PR TITLE
Add venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,12 @@ readthedocs/htmlcov
 tags
 .python-version
 *.pyo
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
Fixes #3609 
Ignore Python virtual env files