### PR TITLE
Do not have a separate background for ads

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -65,11 +65,6 @@ div.rtd-pro.alabaster {
 div.rtd-pro.wy-menu,
 div.rst-pro.wy-menu {
     bottom: 60px;
-    background: rgba(0, 0, 0, .06);
-}
-
-div.rtd-pro.alabaster {
-    background: rgba(220, 220, 220, .1);
 }
 
 div.rtd-pro > span,
@@ -169,10 +164,6 @@ div.rtd-pro-wrapper {
 @media (max-width: 768px) {
     div.rst-pro.wy-menu {
         display: none;
-    }
-
-    div.rtd-pro.alabaster {
-        background: rgba(220, 220, 220, .05);
     }
 
     div.rtd-pro.alabaster a.rtd-pro-image-wrapper {


### PR DESCRIPTION
If we do want to have a separate background for ads I would say we should be systematic about it. Also, this makes it harder to build an ad for more themes.

**BEFORE**
<img width="629" alt="screen shot 2018-02-16 at 11 18 20 am" src="https://user-images.githubusercontent.com/185043/36325506-dba9ef4a-130c-11e8-98c9-bae1e2c872f8.png">

**AFTER**
<img width="547" alt="screen shot 2018-02-16 at 11 18 13 am" src="https://user-images.githubusercontent.com/185043/36325513-e2e29050-130c-11e8-9218-5abf0546ad02.png">
