### PR TITLE
Mention RTD in the Project URL of the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 ## Details
 
-* Project URL: 
+* Read the Docs project URL:
 * Build URL (if applicable):
-* Read the Docs username (if applicable): 
+* Read the Docs username (if applicable):
 
 ## Expected Result
 


### PR DESCRIPTION
Maybe this helps people to put the RTD URL instead of the github or any other kind of URL related to the project that they are reporting.