### PR TITLE
Fixup DJANGO_SETTINGS_SKIP_LOCAL in tests

### DIFF
--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -35,6 +35,6 @@ CACHES = {
 
 if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
     try:
-        from local_settings import *  # noqa
+        from .local_settings import *  # noqa
     except ImportError:
         pass


### PR DESCRIPTION
The import path for the local_settings should be relative to the
test module and not absolute otherwise the import will fail.