### PR TITLE
Don't check order on assertQuerysetEqual on tests for subprojects

### DIFF
--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -53,6 +53,7 @@ class SubprojectFormTests(TestCase):
             Project.objects.for_admin_user(user),
             [project],
             transform=lambda n: n,
+            ordered=False,
         )
         form = ProjectRelationshipForm(
             {'child': subproject.pk},
@@ -76,6 +77,7 @@ class SubprojectFormTests(TestCase):
             Project.objects.for_admin_user(user),
             [project, subproject],
             transform=lambda n: n,
+            ordered=False,
         )
         form = ProjectRelationshipForm(
             {'child': subproject.pk},
@@ -102,6 +104,7 @@ class SubprojectFormTests(TestCase):
             Project.objects.for_admin_user(user),
             [project, subproject, subsubproject],
             transform=lambda n: n,
+            ordered=False,
         )
         form = ProjectRelationshipForm(
             {'child': subsubproject.pk},
@@ -132,6 +135,7 @@ class SubprojectFormTests(TestCase):
             Project.objects.for_admin_user(user),
             [project, subproject],
             transform=lambda n: n,
+            ordered=False,
         )
         form = ProjectRelationshipForm(
             {'child': subproject.pk},


### PR DESCRIPTION
I saw this while looking into another issue. When I run the tests only on this file `tox -e py36 readthedocs/rtd_tests/tests/test_subprojects.py` tests fail because of the order, weird that this never fails when running the full suite of tests.