### PR TITLE
Fix issue with missing setting in oauth SyncRepo task

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -290,6 +290,7 @@ class CommunityBaseSettings(Settings):
     # RTD Settings
     REPO_LOCK_SECONDS = 30
     ALLOW_PRIVATE_REPOS = False
+    DEFAULT_PRIVACY_LEVEL = 'public'
     GROK_API_HOST = 'https://api.grokthedocs.com'
     SERVE_DOCS = ['public']
 


### PR DESCRIPTION
This was looking for setting DEFAULT_PRIVACY_LEVEL, which wasn't set by default
in our settings.