### PR TITLE
Fix exact redirects.

### DIFF
--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -146,11 +146,7 @@ class Redirect(models.Model):
     def redirect_exact(self, path, language=None, version_slug=None):
         if language and version_slug:
             # reconstruct the full path for an exact redirect
-            full_path = '/{language}/{version_slug}/{path}'.format(
-                language=language,
-                version_slug=version_slug,
-                path=path.lstrip('/'),
-            )
+            full_path = self.get_full_path(path, language, version_slug)
         if full_path == self.from_url:
             log.debug('Redirecting %s', self)
             return self.to_url

--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -144,6 +144,7 @@ class Redirect(models.Model):
             return to
 
     def redirect_exact(self, path, language=None, version_slug=None):
+        full_path = path
         if language and version_slug:
             # reconstruct the full path for an exact redirect
             full_path = self.get_full_path(path, language, version_slug)

--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -143,8 +143,15 @@ class Redirect(models.Model):
                 version_slug=version_slug)
             return to
 
-    def redirect_exact(self, path, **__):
-        if path == self.from_url:
+    def redirect_exact(self, path, language=None, version_slug=None):
+        if language and version_slug:
+            # reconstruct the full path for an exact redirect
+            full_path = '/{language}/{version_slug}/{path}'.format(
+                language=language,
+                version_slug=version_slug,
+                path=path.lstrip('/'),
+            )
+        if full_path == self.from_url:
             log.debug('Redirecting %s', self)
             return self.to_url
         # Handle full sub-level redirects

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -148,6 +148,17 @@ class RedirectAppTests(TestCase):
             r['Location'], 'http://pip.readthedocs.org/en/latest/tutorial/install.html')
 
     @override_settings(USE_SUBDOMAIN=True)
+    def test_redirect_exact(self):
+        Redirect.objects.create(
+            project=self.pip, redirect_type='exact',
+            from_url='/en/latest/install.html', to_url='/en/latest/tutorial/install.html'
+        )
+        r = self.client.get('/en/latest/install.html', HTTP_HOST='pip.readthedocs.org')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'http://pip.readthedocs.org/en/latest/tutorial/install.html')
+
+    @override_settings(USE_SUBDOMAIN=True)
     def test_redirect_keeps_version_number(self):
         Redirect.objects.create(
             project=self.pip, redirect_type='page',


### PR DESCRIPTION
Exact redirects depend on the full path being set against, so that you can do things like redirect versions. This was broken in a previous refactor.