### PR TITLE
Don't share state in build task

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -161,13 +161,20 @@ class SyncRepositoryMixin(object):
                          msg=msg))
 
 
-class SyncRepositoryTask(SyncRepositoryMixin, Task):
+class SyncRepositoryTask(Task):
 
     """Entry point to synchronize the VCS documentation."""
 
     max_retries = 5
     default_retry_delay = (7 * 60)
     name = __name__ + '.sync_repository'
+
+    def run(self, *args, **kwargs):
+        step = SyncRepositoryTaskStep()
+        return step.run(*args, **kwargs)
+
+
+class SyncRepositoryTaskStep(SyncRepositoryMixin):
 
     def run(self, version_pk):  # pylint: disable=arguments-differ
         """
@@ -194,7 +201,18 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
         return False
 
 
-class UpdateDocsTask(SyncRepositoryMixin, Task):
+class UpdateDocsTask(Task):
+
+    max_retries = 5
+    default_retry_delay = (7 * 60)
+    name = __name__ + '.update_docs'
+
+    def run(self, *args, **kwargs):
+        step = UpdateDocsTaskStep()
+        return step.run(*args, **kwargs)
+
+
+class UpdateDocsTaskStep(SyncRepositoryMixin):
 
     """
     The main entry point for updating documentation.
@@ -204,11 +222,6 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     html docs if needed.
     """
 
-    max_retries = 5
-    default_retry_delay = (7 * 60)
-    name = __name__ + '.update_docs'
-
-    # TODO: the argument from the __init__ are used only in tests
     def __init__(self, build_env=None, python_env=None, config=None,
                  force=False, search=True, localmedia=True,
                  build=None, project=None, version=None):

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -12,7 +12,7 @@ from readthedocs.doc_builder.config import ConfigWrapper
 from readthedocs.doc_builder.environments import LocalBuildEnvironment
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.doc_builder.loader import get_builder_class
-from readthedocs.projects.tasks import UpdateDocsTask
+from readthedocs.projects.tasks import UpdateDocsTaskStep
 from readthedocs.rtd_tests.tests.test_config_wrapper import create_load
 
 from ..mocks.environment import EnvironmentMockGroup
@@ -44,7 +44,7 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
-        task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
+        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
         task.build_docs()
 
@@ -68,7 +68,7 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
-        task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
+        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
 
         task.build_docs()
@@ -93,7 +93,7 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
-        task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
+        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
         task.build_docs()
 
@@ -119,7 +119,7 @@ class BuildEnvironmentTests(TestCase):
         config = ConfigWrapper(version=version, yaml_config=create_load({
             'formats': ['epub']
         })()[0])
-        task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
+        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
         task.build_docs()
 
@@ -174,7 +174,7 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
-        task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
+        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
 
         # Mock out the separate calls to Popen using an iterable side_effect
@@ -216,7 +216,7 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = ConfigWrapper(version=version, yaml_config=create_load()()[0])
-        task = UpdateDocsTask(build_env=build_env, project=project, python_env=python_env,
+        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
                               version=version, search=False, localmedia=False, config=config)
 
         # Mock out the separate calls to Popen using an iterable side_effect

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -64,9 +64,9 @@ class TestCeleryBuilding(RTDTestCase):
         self.assertTrue(result.successful())
         self.assertFalse(exists(directory))
 
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_python_environment', new=MagicMock)
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs', new=MagicMock)
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_python_environment', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.build_docs', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_vcs', new=MagicMock)
     def test_update_docs(self):
         build = get(Build, project=self.project,
                     version=self.project.versions.first())
@@ -79,10 +79,10 @@ class TestCeleryBuilding(RTDTestCase):
                 intersphinx=False)
         self.assertTrue(result.successful())
 
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_python_environment', new=MagicMock)
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_python_environment', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.build_docs', new=MagicMock)
     @patch('readthedocs.doc_builder.environments.BuildEnvironment.update_build', new=MagicMock)
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs')
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_vcs')
     def test_update_docs_unexpected_setup_exception(self, mock_setup_vcs):
         exc = Exception()
         mock_setup_vcs.side_effect = exc
@@ -97,10 +97,10 @@ class TestCeleryBuilding(RTDTestCase):
                 intersphinx=False)
         self.assertTrue(result.successful())
 
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_python_environment', new=MagicMock)
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.setup_vcs', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_python_environment', new=MagicMock)
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_vcs', new=MagicMock)
     @patch('readthedocs.doc_builder.environments.BuildEnvironment.update_build', new=MagicMock)
-    @patch('readthedocs.projects.tasks.UpdateDocsTask.build_docs')
+    @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.build_docs')
     def test_update_docs_unexpected_build_exception(self, mock_build_docs):
         exc = Exception()
         mock_build_docs.side_effect = exc


### PR DESCRIPTION
Move task steps to an isolated class, instead of possibly sharing state in
between tasks. This bug is not consistently reproduceable, but one consistent
way to reproduce is to drop to ``rdb`` on the UpdateDocsTask run method.
Previously, if you did this while running 2 celery processes, and triggered 2
builds, you could witness state changing on the task instance. By moving state
to a separate class that is instantiated on each task execution, this completely
avoids shared state in these tasks.