### PR TITLE
Access single version project with USE_SUBDOMAIN=False

### DIFF
--- a/readthedocs/core/urls/single_version.py
+++ b/readthedocs/core/urls/single_version.py
@@ -11,7 +11,7 @@ from django.conf.urls.static import static
 from readthedocs.constants import pattern_opts
 from readthedocs.core.views import serve
 
-handler500 = 'readthedocs.core.views.server_error'
+handler500 = 'readthedocs.core.views.server_error_500'
 handler404 = 'readthedocs.core.views.server_error_404'
 
 single_version_urls = [

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -88,6 +88,9 @@ def map_project_slug(view_func):
     def inner_view(request, project=None, project_slug=None, *args, **kwargs):  # noqa
         if project is None:
             if not project_slug:
+                # FIXME: this blows up when USE_SUBDOMAIN=False and DEBUG=False
+                # and accessing a single version project like:
+                # http://localhost:8000/docs/contribution-guide-org/
                 project_slug = request.slug
             try:
                 project = Project.objects.get(slug=project_slug)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -178,7 +178,8 @@ class SyncRepositoryTask(Task):
 
 class SyncRepositoryTaskStep(SyncRepositoryMixin):
 
-    """Entry point to synchronize the VCS documentation.
+    """
+    Entry point to synchronize the VCS documentation.
 
     .. note::
 
@@ -186,7 +187,6 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin):
         underlying task. Previously, we were using a custom ``celery.Task`` for
         this, but this class is only instantiated once -- on startup. The effect
         was that this instance shared state between workers.
-
     """
 
     def run(self, version_pk):  # pylint: disable=arguments-differ

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -854,7 +854,7 @@ class TestPythonEnvironment(TestCase):
 
         self.base_requirements = [
             'Pygments==2.2.0',
-            'setuptools==37.0.0',
+            'setuptools<40',
             'docutils==0.13.1',
             'mock==1.0.1',
             'pillow==2.6.1',

--- a/readthedocs/rtd_tests/tests/test_single_version.py
+++ b/readthedocs/rtd_tests/tests/test_single_version.py
@@ -30,3 +30,8 @@ class RedirectSingleVersionTests(TestCase):
         with override_settings(USE_SUBDOMAIN=True):
             self.assertEqual(self.pip.get_docs_url(),
                              'http://pip.public.readthedocs.org/en/latest/')
+
+    def test_access_documentation(self):
+        with override_settings(USE_SUBDOMAIN=False):
+            resp = self.client.get(self.pip.get_docs_url())
+            self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
This PR is based on #3975 

The test will fail when trying to access `request.slug` in the `map_project_slug` decorator.