### PR TITLE
Handle raising exceptions from PublicTask

### DIFF
--- a/readthedocs/restapi/views/task_views.py
+++ b/readthedocs/restapi/views/task_views.py
@@ -29,10 +29,12 @@ def get_status_data(task_name, state, data, error=None):
         'data': data,
         'started': state in STARTED_STATES,
         'finished': state in FINISHED_STATES,
-        'success': state in SUCCESS_STATES,
+        # When an exception is raised inside the task, we keep this as SUCCESS
+        # and add the exception messsage into the 'error' key
+        'success': state in SUCCESS_STATES and error is None,
     }
-    if error is not None and isinstance(error, Exception):
-        data['error'] = error.message
+    if error is not None:
+        data['error'] = error
     return data
 
 

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -21,6 +21,7 @@ from readthedocs.builds.models import Build, Version
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 from readthedocs.projects.models import Feature, Project
+from readthedocs.restapi.views.task_views import get_status_data
 
 super_auth = base64.b64encode(b'super:test').decode('utf-8')
 eric_auth = base64.b64encode(b'eric:test').decode('utf-8')
@@ -759,3 +760,22 @@ class APIVersionTests(TestCase):
             resp.data,
             version_data,
         )
+
+
+class TaskViewsTests(TestCase):
+
+    def test_get_status_data(self):
+        data = get_status_data(
+            'public_task_exception',
+            'SUCCESS',
+            {'data': 'public'},
+            'Something bad happened',
+        )
+        self.assertEqual(data, {
+            'name': 'public_task_exception',
+            'data': {'data': 'public'},
+            'started': True,
+            'finished': True,
+            'success': False,
+            'error': 'Something bad happened',
+        })

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -123,3 +123,33 @@ class TestCeleryBuilding(RTDTestCase):
                 args=(version.pk,),
             )
         self.assertTrue(result.successful())
+
+    def test_public_task_exception(self):
+        """
+        Test when a PublicTask rises an Exception.
+
+        The exception should be catched and added to the ``info`` attribute of
+        the result. Besides, the task should be SUCCESS.
+        """
+        from readthedocs.core.utils.tasks import PublicTask
+        from readthedocs.worker import app
+
+        class PublicTaskException(PublicTask):
+            name = 'public_task_exception'
+
+            def run_public(self):
+                raise Exception('Something bad happened')
+
+        app.tasks.register(PublicTaskException)
+        exception_task = PublicTaskException()
+        result = exception_task.delay()
+
+        # although the task risen an exception, it's success since we add the
+        # exception into the ``info`` attributes
+        self.assertEqual(result.status, 'SUCCESS')
+        self.assertEqual(result.info, {
+            'task_name': 'public_task_exception',
+            'context': {},
+            'public_data': {},
+            'error': 'Something bad happened',
+        })


### PR DESCRIPTION
When the task raises an exception there is no way to have a custom result under ``AsyncResult.info``, it will be always the Exception that was risen from inside the task.

Because of that, when the task raises an Exception we are handling it inside the ``run`` method and we add the exception's message into our custom result *without marking* the task as FAILURE.

Celery docs: http://docs.celeryproject.org/en/latest/reference/celery.result.html#celery.result.AsyncResult.info

Workaround to #4077

> Now, if you revoke the RTD app in your Github service, you will see a nice error message

![captura de pantalla_2018-05-09_17-19-16](https://user-images.githubusercontent.com/244656/39842706-1fad08fe-53ad-11e8-8002-552ca6c7e31f.png)
