### PR TITLE
Weird behavior when using a subdomain and doing a request from another host on tests

### DIFF
--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -187,8 +187,7 @@ class ResolverBase(TestCase):
         fixture.get(Project, slug='sub_alias', language='ya')
 
     def tearDown(self):
-        #  set_urlconf(None)
-        pass
+        set_urlconf(None)
 
     @override_settings(
             PRODUCTION_DOMAIN='readthedocs.org',

--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -5,6 +5,7 @@ import django_dynamic_fixture as fixture
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.core.urlresolvers import reverse
 
 from readthedocs.projects.forms import ProjectRelationshipForm
 from readthedocs.projects.models import Project, ProjectRelationship
@@ -200,7 +201,19 @@ class ResolverBase(TestCase):
 
     @override_settings(USE_SUBDOMAIN=True)
     def test_resolver_subproject_subdomain_alias(self):
+        url_name = 'project-sync-versions'
+
+        url = reverse(url_name, args=[1])
+        self.assertEqual(url, '/api/v2/project/1/sync_versions/')
+
         resp = self.client.get('/projects/sub_alias/', HTTP_HOST='pip.readthedocs.org')
+        # If this is executed, the tests will pass
+        # self.client.get('/projects/sub_alias/')
+
+        # Here Django fails to reverse the same url name
+        url = reverse(url_name, args=[1])
+        self.assertEqual(url, '/api/v2/project/1/sync_versions/')
+
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
             resp._headers['location'][1],

--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -5,7 +5,7 @@ import django_dynamic_fixture as fixture
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, set_urlconf
 
 from readthedocs.projects.forms import ProjectRelationshipForm
 from readthedocs.projects.models import Project, ProjectRelationship
@@ -186,6 +186,9 @@ class ResolverBase(TestCase):
         relation.save()
         fixture.get(Project, slug='sub_alias', language='ya')
 
+    def tearDown(self):
+        #  set_urlconf(None)
+        pass
 
     @override_settings(
             PRODUCTION_DOMAIN='readthedocs.org',
@@ -207,15 +210,19 @@ class ResolverBase(TestCase):
         self.assertEqual(url, '/api/v2/project/1/sync_versions/')
 
         resp = self.client.get('/projects/sub_alias/', HTTP_HOST='pip.readthedocs.org')
-        # If this is executed, the tests will pass
-        # self.client.get('/projects/sub_alias/')
 
         # Here Django fails to reverse the same url name
-        url = reverse(url_name, args=[1])
-        self.assertEqual(url, '/api/v2/project/1/sync_versions/')
+        #  url = reverse(url_name, args=[1])
+        #  self.assertEqual(url, '/api/v2/project/1/sync_versions/')
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
             resp._headers['location'][1],
             'http://pip.readthedocs.org/projects/sub_alias/ja/latest/'
         )
+
+
+class TestClass(TestCase):
+
+    def test_other_test(self):
+        reverse('project-sync-versions', args=[1])


### PR DESCRIPTION
This is more an issue report that a PR. I'm doing this because I think is easier to show what's happening and get help since I'm not sure why is this happening :/.

When `@override_settings(USE_SUBDOMAIN=True)` and `self.client.get('/projects/sub_alias/', HTTP_HOST='pip.readthedocs.org')` is used, the reverse function fails (throw an exception). After doing the same request without the `HTTP_HOST` header, everything is back to normal. 

Note that this behavior isn't just happening inside this test, but on all tests after this one (see https://github.com/rtfd/readthedocs.org/pull/3913#issuecomment-382279429). You can tests this, by adding a tests case that uses the reverse function after the `ResolverBase`

```
class TestClass(TestCase):

    def test_other_test(self):
        reverse('project-sync-versions', args=[1])
```

I think maybe this is related to the custom resolver that keeps a state between each test case.