### PR TITLE
#3757: Split requirements/pip.txt

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,4 +1,5 @@
 -r pip.txt
+-r local-docs-build.txt
 psycopg2==2.7.3.2
 gunicorn==19.1.0
 pysolr==2.0.13
@@ -10,6 +11,6 @@ hiredis==0.1.2
 maxcdn==0.0.7
 
 #For resizing images
-pillow
+pillow==2.6.1
 
 cssselect==0.7.1

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,4 +1,5 @@
 -r pip.txt
+-r local-docs-build.txt
 maxcdn
 astroid
 pylint

--- a/requirements/local-docs-build.txt
+++ b/requirements/local-docs-build.txt
@@ -1,0 +1,8 @@
+mkdocs==0.15.0
+sphinxcontrib-httpdomain==1.4.0
+commonmark==0.5.4
+recommonmark==0.4.0
+docutils==0.13.1
+Sphinx==1.5.3
+sphinx_rtd_theme<0.3
+readthedocs-build<2.1

--- a/requirements/onebox.txt
+++ b/requirements/onebox.txt
@@ -1,4 +1,5 @@
 -r pip.txt
+-r local-docs-build.txt
 gunicorn
 #For resizing images
 pillow

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,16 +1,14 @@
+#LOCAL-DOCS-BUILD PACKAGE
+-r local-docs-build.txt
+
 # Base packages
 pip==9.0.1
 appdirs==1.4.3
 virtualenv==15.0.1
-docutils==0.11
-Sphinx==1.5.3
-sphinx_rtd_theme==0.2.5b1
 Pygments==2.2.0
-mkdocs==0.14.0
 django==1.9.12
 six==1.10.0
 future==0.16.0
-readthedocs-build<2.1
 
 django-tastypie==0.13.0
 django-haystack==2.6.0
@@ -58,10 +56,6 @@ django-messages-extends==0.5
 djangorestframework-jsonp==1.0.2
 django-taggit==0.22.2
 
-# Docs
-sphinxcontrib-httpdomain==1.4.0
-commonmark==0.5.5
-recommonmark==0.4.0
 
 # Version comparison stuff
 packaging==16.8

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,4 +1,5 @@
 -r pip.txt
+-r local-docs-build.txt
 
 pytest<4,>=3.3.2
 pytest-django==3.1.2


### PR DESCRIPTION
Hi @humitos , I have made the requested changes in pull request #3767  here which references the issue #3757 

1. Separated requirements/pip.txt and requirements/local-docs-build.txt
2. Included requirements/local-docs-build.txt into requirements/pip.txt since it's used to parse the YAML file.
3. Matched the versions installed by default under readthedocs/doc-builder/python_environments.py with the versions in requirements/