### PR TITLE
Pip install note for Windows

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -28,6 +28,10 @@ Assuming you have Python_ already, `install Sphinx`_::
 
     $ pip install sphinx sphinx-autobuild
 
+.. note:: If your **pip** commands fail on Windows, try the following version:
+
+    python -m pip install ...
+
 Create a directory inside your project to hold your docs::
 
     $ cd /path/to/project


### PR DESCRIPTION
Added note about Windows issue with "pip install" (the original path has spaces in the installation folder so the command fails).