### PR TITLE
Fix a 500 when searching for files with API v1

### DIFF
--- a/readthedocs/api/utils.py
+++ b/readthedocs/api/utils.py
@@ -43,7 +43,7 @@ class SearchMixin(object):
             search_highlight = True
     """
 
-    def get_search(self, request):
+    def get_search(self, request, **kwargs):
         self.method_check(request, allowed=['get'])
         self.is_authenticated(request)
         self.throttle_check(request)


### PR DESCRIPTION
This URL results in a 500 error in production:
http://readthedocs.org/api/v1/file/search/?format=json&q=virtualenvwrapper

This PR fixes that error. I know the API v1 is in some stage of deprecation but this will at least fix the error.