### PR TITLE
Upgrade django-taggit to 0.22.2

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -56,6 +56,7 @@ django-textclassifier==1.0
 django-annoying==0.10.1
 django-messages-extends==0.5
 djangorestframework-jsonp==1.0.2
+django-taggit==0.22.2
 
 # Docs
 sphinxcontrib-httpdomain==1.4.0
@@ -71,4 +72,3 @@ nilsimsa==0.3.7
 
 # Pegged git requirements
 git+https://github.com/zyga/django-pagination.git@86caf15#egg=django_pagination-dev
-git+https://github.com/alex/django-taggit.git#egg=django_taggit-dev


### PR DESCRIPTION
Upgrade this package to be more prepared for Python3 and Django 2.0

Related #3666 