### PR TITLE
Resolve domain when a project is a translation of itself

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -162,11 +162,14 @@ class ResolverBase(object):
         :rtype: Project
         """
         relation = project.superprojects.first()
-        if project.main_language_project:
+        # If ``project.main_language_project == project`` means that the project
+        # it's a translation of itself and have an inconsistent
+        # relationship. It's was added when this restriction didn't exist yet
+        if project.main_language_project and project.main_language_project != project:
             return self._get_canonical_project(project.main_language_project)
-        # If ``relation.parent == project`` means that the project has an
-        # inconsistent relationship and was added when this restriction didn't
-        # exist
+        # If ``relation.parent == project`` means that the project is subproject
+        # of iteself. This is an inconsistent relationship and was added when
+        # this restriction didn't exist
         elif relation and relation.parent != project:
             return self._get_canonical_project(relation.parent)
         return project

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -321,6 +321,27 @@ class ResolverDomainTests(ResolverBase):
             url = resolve_domain(project=self.translation)
             self.assertEqual(url, 'pip.readthedocs.org')
 
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
+    def test_domain_resolver_translation_itself(self):
+        """
+        Test inconsistent project/translation relationship.
+
+        If a project is a translation of itself (inconsistent relationship) we
+        still resolves the proper domain.
+        """
+        # remove all possible translations relationships
+        self.pip.translations.all().delete()
+
+        # add the project as subproject of itself
+        self.pip.translations.add(self.pip)
+
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve_domain(project=self.pip)
+            self.assertEqual(url, 'readthedocs.org')
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve_domain(project=self.pip)
+            self.assertEqual(url, 'pip.readthedocs.org')
+
     @override_settings(
         PRODUCTION_DOMAIN='readthedocs.org',
         PUBLIC_DOMAIN='public.readthedocs.org')


### PR DESCRIPTION
Ref: https://sentry.io/read-the-docs/readthedocs-org/issues/533028643/