### PR TITLE
add description for tox tasks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion=2.9.0
 envlist = py{27,36},lint,docs
 skipsdist = True
 
@@ -8,6 +9,7 @@ python =
     3.6: py36
 
 [testenv]
+description = run test suite for the application with {basepython}
 setenv =
     PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
     DJANGO_SETTINGS_MODULE=readthedocs.settings.test
@@ -19,11 +21,13 @@ commands =
     py.test {posargs}
 
 [testenv:docs]
+description = build readthedocs documentation
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
 [testenv:lint]
+description = run linter (prospector) to ensure the source code corresponds to our coding standards
 deps = -r{toxinidir}/requirements/lint.txt
 commands =
     prospector \
@@ -36,10 +40,12 @@ commands =
     --die-on-tool-error {posargs}
 
 [testenv:eslint]
+description = run the JavaScript linter (requires gulp installed)
 commands =
     gulp lint
 
 [testenv:coverage]
+description = run test suite with code coverage for the application with {basepython}
 deps =
     -r{toxinidir}/requirements/testing.txt
     pytest-cov


### PR DESCRIPTION
For example:

```bash
tox -av 
default environments:
py27     -> run test suite for the application with python2.7
py36     -> run test suite for the application with python3.6
lint     -> run linter (prospector) to ensure the source code corresponds to our coding standards
docs     -> build readthedocs documentation

additional environments:
coverage -> run test suite with code coverage for the application with /usr/bin/python
eslint   -> run the JavaScript linter (requires gulp installed)
```