### PR TITLE
Fixed footer ad width fix

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -93,7 +93,6 @@ div.ethical-sidebar, div.ethical-footer {
 /* Fixed footer promotions */
 .ethical-fixedfooter {
     box-sizing: border-box;
-    width: 100%;
     position: fixed;
     bottom: 0;
     left: 0;
@@ -105,6 +104,8 @@ div.ethical-sidebar, div.ethical-footer {
     padding: 0.5em 2.5em;
     text-align: center;
     color: #404040;
+    width: 100%;    /* Fallback for Opera Mini */
+    width: 100vw;
 }
 .ethical-fixedfooter a,
 .ethical-fixedfooter a:hover,


### PR DESCRIPTION
This is a fix in case content on the page causes the `<body>` width to exceed the viewport width.

`vw` is understood by basically every browser visiting our site (IE9+, Chrome, FF, Safari) except Opera Mini. For this case, 100% is used as a fallback. https://caniuse.com/#search=vw

Here's the issue I'm trying to fix:
<img width="343" alt="screen shot 2018-04-13 at 11 34 33 am" src="https://user-images.githubusercontent.com/185043/38752036-b60d8cfa-3f0e-11e8-86e1-fa7115bcde8f.png">
