### PR TITLE
Fix a JS error on mkdocs: mkdocs_page_input_path

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
@@ -6,5 +6,9 @@ var doc_slug = "{{ slug }}";
 var page_name = "{{ pagename }}";
 var html_theme = "{{ html_theme }}";
 
-READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
-    0, mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix));
+if (typeof mkdocs_page_input_path !== 'undefined') {
+    READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
+        0,
+        mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix)
+    );
+}

--- a/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
@@ -6,6 +6,7 @@ var doc_slug = "{{ slug }}";
 var page_name = "{{ pagename }}";
 var html_theme = "{{ html_theme }}";
 
+// This variable is only defined on the RTD mkdocs theme
 if (typeof mkdocs_page_input_path !== "undefined") {
     READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
         0,

--- a/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/data.js.tmpl
@@ -6,7 +6,7 @@ var doc_slug = "{{ slug }}";
 var page_name = "{{ pagename }}";
 var html_theme = "{{ html_theme }}";
 
-if (typeof mkdocs_page_input_path !== 'undefined') {
+if (typeof mkdocs_page_input_path !== "undefined") {
     READTHEDOCS_DATA["page"] = mkdocs_page_input_path.substr(
         0,
         mkdocs_page_input_path.lastIndexOf(READTHEDOCS_DATA.source_suffix)


### PR DESCRIPTION
The `mkdocs_page_input_path` variable is only defined on the RTD theme. For other themes, the variable is not defined.

Here's a page that manifests the error: https://crafttweaker.readthedocs.io/en/latest/

- Replaces: #3536