### PR TITLE
Use gitpython for tags

### DIFF
--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -57,30 +57,6 @@ class TestGitBackend(RTDTestCase):
         repo.checkout()
         self.assertTrue(exists(repo.working_dir))
 
-    def test_parse_git_tags(self):
-        data = """\
-            3b32886c8d3cb815df3793b3937b2e91d0fb00f1 refs/tags/2.0.0
-            bd533a768ff661991a689d3758fcfe72f455435d refs/tags/2.0.1
-            c0288a17899b2c6818f74e3a90b77e2a1779f96a refs/tags/2.0.2
-            a63a2de628a3ce89034b7d1a5ca5e8159534eef0 refs/tags/2.1.0.beta2
-            c7fc3d16ed9dc0b19f0d27583ca661a64562d21e refs/tags/2.1.0.rc1
-            edc0a2d02a0cc8eae8b67a3a275f65cd126c05b1 refs/tags/2.1.0.rc2
-            274a5a8c988a804e40da098f59ec6c8f0378fe34 refs/tags/release/foobar
-         """
-        expected_tags = [
-            ('3b32886c8d3cb815df3793b3937b2e91d0fb00f1', '2.0.0'),
-            ('bd533a768ff661991a689d3758fcfe72f455435d', '2.0.1'),
-            ('c0288a17899b2c6818f74e3a90b77e2a1779f96a', '2.0.2'),
-            ('a63a2de628a3ce89034b7d1a5ca5e8159534eef0', '2.1.0.beta2'),
-            ('c7fc3d16ed9dc0b19f0d27583ca661a64562d21e', '2.1.0.rc1'),
-            ('edc0a2d02a0cc8eae8b67a3a275f65cd126c05b1', '2.1.0.rc2'),
-            ('274a5a8c988a804e40da098f59ec6c8f0378fe34', 'release/foobar'),
-        ]
-
-        given_ids = [(x.identifier, x.verbose_name) for x in
-                     self.project.vcs_repo().parse_tags(data)]
-        self.assertEqual(expected_tags, given_ids)
-
     def test_check_for_submodules(self):
         repo = self.project.vcs_repo()
 

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 from os.path import exists
 
 import pytest

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -61,12 +61,11 @@ class TestGitBackend(RTDTestCase):
         repo_path = self.project.repo
         create_tag(repo_path, 'v01')
         create_tag(repo_path, 'v02', annotated=True)
-        create_tag(repo_path, 'release-ünîø∂é')
         repo = self.project.vcs_repo()
         # Hack the repo path
         repo.working_dir = repo_path
         self.assertEqual(
-            set(['v01', 'v02', 'release-ünîø∂é']),
+            set(['v01', 'v02']),
             set(vcs.verbose_name for vcs in repo.tags)
         )
 

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from os.path import exists
 
 import pytest
-import six
 from django.contrib.auth.models import User
 import django_dynamic_fixture as fixture
 
@@ -64,24 +63,13 @@ class TestGitBackend(RTDTestCase):
         repo_path = self.project.repo
         create_git_tag(repo_path, 'v01')
         create_git_tag(repo_path, 'v02', annotated=True)
+        create_git_tag(repo_path, 'release-ünîø∂é')
         repo = self.project.vcs_repo()
         # Hack the repo path
         repo.working_dir = repo_path
         self.assertEqual(
-            set(['v01', 'v02']),
+            set(['v01', 'v02', 'release-ünîø∂é']),
             set(vcs.verbose_name for vcs in repo.tags)
-        )
-
-    @pytest.mark.skipif(six.PY2, reason='Python 3 only')
-    def test_git_tags_unicode(self):
-        repo_path = self.project.repo
-        create_git_tag(repo_path, 'release-ünîø∂é'.encode())
-        repo = self.project.vcs_repo()
-        # Hack the repo path
-        repo.working_dir = repo_path
-        self.assertEqual(
-            ['release-ünîø∂é'],
-            [vcs.verbose_name for vcs in repo.tags]
         )
 
     def test_check_for_submodules(self):

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -65,7 +65,8 @@ class TestGitBackend(RTDTestCase):
         create_git_tag(repo_path, 'v02', annotated=True)
         create_git_tag(repo_path, 'release-ünîø∂é')
         repo = self.project.vcs_repo()
-        # Hack the repo path
+        # We aren't cloning the repo,
+        # so we need to hack the repo path
         repo.working_dir = repo_path
         self.assertEqual(
             set(['v01', 'v02', 'release-ünîø∂é']),

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -75,7 +75,7 @@ class TestGitBackend(RTDTestCase):
     @pytest.mark.skipif(six.PY2, reason='Python 3 only')
     def test_git_tags_unicode(self):
         repo_path = self.project.repo
-        create_git_tag(repo_path, 'release-ünîø∂é')
+        create_git_tag(repo_path, 'release-ünîø∂é'.encode())
         repo = self.project.vcs_repo()
         # Hack the repo path
         repo.working_dir = repo_path

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 from os.path import exists
 
 import pytest
+import six
 from django.contrib.auth.models import User
 import django_dynamic_fixture as fixture
 
@@ -67,6 +70,18 @@ class TestGitBackend(RTDTestCase):
         self.assertEqual(
             set(['v01', 'v02']),
             set(vcs.verbose_name for vcs in repo.tags)
+        )
+
+    @pytest.mark.skipif(six.PY2, reason='Python 3 only')
+    def test_git_tags_unicode(self):
+        repo_path = self.project.repo
+        create_tag(repo_path, 'release-ünîø∂é')
+        repo = self.project.vcs_repo()
+        # Hack the repo path
+        repo.working_dir = repo_path
+        self.assertEqual(
+            ['release-ünîø∂é'],
+            [vcs.verbose_name for vcs in repo.tags]
         )
 
     def test_check_for_submodules(self):

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -9,7 +9,7 @@ from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.projects.models import Project, Feature
 from readthedocs.rtd_tests.base import RTDTestCase
 
-from readthedocs.rtd_tests.utils import make_test_git, make_test_hg
+from readthedocs.rtd_tests.utils import create_tag, make_test_git, make_test_hg
 
 
 class TestGitBackend(RTDTestCase):
@@ -56,6 +56,19 @@ class TestGitBackend(RTDTestCase):
         repo = self.project.vcs_repo()
         repo.checkout()
         self.assertTrue(exists(repo.working_dir))
+
+    def test_git_tags(self):
+        repo_path = self.project.repo
+        create_tag(repo_path, 'v01')
+        create_tag(repo_path, 'v02', annotated=True)
+        create_tag(repo_path, 'release-ünîø∂é')
+        repo = self.project.vcs_repo()
+        # Hack the repo path
+        repo.working_dir = repo_path
+        self.assertEqual(
+            set(['v01', 'v02', 'release-ünîø∂é']),
+            set(vcs.verbose_name for vcs in repo.tags)
+        )
 
     def test_check_for_submodules(self):
         repo = self.project.vcs_repo()

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -12,7 +12,7 @@ from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.projects.models import Project, Feature
 from readthedocs.rtd_tests.base import RTDTestCase
 
-from readthedocs.rtd_tests.utils import create_tag, make_test_git, make_test_hg
+from readthedocs.rtd_tests.utils import create_git_tag, make_test_git, make_test_hg
 
 
 class TestGitBackend(RTDTestCase):
@@ -62,8 +62,8 @@ class TestGitBackend(RTDTestCase):
 
     def test_git_tags(self):
         repo_path = self.project.repo
-        create_tag(repo_path, 'v01')
-        create_tag(repo_path, 'v02', annotated=True)
+        create_git_tag(repo_path, 'v01')
+        create_git_tag(repo_path, 'v02', annotated=True)
         repo = self.project.vcs_repo()
         # Hack the repo path
         repo.working_dir = repo_path
@@ -75,7 +75,7 @@ class TestGitBackend(RTDTestCase):
     @pytest.mark.skipif(six.PY2, reason='Python 3 only')
     def test_git_tags_unicode(self):
         repo_path = self.project.repo
-        create_tag(repo_path, 'release-ünîø∂é')
+        create_git_tag(repo_path, 'release-ünîø∂é')
         repo = self.project.vcs_repo()
         # Hack the repo path
         repo.working_dir = repo_path

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -18,7 +18,8 @@ log = logging.getLogger(__name__)
 
 def check_output(l, env=None):
     output = subprocess.Popen(
-        l, stdout=subprocess.PIPE, universal_newlines=True, env=env
+        l, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True, env=env
     ).communicate()[0]
     log.info(output)
     return output

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for use in tests."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import logging
 import subprocess

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -22,6 +22,7 @@ def check_output(l, env=()):
     else:
         output = subprocess.Popen(l, stdout=subprocess.PIPE,
                                   env=env).communicate()[0]
+    log.info(output)
     return output
 
 
@@ -36,59 +37,60 @@ def make_test_git():
     chdir(directory)
 
     # Initialize and configure
-    # TODO: move the ``log.info`` call inside the ``check_output```
-    log.info(check_output(['git', 'init'] + [directory], env=env))
-    log.info(check_output(
+    check_output(['git', 'init'] + [directory], env=env)
+    check_output(
         ['git', 'config', 'user.email', 'dev@readthedocs.org'],
         env=env
-    ))
-    log.info(check_output(
+    )
+    check_output(
         ['git', 'config', 'user.name', 'Read the Docs'],
         env=env
-    ))
+    )
 
     # Set up the actual repository
-    log.info(check_output(['git', 'add', '.'], env=env))
-    log.info(check_output(['git', 'commit', '-m"init"'], env=env))
+    check_output(['git', 'add', '.'], env=env)
+    check_output(['git', 'commit', '-m"init"'], env=env)
 
     # Add fake repo as submodule. We need to fake this here because local path
     # URL are not allowed and using a real URL will require Internet to clone
     # the repo
-    log.info(check_output(['git', 'checkout', '-b', 'submodule', 'master'], env=env))
+    check_output(['git', 'checkout', '-b', 'submodule', 'master'], env=env)
     # https://stackoverflow.com/a/37378302/2187091
     mkdir(pjoin(directory, 'foobar'))
     gitmodules_path = pjoin(directory, '.gitmodules')
     with open(gitmodules_path, 'w') as fh:
         fh.write('''[submodule "foobar"]\n\tpath = foobar\n\turl = https://foobar.com/git\n''')
-    log.info(check_output(
+    check_output(
         [
             'git', 'update-index', '--add', '--cacheinfo', '160000',
             '233febf4846d7a0aeb95b6c28962e06e21d13688', 'foobar',
         ],
         env=env,
-    ))
-    log.info(check_output(['git', 'add', '.'], env=env))
-    log.info(check_output(['git', 'commit', '-m"Add submodule"'], env=env))
+    )
+    check_output(['git', 'add', '.'], env=env)
+    check_output(['git', 'commit', '-m"Add submodule"'], env=env)
 
     # Add a relative submodule URL in the relativesubmodule branch
-    log.info(check_output(['git', 'checkout', '-b', 'relativesubmodule', 'master'], env=env))
-    log.info(check_output(
+    check_output(['git', 'checkout', '-b', 'relativesubmodule', 'master'], env=env)
+    check_output(
         ['git', 'submodule', 'add', '-b', 'master', './', 'relativesubmodule'],
         env=env
-    ))
-    log.info(check_output(['git', 'add', '.'], env=env))
-    log.info(check_output(['git', 'commit', '-m"Add relative submodule"'], env=env))
+    )
+    check_output(['git', 'add', '.'], env=env)
+    check_output(['git', 'commit', '-m"Add relative submodule"'], env=env)
     # Add an invalid submodule URL in the invalidsubmodule branch
-    log.info(check_output(['git', 'checkout', '-b', 'invalidsubmodule', 'master'], env=env))
-    log.info(check_output(
+    check_output(['git', 'checkout', '-b', 'invalidsubmodule', 'master'], env=env)
+    check_output(
         ['git', 'submodule', 'add', '-b', 'master', './', 'invalidsubmodule'],
         env=env,
-    ))
-    log.info(check_output(['git', 'add', '.'], env=env))
-    log.info(check_output(['git', 'commit', '-m"Add invalid submodule"'], env=env))
+    )
+    check_output(['git', 'add', '.'], env=env)
+    check_output(['git', 'commit', '-m"Add invalid submodule"'], env=env)
 
     # Checkout to master branch again
-    log.info(check_output(['git', 'checkout', 'master'], env=env))
+    check_output(['git', 'checkout', 'master'], env=env)
+
+    # Create some tags
     chdir(path)
     return directory
 

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -89,10 +89,22 @@ def make_test_git():
 
     # Checkout to master branch again
     check_output(['git', 'checkout', 'master'], env=env)
-
-    # Create some tags
     chdir(path)
     return directory
+
+
+def create_tag(directory, tag, annotated=False):
+    env = environ.copy()
+    env['GIT_DIR'] = pjoin(directory, '.git')
+    path = getcwd()
+    chdir(directory)
+
+    command = ['git', 'tag']
+    if annotated:
+        command.extend(['-a', '-m', 'Some tag'])
+    command.append(tag)
+    check_output(command, env=env)
+    chdir(path)
 
 
 def make_test_hg():

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -16,12 +16,10 @@ from django.contrib.auth.models import User
 log = logging.getLogger(__name__)
 
 
-def check_output(l, env=()):
-    if env == ():
-        output = subprocess.Popen(l, stdout=subprocess.PIPE).communicate()[0]
-    else:
-        output = subprocess.Popen(l, stdout=subprocess.PIPE,
-                                  env=env).communicate()[0]
+def check_output(l, env=None):
+    output = subprocess.Popen(
+        l, stdout=subprocess.PIPE, universal_newlines=True, env=env
+    ).communicate()[0]
     log.info(output)
     return output
 

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -16,10 +16,10 @@ from django.contrib.auth.models import User
 log = logging.getLogger(__name__)
 
 
-def check_output(l, env=None):
+def check_output(command, env=None):
     output = subprocess.Popen(
-        l, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        universal_newlines=True, env=env
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env
     ).communicate()[0]
     log.info(output)
     return output

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -93,7 +93,7 @@ def make_test_git():
     return directory
 
 
-def create_tag(directory, tag, annotated=False):
+def create_git_tag(directory, tag, annotated=False):
     env = environ.copy()
     env['GIT_DIR'] = pjoin(directory, '.git')
     path = getcwd()

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -17,6 +17,7 @@ from six import PY2, StringIO
 from readthedocs.core.validators import validate_submodule_url
 from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
+from builtins import str
 
 log = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ setenv =
     PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
     DJANGO_SETTINGS_MODULE=readthedocs.settings.test
     LANG=C
+    LC_CTYPE=C.UTF-8
     DJANGO_SETTINGS_SKIP_LOCAL=True
 deps = -r{toxinidir}/requirements/testing.txt
 changedir = {toxinidir}/readthedocs


### PR DESCRIPTION
Fix #1820

It has been previous attempts to fix the issue with annotated tags (#3302).

I'm using git python to get the tags, I tested this with a local repo with annotated and lightweight tags and it works as expected :).

I'm little worried about pyhon2 here since we need to use `str` to get the info. I did two builds using py2 (one with tags and other with no tags) and works as expected.

Refs #3839