### PR TITLE
Drop pdbpp from testing requirements

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -8,5 +8,4 @@ execnet==1.5.0
 Mercurial==4.4.2
 
 # local debugging tools
-pdbpp
 datadiff


### PR DESCRIPTION
This was causing errors running tests with py36 and pdb set_trace