### PR TITLE
Support sign in and sign up with GH/GL/BB

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -521,6 +521,18 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 .navigable .profile_image img { border-radius:5px; }
 
 .profile #content { padding-top:8px; }
+
+/* login & signup pages */
+.login-page h3, .signup-page h3 {
+    margin: 40px 0;
+}
+.login-page .socialaccount_providers .button,
+.signup-page .socialaccount_providers .button {
+    display: inline-block;
+    float: none;
+    margin: 10px 0;
+}
+
 /* build page */
 
 #build_list select { width: 10em; }

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -273,7 +273,6 @@ class CommunityBaseSettings(Settings):
     ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
     ACCOUNT_AUTHENTICATION_METHOD = 'username_email'
     ACCOUNT_ACTIVATION_DAYS = 7
-    SOCIALACCOUNT_EMAIL_VERIFICATION = 'none'
     SOCIALACCOUNT_AUTO_SIGNUP = False
     SOCIALACCOUNT_PROVIDERS = {
         'github': {

--- a/readthedocs/templates/account/login.html
+++ b/readthedocs/templates/account/login.html
@@ -5,12 +5,14 @@
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
+{% block body_class %}login-page{% endblock %}
+
 {% block content %}
 
 <h1>{% trans "Sign In" %}</h1>
 
-<p>{% blocktrans %}If you have not created an account yet, then please
-<a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
+<p><small>{% blocktrans %}If you have not created an account yet, then please
+<a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</small></p>
 
 <form class="login" method="POST" action="{% url "account_login" %}">
   {% csrf_token %}
@@ -19,7 +21,19 @@
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
   <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
-  {% blocktrans %}If you forgot your password, <a href="/accounts/password/reset/">reset it.</a>{% endblocktrans %}
+
+  {% url 'account_reset_password' as password_reset_url %}
+  <p>
+    <small>{% blocktrans %}If you forgot your password, <a href="{{ password_reset_url }}">reset it.</a>{% endblocktrans %}</small>
+  </p>
 </form>
 
-{% endblock %}
+<h3>{% trans 'Or' %}</h3>
+
+<div class="clearfix">
+  <ul class="socialaccount_providers">
+    {% include "socialaccount/snippets/provider_list.html" with process="login" next="" verbiage="Sign in with" %}
+  </ul>
+</div>
+
+{% endblock content %}

--- a/readthedocs/templates/account/signup.html
+++ b/readthedocs/templates/account/signup.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Signup" %}{% endblock %}
+{% block head_title %}{% trans "Sign up" %}{% endblock %}
 
 {% block body_class %}signup-page{% endblock %}
 

--- a/readthedocs/templates/account/signup.html
+++ b/readthedocs/templates/account/signup.html
@@ -1,0 +1,33 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Signup" %}{% endblock %}
+
+{% block body_class %}signup-page{% endblock %}
+
+{% block content %}
+<h1>{% trans "Sign Up" %}</h1>
+
+<p>
+  <small>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</small>
+</p>
+
+<form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
+  {% csrf_token %}
+  {{ form.as_p }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <button type="submit">{% trans "Sign Up" %} &raquo;</button>
+</form>
+
+<h3>{% trans 'Or' %}</h3>
+
+<div class="clearfix">
+  <ul class="socialaccount_providers">
+    {% include "socialaccount/snippets/provider_list.html" with process="login" next="" verbiage="Sign up with" %}
+  </ul>
+</div>
+
+{% endblock %}

--- a/readthedocs/templates/socialaccount/snippets/provider_list.html
+++ b/readthedocs/templates/socialaccount/snippets/provider_list.html
@@ -11,8 +11,8 @@
            class="socialaccount-provider {{ provider.id }} {{ brand.id }} button"
            href="{% provider_login_url provider.id openid=brand.openid_url process=process next=next %}"
            >
-           {% blocktrans with brand_name=brand.name %}
-             Connect to {{ brand_name }}
+           {% blocktrans with brand_name=brand.name verbiage=verbiage|default:'Connect to' %}
+             {{ verbiage }} {{ brand_name }}
            {% endblocktrans %}
         </a>
       </li>
@@ -24,8 +24,8 @@
          class="socialaccount-provider {{ provider.id }} button"
          href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params next=next %}"
          >
-         {% blocktrans with provider_name=provider.name %}
-           Connect to {{ provider_name }}
+         {% blocktrans with provider_name=provider.name verbiage=verbiage|default:'Connect to' %}
+           {{ verbiage }} {{ provider_name }}
          {% endblocktrans %}
       </a>
     </li>


### PR DESCRIPTION
While this was technically supported if you knew the URLs, this adds formal support for logging in and signing up with our providers (currently GitHub, BitBucket, and GitLab).

<img width="859" alt="screen shot 2018-04-25 at 12 41 55 pm" src="https://user-images.githubusercontent.com/185043/39268932-14312528-4886-11e8-8280-c0517274351d.png">


## How this works

Let's say your user account already is connected to GitHub because you actually use Read the Docs with your GitHub account. The "Sign in with GitHub" button will just work for you. You can still use your old username and password if you like.

If your GitHub account is not connected to anything and you click the "Sign in with GitHub", you will authenticate with GitHub, and then you will get a confirmation screen where you tie your GitHub account and email to a new Read the Docs username (see screenshot below). After confirming, you'll be logged in. The first and last name may be populated from the provider if available.

<img width="842" alt="screen shot 2018-04-25 at 12 45 31 pm" src="https://user-images.githubusercontent.com/185043/39269095-b48a15ac-4886-11e8-9fef-bd8d1c415d3e.png">

BitBucket works exactly the same as GitHub. I didn't actually test GitLab but I assume it does.

**Note:** There is no technical difference between the "Sign in with.." and "Sign up with.." buttons. If your social account is already connected to a user account, you will be logged in. If it isn't, you will be asked to confirm a new sign up.

## Weird edge cases

* Say your social account isn't connected, you click "Sign in with..." and go to the confirm new user screen. The email address already exists and you try to submit it again. You will see an error `An account already exists with this e-mail address. Please sign in to that account first, then connect your Bitbucket account.` This is strange a little bit at first but I believe it is correct functionality. It also won't let you create a duplicate username but that seems standard.
* Say a brand new user signs up with their GitHub account and then disconnects GitHub from their account (on https://readthedocs.org/accounts/social/connections/). The user won't be able to login with GitHub any longer (the accounts aren't connected) but they also can't login with a username and password (their account has no password). The only way to retrieve the account in this case is with a password reset to the email on file.