### PR TITLE
Fix tox env for coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
 
 [testenv:coverage]
 deps =
-    -r{toxinidir}/requirements/pip.txt
+    -r{toxinidir}/requirements/testing.txt
     pytest-cov
 whitelist_externals = echo
 commands =


### PR DESCRIPTION
I was trying to run `tox -e coverage` but were missing dependencies from `requirements/testing.txt` (like pytest-django).