### PR TITLE
Send notifications when generic/unhandled failures

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -366,6 +366,9 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                     )
                 )
                 self.setup_env.update_build(BUILD_STATE_FINISHED)
+
+            # Send notifications for unhandled errors
+            self.send_notifications()
             return False
         else:
             # No exceptions in the setup step, catch unhandled errors in the
@@ -391,6 +394,9 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                         )
                     )
                     self.build_env.update_build(BUILD_STATE_FINISHED)
+
+                # Send notifications for unhandled errors
+                self.send_notifications()
                 return False
 
         return True


### PR DESCRIPTION
This PR used to have a test case but it wasn't accurate. I decided to remove it and leave this small piece of code untested (send an email on unhandled failures). It shouldn't be terrible and it does fix an issue that our customer are having at the moment.

We can improve this later when a re-work is done around the `UpdateDocsTask` and how all the steps of this task are managed.