### PR TITLE
Update Gold Member marketing

### DIFF
--- a/docs/ethical-advertising.rst
+++ b/docs/ethical-advertising.rst
@@ -135,6 +135,9 @@ Opting Out
 
 We have added multiple ways to opt out of the advertising on Read the Docs.
 
+Users can go ad-free for as long as they are logged-in
+by becoming a `Gold Member to Read the Docs <https://readthedocs.org/accounts/gold/>`_.
+
 Users can opt out of seeing paid advertisements on documentation pages:
 
 * Go to the drop down user menu in the top right of the Read the Docs dashboard and clicking **Settings** (https://readthedocs.org/accounts/edit/).

--- a/docs/ethical-advertising.rst
+++ b/docs/ethical-advertising.rst
@@ -136,7 +136,7 @@ Opting Out
 We have added multiple ways to opt out of the advertising on Read the Docs.
 
 Users can go ad-free for as long as they are logged-in
-by becoming a `Gold Member to Read the Docs <https://readthedocs.org/accounts/gold/>`_.
+by becoming a `Gold Member of Read the Docs <https://readthedocs.org/accounts/gold/>`_.
 
 Users can opt out of seeing paid advertisements on documentation pages:
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -17,10 +17,9 @@ Good questions for Stack Overflow would be:
 Community Support
 -----------------
 
-Read the Docs is a community supported site,
-nobody is paid to handle readthedocs.org support.
-We are hoping to bring in enough money with our `Gold`_ program to change that,
-so please sign up if you are able.
+Read the Docs is a community- and ad-supported site.
+We hope to bring in enough money
+with our `Gold`_ and `Ethical Ads`_ programs to keep Read the Docs sustainable.
 
 **All people answering your questions are doing it with their own time,
 so please be kind and provide as much information as possible.**
@@ -58,5 +57,5 @@ or read more at https://readthedocs.com/services/#open-source-support.
 
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/read-the-docs
 .. _Github Issue Tracker: https://github.com/rtfd/readthedocs.org/issues
-.. _sign up: https://readthedocs.org/accounts/gold/
 .. _Gold: https://readthedocs.org/accounts/gold/
+.. _Ethical Ads: https://docs.readthedocs.io/en/latest/ethical-advertising.html

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -17,7 +17,7 @@ Good questions for Stack Overflow would be:
 Community Support
 -----------------
 
-Read the Docs is a community- and ad-supported site.
+Read the Docs is supported by community contributions and advertising.
 We hope to bring in enough money
 with our `Gold`_ and `Ethical Ads`_ programs to keep Read the Docs sustainable.
 

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -14,5 +14,6 @@ def readthedocs_processor(request):
         'DASHBOARD_ANALYTICS_CODE': getattr(settings, 'DASHBOARD_ANALYTICS_CODE'),
         'SITE_ROOT': getattr(settings, 'SITE_ROOT', '') + '/',
         'TEMPLATE_ROOT': getattr(settings, 'TEMPLATE_ROOT', '') + '/',
+        'USE_PROMOS': getattr(settings, 'USE_PROMOS', False),
     }
     return exports

--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -8,7 +8,6 @@ import logging
 from builtins import object
 
 from django import forms
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.forms.fields import CharField
 from django.utils.translation import ugettext_lazy as _
@@ -26,8 +25,6 @@ class UserProfileForm(forms.ModelForm):
         model = UserProfile
         # Don't allow users edit someone else's user page
         fields = ['first_name', 'last_name', 'homepage']
-        if settings.USE_PROMOS:
-            fields.append('allow_ads')
 
     def __init__(self, *args, **kwargs):
         super(UserProfileForm, self).__init__(*args, **kwargs)
@@ -66,6 +63,12 @@ class UserDeleteForm(forms.ModelForm):
             raise forms.ValidationError(_('Username does not match!'))
 
         return data
+
+
+class UserAdvertisingForm(forms.ModelForm):
+    class Meta(object):
+        model = UserProfile
+        fields = ['allow_ads']
 
 
 class FacetField(forms.MultipleChoiceField):

--- a/readthedocs/gold/templates/gold/subscription_form.html
+++ b/readthedocs/gold/templates/gold/subscription_form.html
@@ -59,6 +59,9 @@ $(document).ready(function () {
       we suggest giving at least $20/month to help cover our support and operations costs.
     {% endblocktrans %}
     </p>
+
+  <p>{% trans 'Becoming a Gold Member also makes Read the Docs ad-free for as long as you are logged-in.' %}</p>
+
   <p>
     {% blocktrans %}
       You can also make one-time donations on our <a href="https://readthedocs.org/sustainability/">sustainability</a> page.

--- a/readthedocs/profiles/urls/private.py
+++ b/readthedocs/profiles/urls/private.py
@@ -18,5 +18,6 @@ urlpatterns = [
             'template_name': 'profiles/private/edit_profile.html',
         },
         name='profiles_profile_edit'),
-    url(r'^delete/', views.delete_account, name='delete_account')
+    url(r'^delete/', views.delete_account, name='delete_account'),
+    url(r'^advertising/$', views.account_advertising, name='account_advertising'),
 ]

--- a/readthedocs/profiles/views.py
+++ b/readthedocs/profiles/views.py
@@ -282,6 +282,7 @@ def profile_detail(
     return render(request, template_name, context=context)
 
 
+@login_required
 def account_advertising(request):
     success_url = reverse(account_advertising)
 

--- a/readthedocs/profiles/views.py
+++ b/readthedocs/profiles/views.py
@@ -13,8 +13,9 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.context import RequestContext
+from django.utils.translation import ugettext_lazy as _
 
-from readthedocs.core.forms import UserDeleteForm
+from readthedocs.core.forms import UserDeleteForm, UserAdvertisingForm
 
 
 def create_profile(
@@ -279,3 +280,34 @@ def profile_detail(
 
     context.update({'profile': profile_obj})
     return render(request, template_name, context=context)
+
+
+def account_advertising(request):
+    success_url = reverse(account_advertising)
+
+    try:
+        profile_obj = request.user.profile
+    except ObjectDoesNotExist:
+        return HttpResponseRedirect(reverse('profiles_profile_create'))
+
+    if request.method == 'POST':
+        form = UserAdvertisingForm(
+            data=request.POST,
+            instance=profile_obj,
+        )
+        if form.is_valid():
+            form.save()
+            messages.info(request, _('Updated your advertising preferences'))
+            return HttpResponseRedirect(success_url)
+    else:
+        form = UserAdvertisingForm(instance=profile_obj)
+
+    return render(
+        request,
+        'profiles/private/advertising_profile.html',
+        context={
+            'form': form,
+            'profile': profile_obj,
+            'user': profile_obj.user,
+        },
+    )

--- a/readthedocs/templates/profiles/base_profile_edit.html
+++ b/readthedocs/templates/profiles/base_profile_edit.html
@@ -51,6 +51,9 @@
           <li class="{% block profile-admin-change-email %}{% endblock %}"><a href="{% url 'account_email' %}">{% trans "Change Email" %}</a></li>
           <li class="{% block profile-admin-delete-account %}{% endblock %}"><a href="{% url 'delete_account' %}">{% trans "Delete Account" %}</a></li>
           <li class="{% block profile-admin-gold-edit %}{% endblock %}"><a href="{% url 'gold_detail' %}">{% trans "Gold" %}</a></li>
+          {% if USE_PROMOS %}
+            <li class="{% block profile-admin-advertising %}{% endblock %}"><a href="{% url 'account_advertising' %}">{% trans "Advertising" %}</a></li>
+          {% endif %}
         {% endblock %}
       </ul>
       <div>

--- a/readthedocs/templates/profiles/private/advertising_profile.html
+++ b/readthedocs/templates/profiles/private/advertising_profile.html
@@ -1,0 +1,51 @@
+{% extends "profiles/base_profile_edit.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Set advertising preferences" %}{% endblock %}
+
+{% block profile-admin-advertising %}active{% endblock %}
+
+{% block edit_content_header %} {% trans "Set advertising preferences" %} {% endblock %}
+
+{% block edit_content %}
+  <p>
+    {% blocktrans %}
+      Read the Docs is an open source project.
+      In order to maintain service, we rely on both the
+      support of our users, and from sponsor support.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans %}
+      For more details on advertising on Read the Docs
+      including the privacy protections we have in place for users
+      and community advertising we run on behalf of the open source community,
+      see <a href="https://docs.readthedocs.io/en/latest/ethical-advertising.html">our documentation</a>.
+    {% endblocktrans %}
+  </p>
+
+  {% if request.user.gold.count or request.user.goldonce.count %}
+    <p>
+      {% blocktrans %}
+        <strong>Note:</strong>
+        Since you are a Gold Member or donor, you <strong>will not</strong> see advertising as long as you are logged-in.
+        Thank you for supporting Read the Docs.
+      {% endblocktrans%}
+    </p>
+  {% else %}
+    <p>
+      {% url "gold_detail" as gold_detail %}
+      {% blocktrans %}
+        You may remove ads completely by becoming a <a href="{{ gold_detail }}">Gold member to Read the Docs</a>.
+      {% endblocktrans %}
+    </p>
+  {% endif %}
+
+  <form method="POST" action=".">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" name="submit" value="{% trans "Update advertisement preference" %}" id="submit"/>
+  </form>
+{% endblock %}

--- a/readthedocs/templates/profiles/private/advertising_profile.html
+++ b/readthedocs/templates/profiles/private/advertising_profile.html
@@ -26,7 +26,7 @@
     {% endblocktrans %}
   </p>
 
-  {% if request.user.gold.count or request.user.goldonce.count %}
+  {% if request.user.gold.exists or request.user.goldonce.exists %}
     <p>
       {% blocktrans %}
         <strong>Note:</strong>

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -14,8 +14,8 @@
 {% block project_edit_content %}
   <p>
     {% blocktrans %}
-      Read the Docs is an open source project, maintained and operated by
-      full-time volunteers. In order to maintain service, we rely on both the
+      Read the Docs is an open source project.
+      In order to maintain service, we rely on both the
       support of our users, and from sponsor support.
     {% endblocktrans %}
   </p>
@@ -48,9 +48,10 @@
 
   <p>
     {% blocktrans %}
-      For more information on our stance on sponsor advertisements, we wrote
-      more about our stance
-      <a href="https://blog.readthedocs.com/ads-on-read-the-docs/">on our blog</a>.
+      For more details on advertising on Read the Docs
+      including the privacy protections we have in place for users
+      and community advertising we run on behalf of the open source community,
+      see <a href="https://docs.readthedocs.io/en/latest/ethical-advertising.html">our documentation</a>.
     {% endblocktrans %}
   </p>
 

--- a/readthedocs/templates/projects/project_edit_base.html
+++ b/readthedocs/templates/projects/project_edit_base.html
@@ -24,7 +24,9 @@
         <li class="{% block project-subprojects-active %}{% endblock %}"><a href="{% url "projects_subprojects" project.slug %}">{% trans "Subprojects" %}</a></li>
         <li class="{% block project-integrations-active %}{% endblock %}"><a href="{% url "projects_integrations" project.slug %}">{% trans "Integrations" %}</a></li>
         <li class="{% block project-notifications-active %}{% endblock %}"><a href="{% url "projects_notifications" project.slug %}">{% trans "Notifications" %}</a></li>
-        <li class="{% block project-ads-active %}{% endblock %}"><a href="{% url "projects_advertising" project.slug %}">{% trans "Advertising" %} </a></li>
+        {% if USE_PROMOS %}
+          <li class="{% block project-ads-active %}{% endblock %}"><a href="{% url "projects_advertising" project.slug %}">{% trans "Advertising" %} </a></li>
+        {% endif %}
       </ul>
       <div>
         <h2>{% block project_edit_content_header %}{% endblock %}</h2>

--- a/readthedocs/templates/support.html
+++ b/readthedocs/templates/support.html
@@ -26,7 +26,7 @@ Good questions for Stack Overflow would be:
 Community Support
 -----------------
 
-Read the Docs is a community- and ad-supported site.
+Read the Docs is supported by community contributions and advertising.
 We hope to bring in enough money
 with our `Gold`_ and `Ethical Ads`_ programs to keep Read the Docs sustainable.
 

--- a/readthedocs/templates/support.html
+++ b/readthedocs/templates/support.html
@@ -26,10 +26,9 @@ Good questions for Stack Overflow would be:
 Community Support
 -----------------
 
-Read the Docs is a community supported site,
-nobody is paid to handle readthedocs.org support.
-We are hoping to bring in enough money with our `Gold`_ program to change that,
-so please sign up if you are able.
+Read the Docs is a community- and ad-supported site.
+We hope to bring in enough money
+with our `Gold`_ and `Ethical Ads`_ programs to keep Read the Docs sustainable.
 
 **All people answering your questions are doing it with their own time,
 so please be kind and provide as much information as possible.**
@@ -67,8 +66,8 @@ or read more at https://readthedocs.com/services/#open-source-support.
 
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/read-the-docs
 .. _Github Issue Tracker: https://github.com/rtfd/readthedocs.org/issues
-.. _sign up: https://readthedocs.org/accounts/gold/
 .. _Gold: https://readthedocs.org/accounts/gold/
+.. _Ethical Ads: https://docs.readthedocs.io/en/latest/ethical-advertising.html
 
 {% endfilter %}
 </div>


### PR DESCRIPTION
## Changes

In general, the goal of this PR is to update some of our marketing and documentation to better reflect the reality at Read the Docs.

Here's an overview of the changes:

- Make it more obvious that becoming a Gold Member removes advertising
- Try to standardize on the terminology "Gold Member" rather than "buying gold" or anything else.
- Explain about RTD advertising in the user profile where users can go community-only, donate, or otherwise opt-out/-in
- When `settings.USE_PROMOS = False`, remove the links to manage advertising.

One change I did not do but am considering is to allow staying logged-in longer than 2 weeks. This becomes somewhat important when users are becoming a Gold Member to skip ads. Having people log in every two weeks seems suboptimal.
