### PR TITLE
Enable ads on the readthedocs mkdocs theme

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/constants.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/constants.js
@@ -3,7 +3,8 @@
 var exports = {
     THEME_RTD: 'sphinx_rtd_theme',
     THEME_ALABASTER: 'alabaster',
-    THEME_CELERY: 'sphinx_celery'
+    THEME_CELERY: 'sphinx_celery',
+    THEME_MKDOCS_RTD: 'readthedocs'
 };
 
 exports.PROMO_SUPPORTED_THEMES = [

--- a/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
@@ -19,10 +19,17 @@ var configMethods = {
         return (!('builder' in this) || this.builder !== 'mkdocs');
     },
 
+    is_mkdocs_builder: function () {
+        return (!('builder' in this) || this.builder === 'mkdocs');
+    },
+
     get_theme_name: function () {
         // Crappy heuristic, but people change the theme name on us.  So we have to
         // do some duck typing.
         if (this.theme !== constants.THEME_RTD) {
+            if (this.theme === constants.THEME_MKDOCS_RTD) {
+                return constants.THEME_RTD;
+            }
             if ($('div.rst-other-versions').length === 1) {
                 return constants.THEME_RTD;
             }
@@ -33,7 +40,6 @@ var configMethods = {
     show_promo: function () {
         return (
             this.api_host !== 'https://readthedocs.com' &&
-            this.is_sphinx_builder() &&
             this.theme_supports_promo());
     }
 };

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -16,7 +16,10 @@ function create_sidebar_placement() {
     var selector = null;
     var class_name;         // Used for theme specific CSS customizations
 
-    if (rtd.is_rtd_theme()) {
+    if (rtd.is_mkdocs_builder() && rtd.is_rtd_theme()) {
+        selector = 'nav.wy-nav-side';
+        class_name = 'ethical-rtd';
+    } else if (rtd.is_rtd_theme()) {
         selector = 'nav.wy-nav-side > div.wy-side-scroll';
         class_name = 'ethical-rtd';
     } else if (rtd.get_theme_name() === constants.THEME_ALABASTER ||


### PR DESCRIPTION
This PR enables ads on the `readthedocs` theme for projects using Markdown.

Before merging, we should probably notify users of the mkdocs theme.

**NOTE:** #3920 should probably be merged first as some themes are incorrectly identified as the `readthedocs` theme. It isn't strictly critical as it is unlikely that the ad injection selectors will match on a custom theme and so it will likely just result in API calls that don't result in an ad being displayed.

**SCREENSHOTS**
<img width="1198" alt="screen shot 2018-04-06 at 5 12 34 pm" src="https://user-images.githubusercontent.com/185043/38448970-014b4910-39be-11e8-83a5-ccbde452482d.png">
<img width="615" alt="screen shot 2018-04-06 at 5 13 32 pm" src="https://user-images.githubusercontent.com/185043/38448971-016485d8-39be-11e8-90ea-3d98375e70a5.png">
<img width="376" alt="screen shot 2018-04-06 at 5 14 53 pm" src="https://user-images.githubusercontent.com/185043/38448974-0d83baaa-39be-11e8-88be-9c3f6adcb714.png">
