### PR TITLE
RFC: view for project and its subprojects

### DIFF
--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render, get_object_or_404, redirect
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, DetailView
 
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
@@ -41,6 +41,21 @@ class HomepageView(TemplateView):
         context = super(HomepageView, self).get_context_data(**kwargs)
         context['featured_list'] = Project.objects.filter(featured=True)
         context['projects_count'] = Project.objects.count()
+        return context
+
+
+class ProjectView(DetailView):
+
+    model = Project
+    context_object_name = 'project'
+    template_name = 'project.html'
+    queryset = Project.objects.all()
+
+    def get_context_data(self, **kwargs):
+        """Add children projects."""
+        context = super(ProjectView, self).get_context_data(**kwargs)
+        project = context['project']
+        context['project_list'] = project.related_projects.all()
         return context
 
 

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -14,6 +14,31 @@ from readthedocs.search.signals import (before_project_search,
                                         before_section_search)
 
 
+def search_project_filter(request, project_slug):
+    project = (Project.objects
+               .api(request.user)
+               .get(slug=project_slug))
+    project_slugs = [project.slug]
+    # We need to use the obtuse syntax here because the manager
+    # doesn't pass along to ProjectRelationships
+    project_slugs.extend(s.slug for s
+                         in Project.objects.public(
+                             request.user).filter(
+                             superprojects__parent__slug=project.slug))
+    project_filter = {"terms": {"project": project_slugs}}
+
+    # Add routing to optimize search by hitting the right shard.
+    # This purposely doesn't apply routing if the project has more
+    # than one parent project.
+    if project.superprojects.exists():
+        if project.superprojects.count() == 1:
+            routing = (project.superprojects.first()
+                       .parent.slug)
+    else:
+        routing = project_slug
+    return project_filter, routing
+
+
 def search_project(request, query, language=None):
     """Search index for projects matching query."""
     body = {
@@ -116,29 +141,12 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
 
         if project_slug:
             try:
-                project = (Project.objects
-                           .api(request.user)
-                           .get(slug=project_slug))
-                project_slugs = [project.slug]
-                # We need to use the obtuse syntax here because the manager
-                # doesn't pass along to ProjectRelationships
-                project_slugs.extend(s.slug for s
-                                     in Project.objects.public(
-                                         request.user).filter(
-                                         superprojects__parent__slug=project.slug))
-                final_filter['and'].append({"terms": {"project": project_slugs}})
-
-                # Add routing to optimize search by hitting the right shard.
-                # This purposely doesn't apply routing if the project has more
-                # than one parent project.
-                if project.superprojects.exists():
-                    if project.superprojects.count() == 1:
-                        kwargs['routing'] = (project.superprojects.first()
-                                             .parent.slug)
-                else:
-                    kwargs['routing'] = project_slug
+                project_filter, routing = search_project_filter(request, project_slug)
             except Project.DoesNotExist:
                 return None
+
+            final_filter['and'].append(project_filter)
+            kwargs['routing'] = routing
 
         if version_slug:
             final_filter['and'].append({'term': {'version': version_slug}})

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -46,7 +46,8 @@ def elastic_search(request):
     if user_input.query:
         if user_input.type == 'project':
             results = search_lib.search_project(
-                request, user_input.query, language=user_input.language)
+                request, user_input.query, language=user_input.language,
+                project_slug=user_input.project)
         elif user_input.type == 'file':
             results = search_lib.search_file(
                 request, user_input.query, project_slug=user_input.project,

--- a/readthedocs/templates/core/widesearchbar.html
+++ b/readthedocs/templates/core/widesearchbar.html
@@ -10,6 +10,7 @@
             <form action="{% url "search" %}" method="GET">
               <div class="text-input-wrapper">
                 <input type="text" name="q" value="{{ term }}" id="id_site_search" placeholder="{% trans 'Search Read the Docs' %}">
+                <input type="hidden" name="project" value="{{ project_slug }}">
               </div>
               <div class="submit-input-wrapper">
                 {% comment %} Translators: This is about starting a search {% endcomment %}

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -112,7 +112,7 @@
 
   <!-- Search -->
   <section>
-    {% include "core/widesearchbar.html" %}
+    {% include "core/widesearchbar.html" with project_slug="" %}
   </section>
 
   {% if featured_list %}

--- a/readthedocs/templates/project.html
+++ b/readthedocs/templates/project.html
@@ -50,7 +50,7 @@
 
   <!-- Search -->
   <section>
-    {% include "core/widesearchbar.html" %}
+    {% include "core/widesearchbar.html" with project_slug=project.slug %}
   </section>
 
   {% if project_list %}

--- a/readthedocs/templates/project.html
+++ b/readthedocs/templates/project.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% load humanize %}
+{% load pagination_tags %}
+
+{% block extra_metas %}
+  <meta name="description" content="{% trans "Read the Docs simplifies technical documentation by automating building, versioning, and hosting for you. Build up-to-date documentation for the web, print, and offline use on every version control push automatically." %}">
+{% endblock extra_metas %}
+
+{% block title %}{% trans "Home" %}{% endblock %}
+
+{% block body_class %}home {% if not request.user.is_authenticated %}splash{% endif %}{% endblock %}
+
+{% block nav-browse %}class="active"{% endblock %}
+
+{% block header-wrapper %}
+  {% if request.user.is_authenticated %}
+    {% include "core/header.html" %}
+  {% else %}
+    {% include "core/home-header.html" %}
+  {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+        <script>
+    $(document).ready(function() {
+            // Show action on hover
+            $(".module-item-menu").hover(
+              function () {
+                $(".hidden-child", this).show();
+              }, function () {
+                $(".hidden-child", this).hide();
+              }
+            );
+    });
+        </script>
+{% endblock %}
+
+
+{% block content %}
+
+  <!-- Lead -->
+  <section>
+    <h2>{{ project.name }}</h2>
+    <p class="lead">
+    {{ project.description }}
+    </p>
+  </section>
+
+  <!-- Search -->
+  <section>
+    {% include "core/widesearchbar.html" %}
+  </section>
+
+  {% if project_list %}
+    <!-- BEGIN projects list -->
+    <section>
+      <h3>{% trans "Projects" %}</h3>
+      <div class="module-list">
+        <div class="module-list-wrapper">
+          <ul style="margin-bottom: 0">
+            {% include "core/project_list.html" %}
+          </ul>
+        </div>
+      </div>
+    </section>
+    <!-- END projects list -->
+  {% endif %}
+{% endblock %}

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -14,9 +14,10 @@ from tastypie.api import Api
 from readthedocs.api.base import (ProjectResource, UserResource,
                                   VersionResource, FileResource)
 from readthedocs.core.urls import docs_urls, core_urls, deprecated_urls
-from readthedocs.core.views import (HomepageView, SupportView,
+from readthedocs.core.views import (HomepageView, SupportView, ProjectView,
                                     server_error_404, server_error_500)
 from readthedocs.search import views as search_views
+from readthedocs.constants import pattern_opts
 
 
 v1_api = Api(api_name='v1')
@@ -32,6 +33,8 @@ handler500 = server_error_500
 
 basic_urls = [
     url(r'^$', HomepageView.as_view(), name='homepage'),
+    url(r'^project/(?P<slug>{project_slug})/$'.format(**pattern_opts),
+        ProjectView.as_view(), name='project_home_detail'),
     url(r'^support/', SupportView.as_view(), name='support'),
     url(r'^security/', TemplateView.as_view(template_name='security.html')),
     url(r'^.well-known/security.txt',


### PR DESCRIPTION
We need something like the concept of an organization that collects more than one project. Fortunately we can do this kind of hierarchy using the subprojects. What we are missing though are a view that will return a project and its subprojects and the ability to restrict search results within a projects and its subprojects. This is what is inside this PR.
The work is still raw, tests are missing and there may be details to iron out but appear to work fine on my local installation :)
I'm posting this because I'd like to know if the idea is sound and is something you'll accept upstream.