### PR TITLE
Remove django-celery-beat and use the default scheduler

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -84,7 +84,6 @@ class CommunityBaseSettings(Settings):
             'annoying',
             'django_extensions',
             'messages_extends',
-            'django_celery_beat',
 
             # daniellindsleyrocksdahouse
             'haystack',
@@ -245,7 +244,6 @@ class CommunityBaseSettings(Settings):
     CELERY_CREATE_MISSING_QUEUES = True
 
     CELERY_DEFAULT_QUEUE = 'celery'
-    CELERYBEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
     CELERYBEAT_SCHEDULE = {
         # Ran every hour on minute 30
         'hourly-remove-orphan-symlinks': {

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -38,7 +38,6 @@ defusedxml==0.5.0
 # Basic tools
 redis==2.10.6
 celery==4.1.0
-django-celery-beat==1.1.1
 
 # django-allauth 0.33.0 dropped support for Django 1.9
 # https://django-allauth.readthedocs.io/en/latest/release-notes.html#backwards-incompatible-changes


### PR DESCRIPTION
There are some issues with timezone for the `DatabaseScheduler`, so we fallback to the default one (celery.beat.PersistentScheduler) which is simpler --doesn't allow us to change the scheduled task from the admin, but we don't need that.

In case we need this again, we can come back when those issues are already fixed and revert this commit.