### PR TITLE
Improve installation guide

### DIFF
--- a/docs/.rstcheck.cfg
+++ b/docs/.rstcheck.cfg
@@ -1,4 +1,4 @@
 [rstcheck]
-ignore_directives=automodule,http:get
+ignore_directives=automodule,http:get,tabs,tab
 ignore_roles=djangosetting,setting
 ignore_messages=(Duplicate implicit target name: ".*")|(Hyperlink target ".*" is not referenced)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ extensions = [
     'sphinxcontrib.httpdomain',
     'djangodocs',
     'doc_extensions',
+    'sphinx_tabs.tabs',
 ]
 templates_path = ['_templates']
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -169,7 +169,7 @@ you will be able to log in and view the `dashboard <http://localhost:8000/dashbo
 
 .. note::
 
-   You can get the verification link from the console where you ran the server.
+    You can get the verification link from the console where you ran the server.
 
 Importing your docs
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -155,6 +155,12 @@ For example to update the ``pip`` repo::
 
     python manage.py update_repos pip
 
+.. note::
+
+    If you have problems building successfully a project,
+    probably is because some missing libraries for ``pdf`` and ``epub`` generation.
+    You can uncheck this on the advanced settings of your project.
+
 What's available
 ----------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -142,17 +142,6 @@ For example to update the ``pip`` repo::
 
     python manage.py update_repos pip
 
-Further steps
--------------
-
-By now you can trigger builds on your local environment, 
-to encapsulate the build process inside a Docker container,
-see :doc:`development/buildenvironments`.
-
-For building this documentation,
-see :doc:`docs`.
-And for setting up for the front end development, see :doc:`development/standards`.
-
 What's available
 ----------------
 
@@ -165,4 +154,15 @@ Importing your docs
 One of the goals of readthedocs.org is to make it easy for any open source developer to get high quality hosted docs with great visibility!
 Simply provide us with the clone URL to your repo, we'll pull your code, extract your docs, and build them!
 We make available a post-commit webhook that can be configured to update the docs whenever you commit to your repo.
-See :doc:`/intro/import-guide` to learn more.
+See our :doc:`getting_started` page to learn more.
+
+Further steps
+-------------
+
+By now you can trigger builds on your local environment, 
+to encapsulete the build process inside a Docker container,
+see :doc:`development/buildenvironments`.
+
+For building this documentation,
+see :doc:`docs`.
+And for setting up for the front end development, see :doc:`development/standards`.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -61,12 +61,6 @@ Install::
 
     sudo yum install python-devel python-pip libxml2-devel libxslt-devel
 
-Other Linux
-~~~~~~~~~~~
-
-Users of other Linux distributions may need to install the equivalent packages,
-depending on their system configuration.
-
 Other operating systems
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -64,7 +64,7 @@ Install::
 Other operating systems
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-On others operating systems no further dependencies are required,
+On other operating systems no further dependencies are required,
 or you need to find the proper equivalent libraries.
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -167,6 +167,10 @@ What's available
 After registering with the site (or creating yourself a superuser account),
 you will be able to log in and view the `dashboard <http://localhost:8000/dashboard/>`_.
 
+.. note::
+
+   You can get the verification link from the console where you ran the server.
+
 Importing your docs
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -97,6 +97,18 @@ Next, install the dependencies using ``pip``
     pip install -r requirements.txt
 
 This may take a while, so go grab a beverage.
+
+.. note::
+
+    If you are having trouble on OS X Mavericks
+    (or possibly other versions of OS X) with building ``lxml``,
+    you probably might need to use Homebrew_ to ``brew install libxml2``,
+    and invoke the install with::
+    
+        CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
+        LDFLAGS=-L/usr/local/opt/libxml2/lib \
+        pip install -r requirements.txt
+
 When it's done, build the database::
 
     python manage.py migrate

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -97,18 +97,6 @@ Next, install the dependencies using ``pip``
     pip install -r requirements.txt
 
 This may take a while, so go grab a beverage.
-
-.. note::
-
-    If you are having trouble on OS X Mavericks
-    (or possibly other versions of OS X) with building ``lxml``,
-    you probably might need to use Homebrew_ to ``brew install libxml2``,
-    and invoke the install with::
-    
-        CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
-        LDFLAGS=-L/usr/local/opt/libxml2/lib \
-        pip install -r requirements.txt
-
 When it's done, build the database::
 
     python manage.py migrate
@@ -146,7 +134,7 @@ For builds to properly work as expected,
 it is necessary the port you're serving on
 (i.e. ``python manage.py runserver 0.0.0.0:8080``)
 match the port defined in ``PRODUCTION_DOMAIN``.
-You can utilize ``readthedocs/settings/local_settings.py`` to modify this
+You can use ``readthedocs/settings/local_settings.py`` to modify this
 (by default, it's ``localhost:8000``).
 
 While the web server is running,
@@ -167,23 +155,20 @@ What's available
 After registering with the site (or creating yourself a superuser account),
 you will be able to log in and view the `dashboard <http://localhost:8000/dashboard/>`_.
 
-.. note::
-
-    You can get the verification link from the console where you ran the server.
-
 Importing your docs
 ~~~~~~~~~~~~~~~~~~~
 
 One of the goals of readthedocs.org is to make it easy for any open source developer to get high quality hosted docs with great visibility!
 Simply provide us with the clone URL to your repo, we'll pull your code, extract your docs, and build them!
+
 We make available a post-commit webhook that can be configured to update the docs whenever you commit to your repo.
-See our :doc:`getting_started` page to learn more.
+See our :doc:`/intro/import-guide` page to learn more.
 
 Further steps
 -------------
 
 By now you can trigger builds on your local environment, 
-to encapsulete the build process inside a Docker container,
+to encapsulate the build process inside a Docker container,
 see :doc:`development/buildenvironments`.
 
 For building this documentation,

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,7 +70,7 @@ depending on their system configuration.
 .. _Python 3.6: http://www.python.org/
 .. _virtualenv: https://virtualenv.pypa.io/en/stable/
 .. _Git: http://git-scm.com/
-.. _`Mercurial`: https://www.mercurial-scm.org/
+.. _Mercurial: https://www.mercurial-scm.org/
 .. _Pip: https://pip.pypa.io/en/stable/
 .. _Homebrew: http://brew.sh/
 .. _Elasticsearch: https://www.elastic.co/products/elasticsearch

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,15 +11,12 @@ First, obtain `Python 3.6`_ and virtualenv_ if you do not already have them.
 Using a virtual environment is strongly recommended,
 since it will help you to avoid clutter in your system-wide libraries.
 
-Additionally Read the Docs depends on: 
+Additionally Read the Docs depends on:
 
 * `Git`_ (version >=2)
 * `Mercurial`_ (only if you need to work with mercurial repositories)
 * `Pip`_ (version >1.5)
 * `Redis`_
-
-    * On Ubuntu you can install it using ``sudo apt-get install redis-server``
-
 * `Elasticsearch`_ (only if you want full support for searching inside the site)
 
     * Ubuntu users could install this package by following :doc:`/custom_installs/elasticsearch`.
@@ -52,6 +49,10 @@ Install::
     sudo apt-get install build-essential
     sudo apt-get install python-dev python-pip python-setuptools
     sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
+
+If you don't have redis installed yet, you can do it with::
+    
+    sudo apt-get install redis-server
 
 On CentOS/RHEL 7
 ~~~~~~~~~~~~~~~~

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,105 +1,106 @@
 Installation
 ============
 
-Here is a step by step plan on how to install Read the Docs.
+Here is a step by step guide on how to install Read the Docs.
 It will get you to a point of having a local running instance.
 
+Requirements
+------------
 
-First, obtain `Python 3.6`_ and virtualenv_ if you do not already have them. Using a
-virtual environment will make the installation easier, and will help to avoid
-clutter in your system-wide libraries. You will also need Git_ in order to
-clone the repository. If you plan to import Python 2.7 project to your RTD then you'll
-need to install Python 2.7 with virtualenv in your system as well.
+First, obtain `Python 3.6`_ and virtualenv_ if you do not already have them.
+Using a virtual environment is strongly recommended,
+since it will help you to avoid clutter in your system-wide libraries.
+
+Additionally Read the Docs depends on: 
+
+* `Git`_ (version >=2)
+* `Mercurial`_ (only if you need to work with mercurial repositories)
+* `Pip`_ (version >1.5)
+* `Redis`_
+
+    * On Ubuntu you can install it using ``sudo apt-get install redis-server``
+
+* `Elasticsearch`_ (only if you want full support for searching inside the site)
+
+    * Ubuntu users could install this package by following :doc:`/custom_installs/elasticsearch`.
+
+.. note::
+
+    If you plan to import Python 2 projects to your RTD,
+    then you'll need to install Python 2 with virtualenv in your system as well.
+
+In order to get all the dependencies successfully installed,
+you need these libraries.
+
+On Mac OS
+~~~~~~~~~
+
+If you are having trouble on OS X Mavericks
+(or possibly other versions of OS X) with building ``lxml``,
+you probably might need to use Homebrew_ to ``brew install libxml2``,
+and invoke the install with::
+
+    CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
+    LDFLAGS=-L/usr/local/opt/libxml2/lib \
+    pip install -r requirements.txt
+
+On Ubuntu
+~~~~~~~~~
+
+Install::
+
+    sudo apt-get install build-essential
+    sudo apt-get install python-dev python-pip python-setuptools
+    sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
+
+On CentOS/RHEL 7
+~~~~~~~~~~~~~~~~
+
+Install::
+
+    sudo yum install python-devel python-pip libxml2-devel libxslt-devel
+
+Other Linux
+~~~~~~~~~~~
+
+Users of other Linux distributions may need to install the equivalent packages,
+depending on their system configuration.
 
 
 .. _Python 3.6: http://www.python.org/
-.. _virtualenv: http://pypi.python.org/pypi/virtualenv
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
 .. _Git: http://git-scm.com/
+.. _`Mercurial`: https://www.mercurial-scm.org/
+.. _Pip: https://pip.pypa.io/en/stable/
 .. _Homebrew: http://brew.sh/
 .. _Elasticsearch: https://www.elastic.co/products/elasticsearch
-.. _PostgreSQL: https://www.postgresql.org/
 .. _Redis: https://redis.io/
 
-.. note::
 
-    Requires Git version >=2
+Cloning the repository and start Django
+---------------------------------------
 
-.. note::
+Clone the repository somewhere on your disk and enter to the repository::
 
-    If you are having trouble on OS X Mavericks (or possibly other versions of
-    OS X) with building ``lxml``, you probably might need to use Homebrew_
-    to ``brew install libxml2``, and invoke the install with::
-
-        CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
-        LDFLAGS=-L/usr/local/opt/libxml2/lib \
-        pip install -r requirements.txt
-
-.. note::
-
-    Linux users may find they need to install a few additional packages
-    in order to successfully execute ``pip install -r requirements.txt``.
-    For example, a clean install of Ubuntu 14.04 LTS will require the
-    following packages::
-
-        sudo apt-get install build-essential
-        sudo apt-get install python-dev python-pip python-setuptools
-        sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
-
-    CentOS/RHEL 7 will require::
-
-        sudo yum install python-devel python-pip libxml2-devel libxslt-devel
-
-    Users of other Linux distributions may need to install the equivalent
-    packages, depending on their system configuration.
-
-.. note::
-
-   If you want full support for searching inside your Read the Docs
-   site you will need to install Elasticsearch_.
-
-   Ubuntu users could install this package by following :doc:`/custom_installs/elasticsearch`.
-
-.. note::
-
-   Besides the Python specific dependencies, you will also need Redis_.
-
-   Ubuntu users could install this package as following::
-
-        sudo apt-get install redis-server
-
-
-You will need to verify that your pip version is higher than 1.5 you can do this as such::
-
-    pip --version
-
-If this is not the case please update your pip version before continuing::
-
-    pip install --upgrade pip
-
-Once you have these, create a virtual environment somewhere on your disk, then
-activate it::
-
-    virtualenv rtd
-    cd rtd
-    source bin/activate
-
-Create a folder in here, and clone the repository::
-
-    mkdir checkouts
-    cd checkouts
     git clone https://github.com/rtfd/readthedocs.org.git
-
-Next, install the dependencies using ``pip`` (included inside of virtualenv_)::
-
     cd readthedocs.org
+
+Create a virtual environment and activate it::
+
+    virtualenv venv
+    source venv/bin/activate
+
+Next, install the dependencies using ``pip``
+(make sure you are inside of the virtual environment)::
+
     pip install -r requirements.txt
 
-This may take a while, so go grab a beverage. When it's done, build your
-database::
+This may take a while, so go grab a beverage.
+When it's done, build the database::
 
     python manage.py migrate
 
-Then please create a superuser account for Django::
+Then create a superuser account for Django::
 
     python manage.py createsuperuser
 
@@ -107,7 +108,7 @@ Now let's properly generate the static assets::
 
     python manage.py collectstatic
 
-By now, it is the right time to load in a couple users and a test project::
+Now you can optionally load a couple users and a test projects::
 
     python manage.py loaddata test_data
 
@@ -120,24 +121,37 @@ By now, it is the right time to load in a couple users and a test project::
     create an ``EmailAddress`` entry for the user, then you can use ``shell_plus`` to
     update the object with ``primary=True``, ``verified=True``.
 
-Finally, you're ready to start the webserver::
+Finally, you're ready to start the web server::
 
     python manage.py runserver
 
-Visit http://127.0.0.1:8000/ in your browser to see how it looks; you can use
-the admin interface via http://127.0.0.1:8000/admin (logging in with the
-superuser account you just created).
+Visit http://127.0.0.1:8000/ in your browser to see how it looks;
+you can use the admin interface via http://127.0.0.1:8000/admin
+(logging in with the superuser account you just created).
 
-For builds to properly kick off as expected, it is necessary the port
-you're serving on (i.e. ``runserver 0.0.0.0:8080``) match the port defined
-in ``PRODUCTION_DOMAIN``. You can utilize ``local_settings.py`` to modify this.
+For builds to properly work as expected,
+it is necessary the port you're serving on
+(i.e. ``python manage.py runserver 0.0.0.0:8080``)
+match the port defined in ``PRODUCTION_DOMAIN``.
+You can utilize ``readthedocs/settings/local_settings.py`` to modify this.
 (By default, it's ``localhost:8000``)
 
-While the webserver is running, you can build documentation for the latest version of
-a project called 'pip' with the ``update_repos`` command.  You can replace 'pip'
-with the name of any added project::
+While the web server is running,
+you can build the documentation for the latest version of any project using the ``update_repos`` command.
+For example to update the ``pip`` repo::
 
     python manage.py update_repos pip
+
+Further steps
+-------------
+
+By now you can trigger builds on your local environment, 
+to encapsulate the build process inside a Docker container,
+see :doc:`development/buildenvironments`.
+
+For building this documentation,
+see :doc:`docs`.
+And for setting up for the front end development, see :doc:`development/standards`.
 
 What's available
 ----------------
@@ -146,7 +160,7 @@ After registering with the site (or creating yourself a superuser account),
 you will be able to log in and view the `dashboard <http://localhost:8000/dashboard/>`_.
 
 Importing your docs
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 One of the goals of readthedocs.org is to make it easy for any open source developer to get high quality hosted docs with great visibility!
 Simply provide us with the clone URL to your repo, we'll pull your code, extract your docs, and build them!

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -67,6 +67,12 @@ Other Linux
 Users of other Linux distributions may need to install the equivalent packages,
 depending on their system configuration.
 
+Other operating systems
+~~~~~~~~~~~~~~~~~~~~~~~
+
+On others operating systems no further dependencies are required,
+or you need to find the proper equivalent libraries.
+
 
 .. _Python 3.6: http://www.python.org/
 .. _virtualenv: https://virtualenv.pypa.io/en/stable/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,43 +29,41 @@ Additionally Read the Docs depends on:
 In order to get all the dependencies successfully installed,
 you need these libraries.
 
-On Mac OS
-~~~~~~~~~
+.. tabs::
+   
+   .. tab:: Mac OS
 
-If you are having trouble on OS X Mavericks
-(or possibly other versions of OS X) with building ``lxml``,
-you probably might need to use Homebrew_ to ``brew install libxml2``,
-and invoke the install with::
+      If you are having trouble on OS X Mavericks
+      (or possibly other versions of OS X) with building ``lxml``,
+      you probably might need to use Homebrew_ to ``brew install libxml2``,
+      and invoke the install with::
+      
+          CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
+          LDFLAGS=-L/usr/local/opt/libxml2/lib \
+          pip install -r requirements.txt
 
-    CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
-    LDFLAGS=-L/usr/local/opt/libxml2/lib \
-    pip install -r requirements.txt
+   .. tab:: Ubuntu
 
-On Ubuntu
-~~~~~~~~~
+      Install::
 
-Install::
+         sudo apt-get install build-essential
+         sudo apt-get install python-dev python-pip python-setuptools
+         sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
 
-    sudo apt-get install build-essential
-    sudo apt-get install python-dev python-pip python-setuptools
-    sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
+      If you don't have redis installed yet, you can do it with::
+         
+         sudo apt-get install redis-server
 
-If you don't have redis installed yet, you can do it with::
-    
-    sudo apt-get install redis-server
+   .. tab:: CentOS/RHEL 7
 
-On CentOS/RHEL 7
-~~~~~~~~~~~~~~~~
+      Install::
 
-Install::
+         sudo yum install python-devel python-pip libxml2-devel libxslt-devel
 
-    sudo yum install python-devel python-pip libxml2-devel libxslt-devel
+   .. tab:: Other OS
 
-Other operating systems
-~~~~~~~~~~~~~~~~~~~~~~~
-
-On other operating systems no further dependencies are required,
-or you need to find the proper equivalent libraries.
+      On other operating systems no further dependencies are required,
+      or you need to find the proper equivalent libraries.
 
 
 .. _Python 3.6: http://www.python.org/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -77,8 +77,8 @@ depending on their system configuration.
 .. _Redis: https://redis.io/
 
 
-Cloning the repository and start Django
----------------------------------------
+Get and run Read the Docs
+-------------------------
 
 Clone the repository somewhere on your disk and enter to the repository::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -184,4 +184,5 @@ see :doc:`development/buildenvironments`.
 
 For building this documentation,
 see :doc:`docs`.
+
 And for setting up for the front end development, see :doc:`development/standards`.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -108,7 +108,7 @@ Now let's properly generate the static assets::
 
     python manage.py collectstatic
 
-Now you can optionally load a couple users and a test projects::
+Now you can optionally load a couple users and test projects::
 
     python manage.py loaddata test_data
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -146,8 +146,8 @@ For builds to properly work as expected,
 it is necessary the port you're serving on
 (i.e. ``python manage.py runserver 0.0.0.0:8080``)
 match the port defined in ``PRODUCTION_DOMAIN``.
-You can utilize ``readthedocs/settings/local_settings.py`` to modify this.
-(By default, it's ``localhost:8000``)
+You can utilize ``readthedocs/settings/local_settings.py`` to modify this
+(by default, it's ``localhost:8000``).
 
 While the web server is running,
 you can build the documentation for the latest version of any project using the ``update_repos`` command.

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -5,6 +5,7 @@ virtualenv==16.0.0
 docutils==0.14
 Sphinx==1.7.8
 sphinx_rtd_theme==0.4.1
+sphinx-tabs==1.1.7
 # Required to avoid Transifex error with reserved slug
 # https://github.com/sphinx-doc/sphinx-intl/pull/27
 git+https://github.com/agjohnson/sphinx-intl.git@7b5c66bdb30f872b3b1286e371f569c8dcb66de5#egg=sphinx-intl


### PR DESCRIPTION
This is my second attend to improve the installation guide (first one #3614), I have take some notes from https://github.com/rtfd/readthedocs.org/pull/3614#issuecomment-365842034, https://github.com/rtfd/readthedocs.org/pull/3614#issuecomment-365844940, https://github.com/rtfd/readthedocs.org/pull/3488#issuecomment-366087951.

I try to reduce the _trying to teach how to use_ for _provide useful links_ and be a little more _lineal_ on the steps. And remove lots of _notes_ that are really necessary, but give the impression of be optional.

Please let me know any issues with the English :)

Closes #2246