### PR TITLE
Make email verification optional for dev

### DIFF
--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -23,6 +23,7 @@ class CommunityDevSettings(CommunityBaseSettings):
 
     DONT_HIT_DB = False
 
+    ACCOUNT_EMAIL_VERIFICATION = 'none'
     SESSION_COOKIE_DOMAIN = None
     CACHE_BACKEND = 'dummy://'
 


### PR DESCRIPTION
This changes our default to allowing users to login w/out verifying their pw,
but still sending the password to them via email.

I think this is better for dev,
so folks don't need to verify a fake email when just playing around locally.