### PR TITLE
Resync webhooks from Admin

### DIFF
--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -274,6 +274,12 @@ class BitbucketService(Service):
                     project,
                 )
                 return (True, resp)
+
+            # Bitbucket returns 404 when the webhook doesn't exist. In this
+            # case, we call ``setup_webhook`` to re-configure it from scratch
+            if resp.status_code == 404:
+                return self.setup_webhook(project)
+
         # Catch exceptions with request or deserializing JSON
         except (KeyError, RequestException, ValueError):
             log.exception(

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -261,6 +261,12 @@ class GitHubService(Service):
                     project,
                 )
                 return (True, resp)
+
+            # GitHub returns 404 when the webhook doesn't exist. In this case,
+            # we call ``setup_webhook`` to re-configure it from scratch
+            if resp.status_code == 404:
+                return self.setup_webhook(project)
+
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             log.exception(

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -331,6 +331,12 @@ class GitLabService(Service):
                 log.info(
                     'GitLab webhook update successful for project: %s', project)
                 return (True, resp)
+
+            # GitLab returns 404 when the webhook doesn't exist. In this case,
+            # we call ``setup_webhook`` to re-configure it from scratch
+            if resp.status_code == 404:
+                return self.setup_webhook(project)
+
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             log.exception(


### PR DESCRIPTION
If the user delete the RTD webhook integration for whatever reason from the project under the external service (GitHub, etc) when the Resync button is pressed we re-create / setup the webhook as it was never existed.

This behaviour already existed, but it worth to mention it:

> If the user modifies the webhook in the external service (changing the URL for example), when Resync button is pressed, we update it with the proper URL.

Closes #3931