### PR TITLE
setting stable version manually

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -30,7 +30,7 @@ from readthedocs.projects.querysets import (
     RelatedProjectQuerySet)
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
 from readthedocs.projects.version_handling import (
-    determine_stable_version, version_windows)
+    determine_stable_version, version_windows, sort_versions)
 from readthedocs.restapi.client import api
 from readthedocs.vcs_support.backends import backend_cls
 from readthedocs.vcs_support.utils import Lock, NonBlockingLock
@@ -724,11 +724,20 @@ class Project(models.Model):
     def get_stable_version(self):
         return self.versions.filter(slug=STABLE).first()
 
+    def get_stable_version_choice(self):
+        version_list = self.versions.all()
+        stable_version_choice = sort_versions(version_list)
+        stable_version_choice = [(version_obj.identifier, version_obj.verbose_name)
+                                  for version_obj, comparable in stable_version_choice
+                                  if (not comparable.is_prerelease and version_obj.active)]
+        return stable_version_choice
+
+
     def update_stable_version(self):
         """
         Returns the version that was promoted to be the new stable version.
 
-        Return ``None`` if no update was mode or if there is no version on the
+        Return ``None`` if no update was made or if there is no version on the
         project that can be considered stable.
         """
         versions = self.versions.all()

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -178,6 +178,7 @@ class ProjectViewSet(UserSelectViewSet):
             )
 
         promoted_version = project.update_stable_version()
+        # promoted version will be none if no update was found.
         if promoted_version:
             new_stable = project.get_stable_version()
             log.info(

--- a/readthedocs/templates/projects/project_versions.html
+++ b/readthedocs/templates/projects/project_versions.html
@@ -14,7 +14,11 @@
 {% for field in form %}
 
     {% if forloop.first  %}
-        {# This is a custom form listing the possible active versions, to make 1 the default #}
+        {# This is a custom form listing possible active versions, to select default, stable  #}
+        <h2> {{ field.label }} </h2>
+        {{ field }}
+        
+    {% elif forloop.counter0 == 1  %}
         <h2> {{ field.label }} </h2>
         {{ field }}
     <p>
@@ -22,8 +26,7 @@
     </p>
 
     {% else %}
-
-        {% if forloop.counter0 == 1 %}
+        {% if forloop.counter0 == 2 %}
             <h2> {% trans "Choose Active Versions" %} </h2>
             <p>
             {% trans "Active versions below will show up on the site." %}


### PR DESCRIPTION
regarding #3279 
@ericholscher, @humitos, I have added a drop-down input to manually set the stable version. I have also started working on `yaml` setting for stable version but need some feature overview.  

- if `stable_version` in `yaml` file, disable stable version setting from UI and give preference to `yaml` setting.
- if `yaml` setting is not a valid version, then use default `readthedocs` mechanism for getting stable branch.

 Is this fine? 