### PR TITLE
Organize logging levels

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -247,7 +247,7 @@ class Version(models.Model):
         try:
             path = self.get_build_path()
             if path is not None:
-                log.debug('Removing build path {0} for {1}'.format(path, self))
+                log.debug('Removing build path %s for %s', path, self)
                 rmtree(path)
         except OSError:
             log.exception('Build path cleanup failed')

--- a/readthedocs/builds/syncers.py
+++ b/readthedocs/builds/syncers.py
@@ -58,8 +58,7 @@ class RemoteSyncer(object):
                 mkdir_cmd = ("ssh %s@%s mkdir -p %s" % (sync_user, server, target))
                 ret = os.system(mkdir_cmd)
                 if ret != 0:
-                    log.info("COPY ERROR to app servers:")
-                    log.info(mkdir_cmd)
+                    log.error("Copy error to app servers: cmd=%s", mkdir_cmd)
                 if is_file:
                     slash = ""
                 else:
@@ -75,8 +74,7 @@ class RemoteSyncer(object):
                         target=target))
                 ret = os.system(sync_cmd)
                 if ret != 0:
-                    log.info("COPY ERROR to app servers.")
-                    log.info(sync_cmd)
+                    log.error("Copy error to app servers: cmd=%s", sync_cmd)
 
 
 class DoubleRemotePuller(object):
@@ -100,8 +98,7 @@ class DoubleRemotePuller(object):
                 )
                 ret = os.system(mkdir_cmd)
                 if ret != 0:
-                    log.info("MKDIR ERROR to app servers:")
-                    log.info(mkdir_cmd)
+                    log.error("MkDir error to app servers: cmd=%s", mkdir_cmd)
             # Add a slash when copying directories
             sync_cmd = (
                 "ssh {user}@{server} 'rsync -av "
@@ -114,8 +111,7 @@ class DoubleRemotePuller(object):
                     target=target))
             ret = os.system(sync_cmd)
             if ret != 0:
-                log.info("COPY ERROR to app servers.")
-                log.info(sync_cmd)
+                log.error("Copy error to app servers: cmd=%s", sync_cmd)
 
 
 class RemotePuller(object):
@@ -142,7 +138,11 @@ class RemotePuller(object):
         )
         ret = os.system(sync_cmd)
         if ret != 0:
-            log.error("COPY ERROR to app servers. Command: [{}] Return: [{}]".format(sync_cmd, ret))
+            log.error(
+                "Copy error to app servers. Command: [%s] Return: [%s]",
+                sync_cmd,
+                ret,
+            )
 
 
 class Syncer(SettingsOverrideObject):

--- a/readthedocs/core/management/commands/clean_builds.py
+++ b/readthedocs/core/management/commands/clean_builds.py
@@ -44,14 +44,19 @@ class Command(BaseCommand):
                 version = Version.objects.get(id=build['version'])
                 latest_build = version.builds.latest('date')
                 if latest_build.date > max_date:
-                    log.warning('{0} is newer than {1}'.format(
-                        latest_build, max_date))
+                    log.warning(
+                        '%s is newer than %s',
+                        latest_build,
+                        max_date,
+                    )
                 path = version.get_build_path()
                 if path is not None:
                     log.info(
-                        ('Found stale build path for {0} '
-                         'at {1}, last used on {2}').format(
-                            version, path, latest_build.date))
+                        'Found stale build path for %s at %s, last used on %s',
+                        version,
+                        path,
+                        latest_build.date,
+                    )
                     if not options['dryrun']:
                         version.clean_build_path()
             except Version.DoesNotExist:

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -53,4 +53,4 @@ class Command(BaseCommand):
                 update_search(version.pk, commit,
                               delete_non_commit_files=False)
             except Exception:
-                log.exception('Reindex failed for {}'.format(version))
+                log.exception('Reindex failed for %s', version)

--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -57,10 +57,9 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
             project = Project.objects.get(slug=project_slug)
         except Project.DoesNotExist:
             log.warning(
-                'Invalid project passed to domain. [{project}:{domain}'.format(
-                    project=project_slug,
-                    domain=host,
-                )
+                'Invalid project passed to domain. [%s:%s]',
+                project_slug,
+                host,
             )
             return False
 

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -233,12 +233,13 @@ def gitlab_build(request):  # noqa: D205
         log.info(
             'GitLab webhook search: url=%s branches=%s',
             search_url,
-            branches
+            branches,
         )
         projects = get_project_from_url(search_url)
         if projects:
             return _build_url(search_url, projects, branches)
-        log.error('Project match not found: url=%s', search_url)
+
+        log.info('Project match not found: url=%s', search_url)
         return HttpResponseNotFound('Project match not found')
     return HttpResponse('Method not allowed, POST is required', status=405)
 
@@ -294,7 +295,7 @@ def bitbucket_build(request):
         log.info(
             'Bitbucket webhook search: url=%s branches=%s',
             search_url,
-            branches
+            branches,
         )
         log.debug('Bitbucket webhook payload:\n\n%s\n\n', data)
         projects = get_project_from_url(search_url)
@@ -304,10 +305,10 @@ def bitbucket_build(request):
             log.error(
                 'Commit/branch not found url=%s branches=%s',
                 search_url,
-                branches
+                branches,
             )
             return HttpResponseNotFound('Commit/branch not found')
-        log.error('Project match not found: url=%s', search_url)
+        log.info('Project match not found: url=%s', search_url)
         return HttpResponseNotFound('Project match not found')
     return HttpResponse('Method not allowed, POST is required', status=405)
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -445,12 +445,12 @@ class BuildEnvironment(BaseEnvironment):
         a failure and the context will be gracefully exited.
         """
         if exc_type is not None:
-            log.error(LOG_TEMPLATE
-                      .format(project=self.project.slug,
-                              version=self.version.slug,
-                              msg=exc_value),
-                      exc_info=True)
             if not issubclass(exc_type, BuildEnvironmentWarning):
+                log.error(LOG_TEMPLATE
+                          .format(project=self.project.slug,
+                                  version=self.version.slug,
+                                  msg=exc_value),
+                          exc_info=True)
                 self.failure = exc_value
             return True
 
@@ -574,10 +574,9 @@ class BuildEnvironment(BaseEnvironment):
             try:
                 api_v2.build(self.build['id']).put(self.build)
             except HttpClientError as e:
-                log.error(
-                    "Unable to update build: id=%d error=%s",
+                log.exception(
+                    "Unable to update build: id=%d",
                     self.build['id'],
-                    e.content,
                 )
             except Exception:
                 log.exception("Unknown build exception")

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -138,7 +138,7 @@ class Service(object):
             return results
         # Catch specific exception related to OAuth
         except InvalidClientIdError:
-            log.error('access_token or refresh_token failed: %s', url)
+            log.warning('access_token or refresh_token failed: %s', url)
             raise Exception('You should reconnect your account')
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
@@ -149,7 +149,10 @@ class Service(object):
             except ValueError:
                 debug_data = resp.content
             log.debug(
-                'paginate failed at %s with response: %s', url, debug_data)
+                'Paginate failed at %s with response: %s',
+                url,
+                debug_data,
+            )
         else:
             return []
 

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -45,8 +45,7 @@ class BitbucketService(Service):
             for repo in repos:
                 self.create_repository(repo)
         except (TypeError, ValueError) as e:
-            log.error('Error syncing Bitbucket repositories: %s',
-                      str(e), exc_info=True)
+            log.exception('Error syncing Bitbucket repositories')
             raise Exception('Could not sync your Bitbucket repositories, '
                             'try reconnecting your account')
 
@@ -80,8 +79,7 @@ class BitbucketService(Service):
                 for repo in repos:
                     self.create_repository(repo, organization=org)
         except ValueError as e:
-            log.error('Error syncing Bitbucket organizations: %s',
-                      str(e), exc_info=True)
+            log.exception('Error syncing Bitbucket organizations')
             raise Exception('Could not sync your Bitbucket team repositories, '
                             'try reconnecting your account')
 
@@ -220,19 +218,27 @@ class BitbucketService(Service):
                 recv_data = resp.json()
                 integration.provider_data = recv_data
                 integration.save()
-                log.info('Bitbucket webhook creation successful for project: %s',
-                         project)
+                log.info(
+                    'Bitbucket webhook creation successful for project: %s',
+                    project,
+                )
                 return (True, resp)
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
-            log.error('Bitbucket webhook creation failed for project: %s',
-                      project, exc_info=True)
+            log.exception(
+                'Bitbucket webhook creation failed for project: %s',
+                project,
+            )
         else:
-            log.error('Bitbucket webhook creation failed for project: %s',
-                      project)
+            log.exception(
+                'Bitbucket webhook creation failed for project: %s',
+                project,
+            )
             try:
-                log.debug('Bitbucket webhook creation failure response: %s',
-                          resp.json())
+                log.debug(
+                    'Bitbucket webhook creation failure response: %s',
+                    resp.json(),
+                )
             except ValueError:
                 pass
             return (False, resp)
@@ -263,20 +269,29 @@ class BitbucketService(Service):
                 recv_data = resp.json()
                 integration.provider_data = recv_data
                 integration.save()
-                log.info('Bitbucket webhook update successful for project: %s',
-                         project)
+                log.info(
+                    'Bitbucket webhook update successful for project: %s',
+                    project,
+                )
                 return (True, resp)
         # Catch exceptions with request or deserializing JSON
         except (KeyError, RequestException, ValueError):
-            log.error('Bitbucket webhook update failed for project: %s',
-                      project, exc_info=True)
+            log.exception(
+                'Bitbucket webhook update failed for project: %s',
+                project,
+            )
         else:
-            log.error('Bitbucket webhook update failed for project: %s',
-                      project)
+            log.exception(
+                'Bitbucket webhook update failed for project: %s',
+                project,
+            )
             # Response data should always be JSON, still try to log if not though
             try:
                 debug_data = resp.json()
             except ValueError:
                 debug_data = resp.content
-            log.debug('Bitbucket webhook update failure response: %s', debug_data)
+            log.debug(
+                'Bitbucket webhook update failure response: %s',
+                debug_data,
+            )
             return (False, resp)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -42,8 +42,7 @@ class GitHubService(Service):
             for repo in repos:
                 self.create_repository(repo)
         except (TypeError, ValueError) as e:
-            log.error('Error syncing GitHub repositories: %s',
-                      str(e), exc_info=True)
+            log.exception('Error syncing GitHub repositories')
             raise Exception('Could not sync your GitHub repositories, '
                             'try reconnecting your account')
 
@@ -62,8 +61,7 @@ class GitHubService(Service):
                 for repo in org_repos:
                     self.create_repository(repo, organization=org_obj)
         except (TypeError, ValueError) as e:
-            log.error('Error syncing GitHub organizations: %s',
-                      str(e), exc_info=True)
+            log.exception('Error syncing GitHub organizations')
             raise Exception('Could not sync your GitHub organizations, '
                             'try reconnecting your account')
 
@@ -211,18 +209,25 @@ class GitHubService(Service):
                 return (True, resp)
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
-            log.error('GitHub webhook creation failed for project: %s',
-                      project, exc_info=True)
+            log.exception(
+                'GitHub webhook creation failed for project: %s',
+                project,
+            )
         else:
-            log.error('GitHub webhook creation failed for project: %s',
-                      project)
-            # Response data should always be JSON, still try to log if not though
+            log.exception(
+                'GitHub webhook creation failed for project: %s',
+                project,
+            )
+            # Response data should always be JSON, still try to log if not
+            # though
             try:
                 debug_data = resp.json()
             except ValueError:
                 debug_data = resp.content
-            log.debug('GitHub webhook creation failure response: %s',
-                      debug_data)
+            log.debug(
+                'GitHub webhook creation failure response: %s',
+                debug_data,
+            )
             return (False, resp)
 
     def update_webhook(self, project, integration):
@@ -251,22 +256,30 @@ class GitHubService(Service):
                 recv_data = resp.json()
                 integration.provider_data = recv_data
                 integration.save()
-                log.info('GitHub webhook creation successful for project: %s',
-                         project)
+                log.info(
+                    'GitHub webhook creation successful for project: %s',
+                    project,
+                )
                 return (True, resp)
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
-            log.error('GitHub webhook update failed for project: %s',
-                      project, exc_info=True)
+            log.exception(
+                'GitHub webhook update failed for project: %s',
+                project,
+            )
         else:
-            log.error('GitHub webhook update failed for project: %s',
-                      project)
+            log.exception(
+                'GitHub webhook update failed for project: %s',
+                project,
+            )
             try:
                 debug_data = resp.json()
             except ValueError:
                 debug_data = resp.content
-            log.debug('GitHub webhook creation failure response: %s',
-                      debug_data)
+            log.debug(
+                'GitHub webhook creation failure response: %s',
+                debug_data,
+            )
             return (False, resp)
 
     @classmethod

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -336,7 +336,10 @@ class GitLabService(Service):
             log.exception(
                 'GitLab webhook update failed for project: %s', project)
         else:
-            log.error('GitLab webhook update failed for project: %s', project)
+            log.exception(
+                'GitLab webhook update failed for project: %s',
+                project,
+            )
             try:
                 debug_data = resp.json()
             except ValueError:

--- a/readthedocs/payments/forms.py
+++ b/readthedocs/payments/forms.py
@@ -166,8 +166,7 @@ class StripeModelForm(forms.ModelForm):
                 forms.ValidationError(str(e)),
             )
         except stripe.error.StripeError as e:
-            log.error('There was a problem communicating with Stripe: %s',
-                      str(e), exc_info=True)
+            log.exception('There was a problem communicating with Stripe')
             raise forms.ValidationError(
                 _('There was a problem communicating with Stripe'))
         return cleaned_data

--- a/readthedocs/projects/search_indexes.py
+++ b/readthedocs/projects/search_indexes.py
@@ -85,8 +85,11 @@ class ImportedFileIndex(indexes.SearchIndex, indexes.Indexable):
             with codecs.open(file_path, encoding='utf-8', mode='r') as f:
                 content = f.read()
         except IOError as e:
-            log.info('(Search Index) Unable to index file: %s, error :%s',
-                     file_path, e)
+            log.info(
+                '(Search Index) Unable to index file: %',
+                file_path,
+                exc_info=True,
+            )
             return
         log.debug('(Search Index) Indexing %s:%s', obj.project, obj.path)
         document_pyquery_path = getattr(settings, 'DOCUMENT_PYQUERY_PATH',

--- a/readthedocs/projects/search_indexes.py
+++ b/readthedocs/projects/search_indexes.py
@@ -86,7 +86,7 @@ class ImportedFileIndex(indexes.SearchIndex, indexes.Indexable):
                 content = f.read()
         except IOError as e:
             log.info(
-                '(Search Index) Unable to index file: %',
+                '(Search Index) Unable to index file: %s',
                 file_path,
                 exc_info=True,
             )

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -185,7 +185,7 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             return True
         except RepositoryError as e:
             # Do not log as ERROR handled exceptions
-            log.warning('There was an error with the repository: msg=%', e.msg)
+            log.warning('There was an error with the repository: msg=%s', e.msg)
         except Exception:
             # Catch unhandled errors when syncing
             log.exception(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -183,12 +183,15 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             self.project = self.version.project
             self.sync_repo()
             return True
-        # Catch unhandled errors when syncing
+        except RepositoryError as e:
+            # Do not log as ERROR handled exceptions
+            log.warning('There was an error with the repository: msg=%', e.msg)
         except Exception:
+            # Catch unhandled errors when syncing
             log.exception(
                 'An unhandled exception was raised during VCS syncing',
             )
-            return False
+        return False
 
 
 class UpdateDocsTask(SyncRepositoryMixin, Task):
@@ -513,7 +516,10 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                     'built': True,
                 })
         except HttpClientError:
-            log.exception('Updating version failed, skipping file sync: version=%s' % self.version)
+            log.exception(
+                'Updating version failed, skipping file sync: version=%s',
+                self.version,
+            )
 
         # Broadcast finalization steps to web application instances
         broadcast(
@@ -898,7 +904,7 @@ def _manage_imported_files(version, path, commit):
                     name=filename,
                 )
             except ImportedFile.MultipleObjectsReturned:
-                log.exception('Error creating ImportedFile')
+                log.warning('Error creating ImportedFile')
                 continue
             if obj.md5 != md5:
                 obj.md5 = md5

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -183,9 +183,9 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             self.project = self.version.project
             self.sync_repo()
             return True
-        except RepositoryError as e:
+        except RepositoryError:
             # Do not log as ERROR handled exceptions
-            log.warning('There was an error with the repository: msg=%s', e.msg)
+            log.warning('There was an error with the repository', exc_info=True)
         except Exception:
             # Catch unhandled errors when syncing
             log.exception(

--- a/readthedocs/projects/views/base.py
+++ b/readthedocs/projects/views/base.py
@@ -93,9 +93,10 @@ class ProjectSpamMixin(object):
 
     def post(self, request, *args, **kwargs):
         if request.user.profile.banned:
-            log.error(
+            log.info(
                 'Rejecting project POST from shadowbanned user %s',
-                request.user)
+                request.user,
+            )
             return HttpResponseRedirect(self.get_failure_url())
         try:
             return super(ProjectSpamMixin, self).post(request, *args, **kwargs)
@@ -104,11 +105,12 @@ class ProjectSpamMixin(object):
             if request.user.date_joined > date_maturity:
                 request.user.profile.banned = True
                 request.user.profile.save()
-                log.error(
+                log.info(
                     'Spam detected from new user, shadowbanned user %s',
-                    request.user)
+                    request.user,
+                )
             else:
-                log.error('Spam detected from user %s', request.user)
+                log.info('Spam detected from user %s', request.user)
             return HttpResponseRedirect(self.get_failure_url())
 
     def get_failure_url(self):

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -295,8 +295,6 @@ class ImportDemoView(PrivateViewMixin, View):
                 messages.success(
                     request, _('Your demo project is currently being imported'))
             else:
-                for (__, msg) in list(form.errors.items()):
-                    log.error(msg)
                 messages.error(
                     request,
                     _('There was a problem adding the demo project'),

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -170,7 +170,7 @@ class ProjectViewSet(UserSelectViewSet):
                 added_versions.update(ret_set)
             deleted_versions = api_utils.delete_versions(project, data)
         except Exception as e:
-            log.exception('Sync Versions Error: %s', e.message)
+            log.exception('Sync Versions Error')
             return Response(
                 {
                     'error': e.message,

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -32,8 +32,11 @@ class PrivacyTests(TestCase):
     def _create_kong(self, privacy_level='private',
                      version_privacy_level='private'):
         self.client.login(username='eric', password='test')
-        log.info(("Making kong with privacy: %s and version privacy: %s"
-                  % (privacy_level, version_privacy_level)))
+        log.info(
+            "Making kong with privacy: %s and version privacy: %s",
+            privacy_level,
+            version_privacy_level,
+        )
         # Create project via project form, simulate import wizard without magic
         form = UpdateProjectForm(
             data={'repo_type': 'git',

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -36,6 +36,7 @@ def make_test_git():
     chdir(directory)
 
     # Initialize and configure
+    # TODO: move the ``log.info`` call inside the ``check_output```
     log.info(check_output(['git', 'init'] + [directory], env=env))
     log.info(check_output(
         ['git', 'config', 'user.email', 'dev@readthedocs.org'],

--- a/readthedocs/search/parse_json.py
+++ b/readthedocs/search/parse_json.py
@@ -96,7 +96,7 @@ def process_file(filename):
         with codecs.open(filename, encoding='utf-8', mode='r') as f:
             file_contents = f.read()
     except IOError as e:
-        log.info('Unable to index file: %s, error :%s', filename, e)
+        log.info('Unable to index file: %s', filename, exc_info=True)
         return
     data = json.loads(file_contents)
     sections = []

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -62,9 +62,15 @@ def valid_mkdocs_json(file_path):
         with codecs.open(file_path, encoding='utf-8', mode='r') as f:
             content = f.read()
     except IOError as e:
-        log.warning('(Search Index) Unable to index file: %s, error: %s', file_path, e)
+        log.warning(
+            '(Search Index) Unable to index file: %s',
+            file_path,
+            exc_info=True,
+        )
         return None
 
+    # TODO: wrap this in a try/except block and use ``exc_info=True`` in the
+    # ``log.warning`` call
     page_json = json.loads(content)
     for to_check in ['url', 'content']:
         if to_check not in page_json:
@@ -80,9 +86,14 @@ def parse_path_from_file(file_path):
         with codecs.open(file_path, encoding='utf-8', mode='r') as f:
             content = f.read()
     except IOError as e:
-        log.warning('(Search Index) Unable to index file: %s, error: %s', file_path, e)
+        log.warning(
+            '(Search Index) Unable to index file: %s',
+            file_path,
+            exc_info=True,
+        )
         return ''
 
+    # TODO: wrap this in a try/except block
     page_json = json.loads(content)
     path = page_json['url']
 
@@ -104,9 +115,14 @@ def parse_content_from_file(file_path):
         with codecs.open(file_path, encoding='utf-8', mode='r') as f:
             content = f.read()
     except IOError as e:
-        log.info('(Search Index) Unable to index file: %s, error :%s', file_path, e)
+        log.info(
+            '(Search Index) Unable to index file: %s',
+            file_path,
+            exc_info=True,
+        )
         return ''
 
+    # TODO: wrap this in a try/except block
     page_json = json.loads(content)
     page_content = page_json['content']
     content = parse_content(page_content)
@@ -137,10 +153,14 @@ def parse_headers_from_file(documentation_type, file_path):
         with codecs.open(file_path, encoding='utf-8', mode='r') as f:
             content = f.read()
     except IOError as e:
-        log.info('(Search Index) Unable to index file: %s, error :%s',
-                 file_path, e)
+        log.info(
+            '(Search Index) Unable to index file: %s',
+            file_path,
+            exc_info=True,
+        )
         return ''
 
+    # TODO: wrap this in a try/except block
     page_json = json.loads(content)
     page_content = page_json['content']
     headers = parse_headers(documentation_type, page_content)
@@ -164,9 +184,14 @@ def parse_sections_from_file(documentation_type, file_path):
         with codecs.open(file_path, encoding='utf-8', mode='r') as f:
             content = f.read()
     except IOError as e:
-        log.info('(Search Index) Unable to index file: %s, error :%s', file_path, e)
+        log.info(
+            '(Search Index) Unable to index file: %s',
+            file_path,
+            exc_info=True,
+        )
         return ''
 
+    # TODO: wrap this in a try/except block
     page_json = json.loads(content)
     page_content = page_json['content']
     sections = parse_sections(documentation_type, page_content)


### PR DESCRIPTION
Log only what we need as ERROR when it's something that we need/want to take a look that something could be a bug/issue.

There are some ERROR that were replaced by WARNING since they are some failures but that we don't need to take a look and the message shown to the user should be enough for them.

Check #3898 for style changes
