### PR TITLE
Fixes #2953 - Url resolved with special characters

### DIFF
--- a/readthedocs/profiles/urls/public.py
+++ b/readthedocs/profiles/urls/public.py
@@ -7,7 +7,7 @@ from readthedocs.profiles import views
 
 
 urlpatterns = [
-    url(r'^(?P<username>[\w@.-]+)/$',
+    url(r'^(?P<username>[+\w@.-]+)/$',
         views.profile_detail,
         {'template_name': 'profiles/public/profile_detail.html'},
         name='profiles_profile_detail'),

--- a/readthedocs/rtd_tests/tests/test_urls.py
+++ b/readthedocs/rtd_tests/tests/test_urls.py
@@ -51,3 +51,25 @@ class TestVersionURLs(TestCase):
             kwargs={'type_': 'pdf', 'version_slug': u'1.4.X', 'project_slug': u'django'}
         )
         self.assertTrue(url)
+
+
+class TestProfileDetailURLs(TestCase):
+
+    def test_profile_detail_url(self):
+        url = reverse(
+            'profiles_profile_detail',
+            kwargs={'username': 'foo+bar'}
+            )
+        self.assertEqual(url, '/profiles/foo+bar/')
+
+        url = reverse(
+            'profiles_profile_detail',
+            kwargs={'username': 'abc+def@ghi.jkl'}
+            )
+        self.assertEqual(url, '/profiles/abc+def@ghi.jkl/')
+
+        url = reverse(
+            'profiles_profile_detail',
+            kwargs={'username': 'abc-def+ghi'}
+            )
+        self.assertEqual(url, '/profiles/abc-def+ghi/')

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -241,30 +241,3 @@ class SubprojectViewTests(TestCase):
             '/dashboard/my-mainproject/subprojects/my-subproject/delete/')
         self.assertEqual(response.status_code, 302)
         self.assertTrue(self.subproject not in [r.child for r in self.project.subprojects.all()])
-
-class URLResolution(TestCase):
-    def setUp(self):
-        self.user1 = new(User, username='foo+bar')
-        self.user1.set_password('test1')
-        self.user1.save()
-
-        self.user2 = new(User, username='abc+def@ghi.jkl')
-        self.user2.set_password('test2')
-        self.user2.save()
-
-        self.user3 = new(User, username='abc-def+ghi')
-        self.user3.set_password('test3')
-        self.user3.save()
-
-        self.client.login(username='foo+bar', password='test1')
-
-    def test_profile_details_page(self):
-
-        response = self.client.get('/profiles/foo+bar/')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get('/profiles/abc+def@ghi.jkl/')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get('/profiles/abc-def+ghi/')
-        self.assertEqual(response.status_code, 200)

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -241,3 +241,30 @@ class SubprojectViewTests(TestCase):
             '/dashboard/my-mainproject/subprojects/my-subproject/delete/')
         self.assertEqual(response.status_code, 302)
         self.assertTrue(self.subproject not in [r.child for r in self.project.subprojects.all()])
+
+class URLResolution(TestCase):
+    def setUp(self):
+        self.user1 = new(User, username='foo+bar')
+        self.user1.set_password('test1')
+        self.user1.save()
+
+        self.user2 = new(User, username='abc+def@ghi.jkl')
+        self.user2.set_password('test2')
+        self.user2.save()
+
+        self.user3 = new(User, username='abc-def+ghi')
+        self.user3.set_password('test3')
+        self.user3.save()
+
+        self.client.login(username='foo+bar', password='test1')
+
+    def test_profile_details_page(self):
+
+        response = self.client.get('/profiles/foo+bar/')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get('/profiles/abc+def@ghi.jkl/')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get('/profiles/abc-def+ghi/')
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This PR Fixes #2953. I have added the `+` character to the username set. Rest all characters `letters` , `numbers`, `-` and `_` were already doing fine with the URL.
