### PR TITLE
Make adjustments to Projects page

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -129,7 +129,7 @@ form.form-wide textarea {
 #content { padding: 50px 0; }
 #content ul { margin-bottom: 20px; }
 
-#content #project_description { margin-bottom: 20px; }
+#project_description { margin-top: 20px; }
 /* Commenting this for now. Want to figure out how to make it look sane with small amounts of text. */
 /* #content p { background-color: #eee; } */
 
@@ -632,7 +632,6 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 .left { float: left; }
 .right { float: right; }
 .right-menu { float: right; margin-right: 132px; }
-.quiet { color: #999; }
 .help_text { color: #999; }
 .highlighted { background-color: #ee9; padding: 0 1px; margin: 0 1px; border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px; }
 .first { margin-left: 0; padding-left: 0; }

--- a/readthedocs/templates/core/project_details.html
+++ b/readthedocs/templates/core/project_details.html
@@ -73,17 +73,14 @@
 {% endif %}
 {% endblock %}
 
-<div id="project_description">
 {% if project.description %}
+<div id="project_description">
   <h3>{% trans "Description" %}</h3>
-  <div id="project_description">
   <p>
     {{ project.description|restructuredtext }}
   </p>
-  </div>
-{% endif %}
 </div>
-
+{% endif %}
 
 </div>{# END .module #}
 


### PR DESCRIPTION
Going over the changes:

`.quiet` was removed because it was already defined elsewhere, which didn't make much sense. The line of duplication is line 46.

`#content #project_description` was simplified to just `#project_description`.

I also made the decision to make the `margin-bottom` a `margin-top` because it does nothing otherwise. An example in practice is [godot](https://readthedocs.org/projects/godot/). And if you are to look at the HTML file, its going to end up rendered at the bottom. Essentially, it's useless and I think it was meant for it to be a top margin such that there would be appropriate spacing.

I also adjusted the template in `project_details.html` such that it removed the extra id and needless div, and would not leave an empty div in case of there not being a description. That way, it fits the purpose of templating better.