### PR TITLE
add admin functions for wiping a version

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -3,6 +3,7 @@
 
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
+import os
 
 from builtins import object
 from random import choice
@@ -18,7 +19,8 @@ from guardian.shortcuts import assign
 from textclassifier.validators import ClassifierValidator
 
 from readthedocs.builds.constants import TAG
-from readthedocs.core.utils import slugify, trigger_build
+from readthedocs.core.utils import slugify, trigger_build, broadcast
+from readthedocs.projects.tasks import remove_dir
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteRepository
 from readthedocs.projects import constants
@@ -323,6 +325,7 @@ class BaseVersionsForm(forms.Form):
         versions = self.project.versions.all()
         for version in versions:
             self.save_version(version)
+            self.wipe_build_environment(version)
         default_version = self.cleaned_data.get('default-version', None)
         if default_version:
             self.project.default_version = default_version
@@ -347,6 +350,20 @@ class BaseVersionsForm(forms.Form):
         if version.active and not version.built and not version.uploaded:
             trigger_build(project=self.project, version=version)
 
+    def wipe_build_environment(self, version):
+        wipe_action = self.cleaned_data.get(
+            'wipe-{}'.format(version.slug),
+            False,
+        )
+        if wipe_action:
+            del_dirs = [
+                os.path.join(version.project.doc_path, 'checkouts', version.slug),
+                os.path.join(version.project.doc_path, 'envs', version.slug),
+                os.path.join(version.project.doc_path, 'conda', version.slug),
+            ]
+            for del_dir in del_dirs:
+                broadcast(type='build', task=remove_dir, args=[del_dir])
+
 
 def build_versions_form(project):
     """Versions form with a list of versions and version privacy levels."""
@@ -365,6 +382,7 @@ def build_versions_form(project):
     for version in versions_qs:
         field_name = 'version-{}'.format(version.slug)
         privacy_name = 'privacy-{}'.format(version.slug)
+        wipe_name = 'wipe-{}'.format(version.slug)
         if version.type == TAG:
             label = '{} ({})'.format(
                 version.verbose_name,
@@ -377,6 +395,12 @@ def build_versions_form(project):
             widget=DualCheckboxWidget(version),
             initial=version.active,
             required=False,
+        )
+        attrs[wipe_name] = forms.BooleanField(
+            # This isn't a real label, but just a slug for the template
+            label='wipe',
+            widget=forms.CheckboxInput,
+            required=False
         )
         attrs[privacy_name] = forms.ChoiceField(
             # This isn't a real label, but just a slug for the template

--- a/readthedocs/templates/projects/project_versions.html
+++ b/readthedocs/templates/projects/project_versions.html
@@ -39,9 +39,12 @@
             {% trans "Tags" %}: {{ field }}
         {% endcomment %}
 
+        {% elif field.label == 'wipe' %}
+          {% trans "Wipe" %} {{ field }}
+
         {% else %}
         {# This is a custom field with a label of the version, and a value of a checkbox denoting if it is active #}
-        <h3>{{ field.label}}</h3>
+        <h3>{{ field.label }}</h3>
           {% trans "Active" %} {{ field }}
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Issue #3684: @agjohnson, I've added a `wipe_build_environment` method in the form class. But you mentioned about rethinking the process in order to have a reusable wipe view.
I'd like to discuss potential ways in which the functionality can be achieved.
Also, how about adding a proxy method to `Version` model to wipe a build environment? This will remove repeated code.
