### PR TITLE
Remove error logging that isn't an error.

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -148,7 +148,7 @@ class Version(models.Model):
 
         # If we came that far it's not a special version nor a branch or tag.
         # Therefore just return the identifier to make a safe guess.
-        log.error('TODO: Raise an exception here. Testing what cases it happens')
+        log.debug('TODO: Raise an exception here. Testing what cases it happens')
         return self.identifier
 
     def get_absolute_url(self):

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -116,7 +116,7 @@ def redirect_page_with_filename(request, project, subproject, filename):  # pyli
 def _serve_401(request, project):
     res = render(request, '401.html')
     res.status_code = 401
-    log.error('Unauthorized access to {0} documentation'.format(project.slug))
+    log.debug('Unauthorized access to {0} documentation'.format(project.slug))
     return res
 
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -738,7 +738,7 @@ def update_search(version_pk, commit, delete_non_commit_files=True):
     if version.project.is_type_sphinx:
         page_list = process_all_json_files(version, build_dir=False)
     else:
-        log.error('Unknown documentation type: %s',
+        log.debug('Unknown documentation type: %s',
                   version.project.documentation_type)
         return
 


### PR DESCRIPTION
This is clogging up our Sentry instance,
causing us to go over our free allotment.