### PR TITLE
various tox improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.swp
 .DS_Store
 .cache
-.coverage
+.coverage*
 .idea
 .vagrant
 .vscode

--- a/tox.ini
+++ b/tox.ini
@@ -1,56 +1,44 @@
 [tox]
-minversion=2.9.0
+minversion = 2.9.0
 envlist = py{27,36},lint,docs
 skipsdist = True
 
 [travis]
-python =
-    2.7: py27
-    3.6: py36
+python = 2.7: py27
+         3.6: py36
 
 [testenv]
 description = run test suite for the application with {basepython}
-setenv =
-    PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
-    DJANGO_SETTINGS_MODULE=readthedocs.settings.test
-    LANG=C
-    DJANGO_SETTINGS_SKIP_LOCAL=True
+setenv = PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
+         DJANGO_SETTINGS_MODULE=readthedocs.settings.test
+         LANG=C
+         DJANGO_SETTINGS_SKIP_LOCAL=True
 deps = -r{toxinidir}/requirements/testing.txt
 changedir = {toxinidir}/readthedocs
-commands =
-    py.test {posargs}
+commands = pytest {posargs}
 
 [testenv:docs]
 description = build readthedocs documentation
 changedir = {toxinidir}/docs
-commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+passenv = HOME http_proxy https_proxy no_proxy
+commands = sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:lint]
 description = run linter (prospector) to ensure the source code corresponds to our coding standards
 deps = -r{toxinidir}/requirements/lint.txt
-commands =
-    prospector \
-    --profile-path={toxinidir} \
-    --profile=prospector-more \
-    --die-on-tool-error {posargs}
-    prospector \
-    --profile-path={toxinidir} \
-    --profile=prospector \
-    --die-on-tool-error {posargs}
+commands = prospector --profile-path={toxinidir} --die-on-tool-error \
+                --profile=prospector-more  {posargs}
+           prospector --profile-path={toxinidir} --die-on-tool-error \
+                --profile=prospector  {posargs}
 
 [testenv:eslint]
 description = run the JavaScript linter (requires gulp installed)
-commands =
-    gulp lint
+whitelist_externals = gulp
+commands = gulp lint
 
 [testenv:coverage]
 description = run test suite with code coverage for the application with {basepython}
-deps =
-    -r{toxinidir}/requirements/testing.txt
-    pytest-cov
-whitelist_externals = echo
-commands =
-    py.test --disable-pytest-warnings \
-        --cov-report=term --cov-report=html --cov=. {posargs}
-    echo Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html
+deps = {[testenv]deps}
+       pytest-cov >= 2.5.1, <3
+commands = pytest --disable-pytest-warnings --cov-report=term --cov-report=html --cov=. {posargs}
+           python -c 'print("Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html")'


### PR DESCRIPTION
- pass proxy environment variables to docs (as these are needed to fetch correctly intersphinx files behind proxies)
- better indentation for commands to see where boundaries between commands are
- do not start all definitions on new line, this makes the file more compact and readable
- use references instead of repeating dependencies, and version qualify dependency
- replace echo with Python for not relying on OS packages
- also ignore intermediate coverage files
