### PR TITLE
Make `resolve_domain` work when a project is subproject of itself

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -164,7 +164,10 @@ class ResolverBase(object):
         relation = project.superprojects.first()
         if project.main_language_project:
             return self._get_canonical_project(project.main_language_project)
-        elif relation:
+        # If ``relation.parent == project`` means that the project has an
+        # inconsistent relationship and was added when this restriction didn't
+        # exist
+        elif relation and relation.parent != project:
             return self._get_canonical_project(relation.parent)
         return project
 

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -292,6 +292,27 @@ class ResolverDomainTests(ResolverBase):
             self.assertEqual(url, 'pip.readthedocs.org')
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
+    def test_domain_resolver_subproject_itself(self):
+        """
+        Test inconsistent project/subproject relationship.
+
+        If a project is subproject of itself (inconsistent relationship) we
+        still resolves the proper domain.
+        """
+        # remove all possible subproject relationships
+        self.pip.subprojects.all().delete()
+
+        # add the project as subproject of itself
+        self.pip.add_subproject(self.pip)
+
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve_domain(project=self.pip)
+            self.assertEqual(url, 'readthedocs.org')
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve_domain(project=self.pip)
+            self.assertEqual(url, 'pip.readthedocs.org')
+
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
     def test_domain_resolver_translation(self):
         with override_settings(USE_SUBDOMAIN=False):
             url = resolve_domain(project=self.translation)


### PR DESCRIPTION
This is an invalid db state since this relationship is not possible, but there are some old project that has this relationship and we want to avoid breaking the code for this cases.