### PR TITLE
Add temporary method for skipping submodule checkout

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1067,12 +1067,14 @@ class Feature(models.Model):
     USE_SETUPTOOLS_LATEST = 'use_setuptools_latest'
     ALLOW_DEPRECATED_WEBHOOKS = 'allow_deprecated_webhooks'
     PIP_ALWAYS_UPGRADE = 'pip_always_upgrade'
+    SKIP_SUBMODULES = 'skip_submodules'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
         (USE_SETUPTOOLS_LATEST, _('Use latest version of setuptools')),
         (ALLOW_DEPRECATED_WEBHOOKS, _('Allow deprecated webhook views')),
         (PIP_ALWAYS_UPGRADE, _('Always run pip install --upgrade')),
+        (SKIP_SUBMODULES, _('Skip git submodule checkout')),
     )
 
     projects = models.ManyToManyField(

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import
 from os.path import exists
 
 from django.contrib.auth.models import User
+import django_dynamic_fixture as fixture
 
-from readthedocs.projects.models import Project
+from readthedocs.projects.models import Project, Feature
 from readthedocs.rtd_tests.base import RTDTestCase
 
 from readthedocs.rtd_tests.utils import make_test_git, make_test_hg
@@ -82,11 +83,23 @@ class TestGitBackend(RTDTestCase):
         repo = self.project.vcs_repo()
 
         repo.checkout()
-        self.assertFalse(repo.submodules_exists())
+        self.assertFalse(repo.are_submodules_available())
 
         # The submodule branch contains one submodule
         repo.checkout('submodule')
-        self.assertTrue(repo.submodules_exists())
+        self.assertTrue(repo.are_submodules_available())
+
+    def test_skip_submodule_checkout(self):
+        repo = self.project.vcs_repo()
+        repo.checkout('submodule')
+        self.assertTrue(repo.are_submodules_available())
+        feature = fixture.get(
+            Feature,
+            projects=[self.project],
+            feature_id=Feature.SKIP_SUBMODULES,
+        )
+        self.assertTrue(self.project.has_feature(Feature.SKIP_SUBMODULES))
+        self.assertFalse(repo.are_submodules_available())
 
 
 class TestHgBackend(RTDTestCase):

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -85,7 +85,20 @@ class Backend(BaseVCS):
         return [code, out, err]
 
     def clone(self):
-        code, _, _ = self.run('git', 'clone', '--recursive', self.repo_url, '.')
+        """Clone the repository
+
+        .. note::
+            Temporarily, we support skipping submodule recursive clone via a
+            feature flag. This will eventually be configureable with our YAML
+            config.
+        """
+        # TODO remove with https://github.com/rtfd/readthedocs-build/issues/30
+        from readthedocs.projects.models import Feature
+        cmd = ['git', 'clone']
+        if not self.project.has_feature(Feature.SKIP_SUBMODULES):
+            cmd.append('--recursive')
+        cmd.extend([self.repo_url, '.'])
+        code, _, _ = self.run(*cmd)
         if code != 0:
             raise RepositoryError
 

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -55,9 +55,11 @@ class Backend(BaseVCS):
         return code == 0
 
     def are_submodules_available(self):
-        """Test whether git submodule checkout step should be performed
+        """
+        Test whether git submodule checkout step should be performed.
 
         .. note::
+
             Temporarily, we support skipping these steps as submodule step can
             fail if using private submodules. This will eventually be
             configureable with our YAML config.
@@ -85,9 +87,11 @@ class Backend(BaseVCS):
         return [code, out, err]
 
     def clone(self):
-        """Clone the repository
+        """
+        Clone the repository.
 
         .. note::
+
             Temporarily, we support skipping submodule recursive clone via a
             feature flag. This will eventually be configureable with our YAML
             config.

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -52,6 +52,7 @@ class BaseVCS(object):
     # pylint: disable=unused-argument
     def __init__(self, project, version_slug, environment=None, **kwargs):
         self.default_branch = project.default_branch
+        self.project = project
         self.name = project.name
         self.repo_url = project.clean_repo
         self.working_dir = project.checkout_path(version_slug)


### PR DESCRIPTION
This adds a project feature that allows for a project to specify that they would
like to skip submodule installation. Currently we are forcing all submodules to
be checked out, so this fails on private submodules.

Refs https://github.com/rtfd/readthedocs-build/issues/30

Based on #3822 for autolint cleanup