### PR TITLE
Always record the git branch command as success

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -122,8 +122,8 @@ class Backend(BaseVCS):
     @property
     def branches(self):
         # Only show remote branches
-        retcode, stdout, _ = self.run('git', 'branch', '-r')
-        # error (or no tags found)
+        retcode, stdout, _ = self.run('git', 'branch', '-r', record_as_success=True)
+        # error (or no branches found)
         if retcode != 0:
             return []
         return self.parse_branches(stdout)


### PR DESCRIPTION
This is causing the build to be marked as FAILED when the repository
has no branches.