### PR TITLE
Hotfix for adding logging call back into project sync task

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -151,6 +151,16 @@ class SyncRepositoryMixin(object):
             except Exception:
                 log.exception('Unknown Sync Versions Exception')
 
+    # TODO this is duplicated in the classes below, and this should be
+    # refactored out anyways, as calling from the method removes the original
+    # caller from logging.
+    def _log(self, msg):
+        log.info(LOG_TEMPLATE
+                 .format(project=self.project.slug,
+                         version=self.version.slug,
+                         msg=msg))
+
+
 
 class SyncRepositoryTask(SyncRepositoryMixin, Task):
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -161,7 +161,6 @@ class SyncRepositoryMixin(object):
                          msg=msg))
 
 
-
 class SyncRepositoryTask(SyncRepositoryMixin, Task):
 
     """Entry point to synchronize the VCS documentation."""


### PR DESCRIPTION
It exists in subclasses, but we should refactor it out anyways.

Closes #3655 