### PR TITLE
Subdomains use HTTPS if settings specify

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -83,6 +83,17 @@ Default: :djangosetting:`PUBLIC_DOMAIN`
 A special domain for serving public documentation.
 If set, public docs will be linked here instead of the `PRODUCTION_DOMAIN`.
 
+
+PUBLIC_DOMAIN_USES_HTTPS
+------------------------
+
+Default: ``False``
+
+If ``True`` and ``PUBLIC_DOMAIN`` is set, that domain will default to
+serving public documentation over HTTPS. By default, documentation is
+served over HTTP.
+
+
 ALLOW_ADMIN
 -----------
 

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -144,9 +144,17 @@ class ResolverBase(object):
                 version_slug = project.get_default_version()
             private = self._get_private(project, version_slug)
 
+        domain = self.resolve_domain(project, private=private)
+
+        # Use HTTPS if settings specify
+        public_domain = getattr(settings, 'PUBLIC_DOMAIN', None)
+        use_https = getattr(settings, 'PUBLIC_DOMAIN_USES_HTTPS', False)
+        if use_https and public_domain and public_domain in domain:
+            protocol = 'https'
+
         return '{protocol}://{domain}{path}'.format(
             protocol=protocol,
-            domain=self.resolve_domain(project, private=private),
+            domain=domain,
             path=self.resolve_path(project, filename=filename, private=private,
                                    **kwargs),
         )

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -488,6 +488,19 @@ class ResolverTests(ResolverBase):
             url = resolve(project=self.pip, private=False)
             self.assertEqual(url, 'http://docs.foobar.com/en/latest/')
 
+    @override_settings(
+        PRODUCTION_DOMAIN='readthedocs.org',
+        PUBLIC_DOMAIN='readthedocs.io',
+        PUBLIC_DOMAIN_USES_HTTPS=True,
+        USE_SUBDOMAIN=True,
+    )
+    def test_resolver_domain_https(self):
+        url = resolve(project=self.pip, private=True)
+        self.assertEqual(url, 'https://pip.readthedocs.io/en/latest/')
+
+        url = resolve(project=self.pip, private=False)
+        self.assertEqual(url, 'https://pip.readthedocs.io/en/latest/')
+
 
 class ResolverAltSetUp(object):
 

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -491,15 +491,19 @@ class ResolverTests(ResolverBase):
     @override_settings(
         PRODUCTION_DOMAIN='readthedocs.org',
         PUBLIC_DOMAIN='readthedocs.io',
-        PUBLIC_DOMAIN_USES_HTTPS=True,
         USE_SUBDOMAIN=True,
     )
     def test_resolver_domain_https(self):
-        url = resolve(project=self.pip, private=True)
-        self.assertEqual(url, 'https://pip.readthedocs.io/en/latest/')
+        with override_settings(PUBLIC_DOMAIN_USES_HTTPS=True):
+            url = resolve(project=self.pip, private=True)
+            self.assertEqual(url, 'https://pip.readthedocs.io/en/latest/')
 
-        url = resolve(project=self.pip, private=False)
-        self.assertEqual(url, 'https://pip.readthedocs.io/en/latest/')
+            url = resolve(project=self.pip, private=False)
+            self.assertEqual(url, 'https://pip.readthedocs.io/en/latest/')
+
+        with override_settings(PUBLIC_DOMAIN_USES_HTTPS=False):
+            url = resolve(project=self.pip, private=True)
+            self.assertEqual(url, 'http://pip.readthedocs.io/en/latest/')
 
 
 class ResolverAltSetUp(object):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -42,6 +42,7 @@ class CommunityBaseSettings(Settings):
     # Domains and URLs
     PRODUCTION_DOMAIN = 'readthedocs.org'
     PUBLIC_DOMAIN = None
+    PUBLIC_DOMAIN_USES_HTTPS = False
     USE_SUBDOMAIN = False
     PUBLIC_API_URL = 'https://{0}'.format(PRODUCTION_DOMAIN)
 


### PR DESCRIPTION
This PR adds an option `PUBLIC_DOMAIN_USES_HTTPS` which if set will make all "view docs" links and everywhere that uses the resolver (eg. the version selector menu) default to HTTPS for `*.readthedocs.io`domains. We know there is a valid certificate for these and so our generated links should use HTTPS.

This is step 1/5 on on getting to HTTPS everywhere:
https://github.com/rtfd/readthedocs.org/issues/3282#issuecomment-369509347