### PR TITLE
Put the rtd extension to the beginning of the list

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -134,6 +134,9 @@ else:
 
 # Add custom RTD extension
 if 'extensions' in globals():
+    # Insert at the beginning because it can interfere
+    # with other extensions.
+    # See https://github.com/rtfd/readthedocs.org/pull/4054
     extensions.insert(0, "readthedocs_ext.readthedocs")
 else:
     extensions = ["readthedocs_ext.readthedocs"]

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -134,6 +134,6 @@ else:
 
 # Add custom RTD extension
 if 'extensions' in globals():
-    extensions.append("readthedocs_ext.readthedocs")
+    extensions.insert(0, "readthedocs_ext.readthedocs")
 else:
     extensions = ["readthedocs_ext.readthedocs"]


### PR DESCRIPTION
This fix #3715

The problem is because of the `sphinx_tabs.tabs` extension, which somehow collides with the rtd extension. If the rtd extension is put before the tabs extension on the list of extensions the problem is solved.

I'm not sure if there are other implications with this change, or isn't really relevant for others users that don't use the tabs extension to have the rtd extension to the end or beginning.