### PR TITLE
Send proper context to celery email notification task

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -951,7 +951,10 @@ def webhook_notification(version, build, hook_url):
     log.debug(LOG_TEMPLATE
               .format(project=project.slug, version='',
                       msg='sending notification to: %s' % hook_url))
-    requests.post(hook_url, data=data)
+    try:
+        requests.post(hook_url, data=data)
+    except Exception:
+        log.exception('Failed to POST on webhook url: url=%s', hook_url)
 
 
 @app.task(queue='web')


### PR DESCRIPTION
This solves an issue in the .com site that we are experimenting.

Although I couldn't get the error report in .org Sentry, I'm not receiving the email on FAILED builds in my .org account either. So, I think this PR will also fix the problem here.

> NOTE: by sending the objects as dictionaries we can continue using the templates as they are. Antoher approach could be sending all that data in separate fields like `version_verbose_name` or `project_name` and adapting the templates to this.

Ref: https://github.com/readthedocs/readthedocs-corporate-ops/issues/77