### PR TITLE
Ticket #3694: rename owners to maintainers

### DIFF
--- a/readthedocs/templates/core/project_detail_right.html
+++ b/readthedocs/templates/core/project_detail_right.html
@@ -33,8 +33,8 @@
   </p>
 {% endblock %}
 
-{% block owners %}
-    <h3>{% trans "Owners" %}</h3>
+{% block maintainers %}
+    <h3>{% trans "Maintainers" %}</h3>
     <p>
       {% for user in project.users.all %}
       <a href="{% url "profiles_profile_detail" user.username %}">{% gravatar user.email 32 %}</a>


### PR DESCRIPTION
patches #3694: renamed owners to maintainers, until a differentiation is established between an owner and a maintainer at model level.