### PR TITLE
Use str to get the exception message

### DIFF
--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -5,12 +5,12 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import logging
-from builtins import str
 
 from allauth.socialaccount.models import SocialAccount
+from builtins import str
 from django.shortcuts import get_object_or_404
-from rest_framework import decorators, permissions, status, viewsets
 from django.template.loader import render_to_string
+from rest_framework import decorators, permissions, status, viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.response import Response

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -5,6 +5,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import logging
+from builtins import str
 
 from allauth.socialaccount.models import SocialAccount
 from django.shortcuts import get_object_or_404
@@ -197,7 +198,7 @@ class ProjectViewSet(UserSelectViewSet):
             log.exception('Sync Versions Error')
             return Response(
                 {
-                    'error': e.message,
+                    'error': str(e),
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )

--- a/readthedocs/restapi/views/task_views.py
+++ b/readthedocs/restapi/views/task_views.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 import logging
+from builtins import str
 
 from django.core.urlresolvers import reverse
 from rest_framework import decorators, permissions

--- a/readthedocs/restapi/views/task_views.py
+++ b/readthedocs/restapi/views/task_views.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 import logging
-from builtins import str
 
 from django.core.urlresolvers import reverse
 from rest_framework import decorators, permissions


### PR DESCRIPTION
We are catching exceptions of type `Exception`, which no always have the `message` attribute (python3 at least).

```python
e = Exception('Bu!')
assert not hasattr(e, 'message')
```