### PR TITLE
#3757 Split requirements/pip.txt for LocalBuildEnvironment and RTD sp…

### DIFF
--- a/requirements/local-docs-build.txt
+++ b/requirements/local-docs-build.txt
@@ -1,0 +1,8 @@
+mkdocs==0.14.0
+sphinxcontrib-httpdomain==1.4.0
+commonmark==0.5.5
+recommonmark==0.4.0
+docutils==0.11
+readthedocs-build<2.1
+Sphinx==1.5.3
+sphinx_rtd_theme==0.2.5b1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -2,15 +2,10 @@
 pip==9.0.1
 appdirs==1.4.3
 virtualenv==15.0.1
-docutils==0.11
-Sphinx==1.5.3
-sphinx_rtd_theme==0.2.5b1
 Pygments==2.2.0
-mkdocs==0.14.0
 django==1.9.12
 six==1.10.0
 future==0.16.0
-readthedocs-build<2.1
 
 django-tastypie==0.13.0
 django-haystack==2.6.0
@@ -58,10 +53,6 @@ django-messages-extends==0.5
 djangorestframework-jsonp==1.0.2
 django-taggit==0.22.2
 
-# Docs
-sphinxcontrib-httpdomain==1.4.0
-commonmark==0.5.5
-recommonmark==0.4.0
 
 # Version comparison stuff
 packaging==16.8


### PR DESCRIPTION
I have tested manually by creating the virtualenv and the server runs successfully without the packages that has been transferred to local-docs-build.txt.