### PR TITLE
Save Docker image data in JSON file only for DockerBuildEnvironment

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -8,13 +8,14 @@ import json
 import logging
 import os
 import shutil
-import six
 from builtins import object, open
 
+import six
 from django.conf import settings
 
 from readthedocs.doc_builder.config import ConfigWrapper
 from readthedocs.doc_builder.constants import DOCKER_IMAGE
+from readthedocs.doc_builder.environments import DockerBuildEnvironment
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.projects.constants import LOG_TEMPLATE
 from readthedocs.projects.models import Feature
@@ -147,7 +148,14 @@ class PythonEnvironment(object):
         env_build_image = env_build.get('image', None)
         env_build_hash = env_build.get('hash', None)
 
-        build_image = self.config.build_image or DOCKER_IMAGE
+        if isinstance(self.build_env, DockerBuildEnvironment):
+            build_image = self.config.build_image or DOCKER_IMAGE
+            image_hash = self.build_env.image_hash
+        else:
+            # e.g. LocalBuildEnvironment
+            build_image = None
+            image_hash = None
+
         # If the user define the Python version just as a major version
         # (e.g. ``2`` or ``3``) we won't know exactly which exact version was
         # used to create the venv but we can still compare it against the new
@@ -155,21 +163,25 @@ class PythonEnvironment(object):
         return any([
             env_python_version != self.config.python_full_version,
             env_build_image != build_image,
-            env_build_hash != self.build_env.image_hash,
+            env_build_hash != image_hash,
         ])
 
     def save_environment_json(self):
         """Save on disk Python and build image versions used to create the venv."""
-        build_image = self.config.build_image or DOCKER_IMAGE
         data = {
             'python': {
                 'version': self.config.python_full_version,
             },
-            'build': {
-                'image': build_image,
-                'hash': self.build_env.image_hash,
-            },
         }
+
+        if isinstance(self.build_env, DockerBuildEnvironment):
+            build_image = self.config.build_image or DOCKER_IMAGE
+            data.update({
+                'build': {
+                    'image': build_image,
+                    'hash': self.build_env.image_hash,
+                },
+            })
 
         with open(self.environment_json_path(), 'w') as fpath:
             # Compatibility for Py2 and Py3. ``io.TextIOWrapper`` expects


### PR DESCRIPTION
Avoid failing when using LocalBuildEnvironment. This was trying to access a specific value defined only in DockerBuildEnvironment and it doesn't make sense to have them in other environments.