### PR TITLE
Use pur to upgrade python packages

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,11 @@ appdirs==1.4.3
 virtualenv==15.2.0
 docutils==0.14
 Sphinx==1.7.2
-sphinx_rtd_theme==0.3.0
+
+# 0.3.0 breaks sidebar
+# https://github.com/rtfd/sphinx_rtd_theme/issues/610
+sphinx_rtd_theme==0.2.5b1
+
 Pygments==2.2.0
 
 # latest compatible version with our code

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,10 +1,10 @@
 # Base packages
-pip==9.0.3
+pip==10.0.0
 appdirs==1.4.3
-virtualenv==15.1.0
+virtualenv==15.2.0
 docutils==0.14
-Sphinx==1.7.0
-sphinx_rtd_theme==0.2.5b1
+Sphinx==1.7.2
+sphinx_rtd_theme==0.3.0
 Pygments==2.2.0
 
 # latest compatible version with our code
@@ -19,20 +19,20 @@ readthedocs-build<2.1
 # django-tastypie 0.13.x and 0.14.0 are not compatible with our code
 django-tastypie==0.13.0
 
-django-haystack==2.7.0
+django-haystack==2.8.1
 celery-haystack==0.10
 django-guardian==1.4.9
-django-extensions==2.0.0
+django-extensions==2.0.6
 
 # djangorestframework 3.7.x drops support for django 1.9.x
 djangorestframework==3.6.4
 
-django-vanilla-views==1.0.4
+django-vanilla-views==1.0.5
 jsonfield==2.0.2
 
 requests==2.18.4
 slumber==0.7.1
-lxml==4.1.1
+lxml==4.2.1
 defusedxml==0.5.0
 
 # Basic tools
@@ -47,8 +47,8 @@ django-allauth==0.32.0
 dnspython==1.15.0
 
 # VCS
-httplib2==0.10.3
-GitPython==2.1.8
+httplib2==0.11.3
+GitPython==2.1.9
 
 # Search
 elasticsearch==1.5.0
@@ -57,7 +57,7 @@ pyquery==1.4.0
 
 # Utils
 django-gravatar2==1.4.2
-pytz==2018.3
+pytz==2018.4
 beautifulsoup4==4.6.0
 Unipath==1.1
 django-kombu==0.9.4
@@ -70,7 +70,7 @@ stripe==1.20.2
 
 django-formtools==2.1
 django-dynamic-fixture==2.0.0
-docker==3.1.3
+docker==3.2.1
 django-textclassifier==1.0
 django-annoying==0.10.4
 django-messages-extends==0.6.0
@@ -79,7 +79,7 @@ django-taggit==0.22.2
 dj-pagination==2.3.2
 
 # Docs
-sphinxcontrib-httpdomain==1.6.0
+sphinxcontrib-httpdomain==1.6.1
 
 # commonmark 0.5.5 is the latest version compatible with our docs, the
 # newer ones make `tox -e docs` to fail
@@ -88,7 +88,7 @@ commonmark==0.5.5
 recommonmark==0.4.0
 
 # Version comparison stuff
-packaging==16.8
+packaging==17.1
 
 # Commenting stuff
 django-cors-middleware==1.3.1


### PR DESCRIPTION
```
$ pur --skip django-tastypie,django,docker-py,elasticsearch,pyelasticsearch,commonmark,stripe,djangorestframework,mkdocs,django-allauth
Updated pip: 9.0.3 -> 10.0.0
Updated virtualenv: 15.1.0 -> 15.2.0
Updated Sphinx: 1.7.0 -> 1.7.2
Updated sphinx-rtd-theme: 0.2.5b1 -> 0.3.0
New version for readthedocs-build found (2.0.9), but current spec prohibits updating: readthedocs-build<2.1
Updated django-haystack: 2.7.0 -> 2.8.1
Updated django-extensions: 2.0.0 -> 2.0.6
Updated django-vanilla-views: 1.0.4 -> 1.0.5
Updated lxml: 4.1.1 -> 4.2.1
Updated httplib2: 0.10.3 -> 0.11.3
Updated GitPython: 2.1.8 -> 2.1.9
Updated pytz: 2018.3 -> 2018.4
Updated docker: 3.1.3 -> 3.2.1
Updated sphinxcontrib-httpdomain: 1.6.0 -> 1.6.1
Updated packaging: 16.8 -> 17.1
All requirements up-to-date.
```