### PR TITLE
Allow import Gitlab repo manually and set a webhook automatically

### DIFF
--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -12,7 +12,9 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from requests.exceptions import RequestException
 
+from readthedocs.builds.utils import get_gitlab_username_repo
 from readthedocs.integrations.models import Integration
+from readthedocs.projects.models import Project
 
 from ..models import RemoteOrganization, RemoteRepository
 from .base import Service
@@ -40,6 +42,22 @@ class GitLabService(Service):
     # because private repos have another base url, eg. git@gitlab.example.com
     url_pattern = re.compile(
         re.escape(urlparse(adapter.provider_base_url).netloc))
+
+    def _get_repo_id(self, project):
+        # The ID or URL-encoded path of the project
+        # https://docs.gitlab.com/ce/api/README.html#namespaced-path-encoding
+        try:
+            repo_id = json.loads(project.remote_repository.json).get('id')
+        except Project.remote_repository.RelatedObjectDoesNotExist:
+            # Handle "Manual Import" when there is no RemoteRepository
+            # associated with the project. It only works with gitlab.com at the
+            # moment (doesn't support custom gitlab installations)
+            username, repo = get_gitlab_username_repo(project.repo)
+            repo_id = '{username}%2F{repo}'.format(
+                username=username,
+                repo=repo,
+            )
+        return repo_id
 
     def get_next_url_to_paginate(self, response):
         return response.links.get('next', {}).get('url')
@@ -255,10 +273,7 @@ class GitLabService(Service):
             integration_type=Integration.GITLAB_WEBHOOK,
         )
 
-        # The ID or URL-encoded path of the project
-        # https://docs.gitlab.com/ce/api/README.html#namespaced-path-encoding
-        repo_id = json.loads(project.remote_repository.json).get('id')
-
+        repo_id = self._get_repo_id(project)
         data = self.get_webhook_data(repo_id, project, integration)
         resp = None
         try:
@@ -307,10 +322,7 @@ class GitLabService(Service):
         """
         session = self.get_session()
 
-        # The ID or URL-encoded path of the project
-        # https://docs.gitlab.com/ce/api/README.html#namespaced-path-encoding
-        repo_id = json.loads(project.remote_repository.json).get('id')
-
+        repo_id = self._get_repo_id(project)
         data = self.get_webhook_data(repo_id, project, integration)
         hook_id = integration.provider_data.get('id')
         resp = None

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -53,6 +53,9 @@ class GitLabService(Service):
             # associated with the project. It only works with gitlab.com at the
             # moment (doesn't support custom gitlab installations)
             username, repo = get_gitlab_username_repo(project.repo)
+            if (username, repo) == (None, None):
+                return None
+
             repo_id = '{username}%2F{repo}'.format(
                 username=username,
                 repo=repo,
@@ -274,6 +277,9 @@ class GitLabService(Service):
         )
 
         repo_id = self._get_repo_id(project)
+        if repo_id is None:
+            return (False, None)
+
         data = self.get_webhook_data(repo_id, project, integration)
         resp = None
         try:
@@ -323,6 +329,9 @@ class GitLabService(Service):
         session = self.get_session()
 
         repo_id = self._get_repo_id(project)
+        if repo_id is None:
+            return (False, None)
+
         data = self.get_webhook_data(repo_id, project, integration)
         hook_id = integration.provider_data.get('id')
         resp = None

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -270,7 +270,6 @@ class GitLabService(Service):
         :returns: boolean based on webhook set up success
         :rtype: bool
         """
-        session = self.get_session()
         integration, _ = Integration.objects.get_or_create(
             project=project,
             integration_type=Integration.GITLAB_WEBHOOK,
@@ -281,6 +280,7 @@ class GitLabService(Service):
             return (False, None)
 
         data = self.get_webhook_data(repo_id, project, integration)
+        session = self.get_session()
         resp = None
         try:
             resp = session.post(

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -485,3 +485,8 @@ class GitLabOAuthTests(TestCase):
             m.return_value = True
             repo = self.service.create_repository(data, organization=self.org)
         self.assertIsNotNone(repo)
+
+    def test_setup_webhook(self):
+        success, response = self.service.setup_webhook(self.project)
+        self.assertFalse(success)
+        self.assertIsNone(response)


### PR DESCRIPTION
When we import a Project manually we don't have a RemoteRepository associated with that Project, so we use the old technique of getting the username and repo names from the URL using `get_gitlab_username_repo` function.

This case (Manual Import) won't support custom Gitlab installations in the future with this code.

Closes https://github.com/readthedocs/readthedocs-corporate/issues/265