### PR TITLE
Correctly report mkdocs theme name

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -100,8 +100,6 @@ class BaseMkdocs(BaseBuilder):
         if 'theme_dir' not in user_config and self.use_theme:
             user_config['theme_dir'] = TEMPLATE_DIR
 
-        user_config['theme_name'] = user_config.get('theme_dir', 'readthedocs').rsplit('/')[-1]
-
         yaml.safe_dump(
             user_config,
             open(os.path.join(self.root_path, 'mkdocs.yml'), 'w')
@@ -110,12 +108,14 @@ class BaseMkdocs(BaseBuilder):
         docs_path = os.path.join(self.root_path, docs_dir)
 
         # RTD javascript writing
-        rtd_data = self.generate_rtd_data(docs_dir=docs_dir, user_config=user_config)
+        rtd_data = self.generate_rtd_data(docs_dir=docs_dir, mkdocs_config=user_config)
         with open(os.path.join(docs_path, 'readthedocs-data.js'), 'w') as f:
             f.write(rtd_data)
 
-    def generate_rtd_data(self, docs_dir, user_config):
+    def generate_rtd_data(self, docs_dir, mkdocs_config):
         """Generate template properties and render readthedocs-data.js."""
+        theme_name = mkdocs_config.get('theme_dir', 'readthedocs').rsplit('/')[-1]
+
         # Will be available in the JavaScript as READTHEDOCS_DATA.
         readthedocs_data = {
             'project': self.version.project.slug,
@@ -123,7 +123,7 @@ class BaseMkdocs(BaseBuilder):
             'language': self.version.project.language,
             'programming_language': self.version.project.programming_language,
             'page': None,
-            'theme': user_config['theme_name'],
+            'theme': theme_name,
             'builder': "mkdocs",
             'docroot': docs_dir,
             'source_suffix': ".md",

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -100,6 +100,8 @@ class BaseMkdocs(BaseBuilder):
         if 'theme_dir' not in user_config and self.use_theme:
             user_config['theme_dir'] = TEMPLATE_DIR
 
+        user_config['theme_name'] = user_config['theme_dir'].rsplit('/')[-1]
+
         yaml.safe_dump(
             user_config,
             open(os.path.join(self.root_path, 'mkdocs.yml'), 'w')
@@ -108,11 +110,11 @@ class BaseMkdocs(BaseBuilder):
         docs_path = os.path.join(self.root_path, docs_dir)
 
         # RTD javascript writing
-        rtd_data = self.generate_rtd_data(docs_dir=docs_dir)
+        rtd_data = self.generate_rtd_data(docs_dir=docs_dir, user_config=user_config)
         with open(os.path.join(docs_path, 'readthedocs-data.js'), 'w') as f:
             f.write(rtd_data)
 
-    def generate_rtd_data(self, docs_dir):
+    def generate_rtd_data(self, docs_dir, user_config):
         """Generate template properties and render readthedocs-data.js."""
         # Will be available in the JavaScript as READTHEDOCS_DATA.
         readthedocs_data = {
@@ -121,7 +123,7 @@ class BaseMkdocs(BaseBuilder):
             'language': self.version.project.language,
             'programming_language': self.version.project.programming_language,
             'page': None,
-            'theme': "readthedocs",
+            'theme': user_config['theme_name'],
             'builder': "mkdocs",
             'docroot': docs_dir,
             'source_suffix': ".md",

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -114,7 +114,11 @@ class BaseMkdocs(BaseBuilder):
 
     def generate_rtd_data(self, docs_dir, mkdocs_config):
         """Generate template properties and render readthedocs-data.js."""
-        theme_name = mkdocs_config.get('theme_dir', 'readthedocs').rsplit('/')[-1]
+        # Get the theme name
+        theme_name = 'readthedocs'
+        theme_dir = mkdocs_config.get('theme_dir')
+        if theme_dir:
+            theme_name = theme_dir.rstrip('/').split('/')[-1]
 
         # Will be available in the JavaScript as READTHEDOCS_DATA.
         readthedocs_data = {

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -100,7 +100,7 @@ class BaseMkdocs(BaseBuilder):
         if 'theme_dir' not in user_config and self.use_theme:
             user_config['theme_dir'] = TEMPLATE_DIR
 
-        user_config['theme_name'] = user_config['theme_dir'].rsplit('/')[-1]
+        user_config['theme_name'] = user_config.get('theme_dir', 'readthedocs').rsplit('/')[-1]
 
         yaml.safe_dump(
             user_config,


### PR DESCRIPTION
The vast majority of docs built with mkdocs are in fact the `readthedocs` theme. However, some aren't. Here are some counter-examples:

- https://crafttweaker.readthedocs.io/en/latest/
- https://mcforge.readthedocs.io/en/latest/