### PR TITLE
Update the `documentation_type` when it's set to 'auto'

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -548,6 +548,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         project_data['documentation_type'] = ret
         api_v2.project(self.project.pk).put(project_data)
         self.project.documentation_type = ret
+        self.version.project.documentation_type = ret
 
     def update_app_instances(self, html=False, localmedia=False, search=False,
                              pdf=False, epub=False):


### PR DESCRIPTION
When the `project.documentation_type` is set to `auto` we are protecting ourselves by updating it at build time to `sphinx`. At this point we also update our project memory instance, but we were missing to update the project memory instance that lives inside the version memory instance.

Closes #3980