### PR TITLE
Bump sphinx default version to 1.7.4

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -243,7 +243,7 @@ class Virtualenv(PythonEnvironment):
                 self.project.get_feature_value(
                     Feature.USE_SPHINX_LATEST,
                     positive='sphinx<2',
-                    negative='sphinx==1.6.5',
+                    negative='sphinx==1.7.4',
                 ),
                 'sphinx-rtd-theme<0.3',
                 'readthedocs-sphinx-ext<0.6'

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -884,7 +884,7 @@ class TestPythonEnvironment(TestCase):
         requirements_sphinx = [
             'commonmark==0.5.4',
             'recommonmark==0.4.0',
-            'sphinx==1.6.5',
+            'sphinx==1.7.4',
             'sphinx-rtd-theme<0.3',
             'readthedocs-sphinx-ext<0.6',
         ]

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -3,7 +3,7 @@ pip==10.0.0
 appdirs==1.4.3
 virtualenv==15.2.0
 docutils==0.14
-Sphinx==1.7.2
+Sphinx==1.7.4
 
 # 0.3.0 breaks sidebar
 # https://github.com/rtfd/sphinx_rtd_theme/issues/610


### PR DESCRIPTION
Since the feature flag is `sphinx<2`, I didn't touch it.

Closes #4015 