### PR TITLE
Use new django celery beat scheduler

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -84,6 +84,7 @@ class CommunityBaseSettings(Settings):
             'annoying',
             'django_extensions',
             'messages_extends',
+            'django_celery_beat',
 
             # daniellindsleyrocksdahouse
             'haystack',
@@ -244,6 +245,7 @@ class CommunityBaseSettings(Settings):
     CELERY_CREATE_MISSING_QUEUES = True
 
     CELERY_DEFAULT_QUEUE = 'celery'
+    CELERYBEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
     CELERYBEAT_SCHEDULE = {
         # Ran every hour on minute 30
         'hourly-remove-orphan-symlinks': {

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -38,6 +38,7 @@ defusedxml==0.5.0
 # Basic tools
 redis==2.10.6
 celery==4.1.0
+django-celery-beat==1.1.1
 
 # django-allauth 0.33.0 dropped support for Django 1.9
 # https://django-allauth.readthedocs.io/en/latest/release-notes.html#backwards-incompatible-changes


### PR DESCRIPTION
This PR will install the new django-celery-beat package and use its scheduler for persistent tasks.

This change involves installing this new package `django-celery-beat` (from `pip.txt`) and also remove the old `djcelery` if it's still installed. Besides, we need to run `migrate` on deploy.