### PR TITLE
Allow extend Translation and Subproject form logic from corporate

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -4,9 +4,9 @@
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
-from builtins import object
 from random import choice
 
+from builtins import object
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -19,6 +19,7 @@ from textclassifier.validators import ClassifierValidator
 
 from readthedocs.builds.constants import TAG
 from readthedocs.core.utils import slugify, trigger_build
+from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteRepository
 from readthedocs.projects import constants
@@ -230,7 +231,7 @@ class UpdateProjectForm(ProjectTriggerBuildMixin, ProjectBasicsForm,
         )
 
 
-class ProjectRelationshipForm(forms.ModelForm):
+class ProjectRelationshipBaseForm(forms.ModelForm):
 
     """Form to add/update project relationships."""
 
@@ -243,7 +244,7 @@ class ProjectRelationshipForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop('project')
         self.user = kwargs.pop('user')
-        super(ProjectRelationshipForm, self).__init__(*args, **kwargs)
+        super(ProjectRelationshipBaseForm, self).__init__(*args, **kwargs)
         # Don't display the update form with an editable child, as it will be
         # filtered out from the queryset anyways.
         if hasattr(self, 'instance') and self.instance.pk is not None:
@@ -279,6 +280,11 @@ class ProjectRelationshipForm(forms.ModelForm):
             .exclude(superprojects__isnull=False)
             .exclude(pk=self.project.pk))
         return queryset
+
+
+class ProjectRelationshipForm(SettingsOverrideObject):
+    _default_class = ProjectRelationshipBaseForm
+    _override_setting = 'PROJECT_RELATIONSHIP_FORM'
 
 
 class DualCheckboxWidget(forms.CheckboxInput):
@@ -481,7 +487,7 @@ class WebHookForm(forms.Form):
         return self.project
 
 
-class TranslationForm(forms.Form):
+class TranslationBaseForm(forms.Form):
 
     """Project translation form."""
 
@@ -490,7 +496,7 @@ class TranslationForm(forms.Form):
     def __init__(self, *args, **kwargs):
         self.parent = kwargs.pop('parent', None)
         self.user = kwargs.pop('user')
-        super(TranslationForm, self).__init__(*args, **kwargs)
+        super(TranslationBaseForm, self).__init__(*args, **kwargs)
         self.fields['project'].choices = self.get_choices()
 
     def get_choices(self):
@@ -561,6 +567,11 @@ class TranslationForm(forms.Form):
         # state.
         self.parent.save()
         return project
+
+
+class TranslationForm(SettingsOverrideObject):
+    _default_class = TranslationBaseForm
+    _override_setting = 'PROJECT_TRANSLATION_FORM'
 
 
 class RedirectForm(forms.ModelForm):

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -284,7 +284,6 @@ class ProjectRelationshipBaseForm(forms.ModelForm):
 
 class ProjectRelationshipForm(SettingsOverrideObject):
     _default_class = ProjectRelationshipBaseForm
-    _override_setting = 'PROJECT_RELATIONSHIP_FORM'
 
 
 class DualCheckboxWidget(forms.CheckboxInput):
@@ -571,7 +570,6 @@ class TranslationBaseForm(forms.Form):
 
 class TranslationForm(SettingsOverrideObject):
     _default_class = TranslationBaseForm
-    _override_setting = 'PROJECT_TRANSLATION_FORM'
 
 
 class RedirectForm(forms.ModelForm):


### PR DESCRIPTION
There is no changes in the logic, just make these two forms extendable from Corporate site since we need to change some logic regarding the Organizations permissions.