### PR TITLE
Remove build queue length warning on build list page

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -16,8 +16,6 @@ from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import trigger_build
 from readthedocs.projects.models import Project
 
-from redis import Redis, ConnectionError
-
 
 log = logging.getLogger(__name__)
 
@@ -66,12 +64,6 @@ class BuildList(BuildBase, BuildTriggerMixin, ListView):
         context['active_builds'] = active_builds
         context['versions'] = Version.objects.public(user=self.request.user, project=self.project)
         context['build_qs'] = self.get_queryset()
-
-        try:
-            redis = Redis.from_url(settings.BROKER_URL)
-            context['queue_length'] = redis.llen('celery')
-        except ConnectionError:
-            context['queue_length'] = None
 
         return context
 

--- a/readthedocs/templates/builds/build_list.html
+++ b/readthedocs/templates/builds/build_list.html
@@ -17,18 +17,6 @@
 {% block content %}
 
 
-<!-- BEGIN queue depth warning -->
-{% if queue_length > 10 %}
-<div>
-  <p>
-  {% blocktrans with queue_length as queue_length %}
-    Whoa! The build queue is {{ queue_length }} tasks long, new builds may take a while.
-  {% endblocktrans %}
-  </p>
-</div>
-{% endif %}
-
-
 <div id="build_list">
 
         {% autopaginate build_qs 15 %}


### PR DESCRIPTION
This piece of UI was never updated to fit somewhere more cohesive in the UI and
I feel is a strange thing to expose directly to users. I think a better
application for this is in an eventual status page. A status page is not a
priority atm though.