### PR TITLE
Allow domains with port on it

### DIFF
--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -79,10 +79,10 @@ class SubdomainMiddleware(object):
                 'localhost' not in host and
                 'testserver' not in host):
             request.cname = True
-            domains = Domain.objects.filter(domain=host)
-            if domains.count():
+            domains = Domain.objects.filter(domain=full_host)
+            if domains.exists():
                 for domain in domains:
-                    if domain.domain == host:
+                    if domain.domain == full_host:
                         request.slug = domain.project.slug
                         request.urlconf = SUBDOMAIN_URLCONF
                         request.domain_object = True

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -57,6 +57,18 @@ class MiddlewareTests(TestCase):
         self.assertEqual(request.domain_object, True)
         self.assertEqual(request.slug, 'pip')
 
+    def test_domain_object_with_port(self):
+        self.domain = get(
+            Domain,
+            domain='docs.foobar.com:8000',
+            project=self.pip,
+        )
+        request = self.factory.get(self.url, HTTP_HOST='docs.foobar.com:8000')
+        self.middleware.process_request(request)
+        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
+        self.assertEqual(request.domain_object, True)
+        self.assertEqual(request.slug, 'pip')
+
     def test_domain_object_missing(self):
         self.domain = get(Domain, domain='docs.foobar2.com', project=self.pip)
         request = self.factory.get(self.url, HTTP_HOST='docs.foobar.com')


### PR DESCRIPTION
I added support to the middleware --that detects if it's a subdomain/custom domain and add the `project_slug` to the request, for using a port in the domain name. So, `docs.example.com:8000` is a valid custom domain.

I needed this for a PR in the corporate site to redirect the user to the proper URL when trying to hit a protected documentation page.

To cover this case, I wrote a new test case that do not pass without the code that I'm just adding --but I'm not 100% sure that this wont affect other place