### PR TITLE
Use next field to redirect user when login is done by social

### DIFF
--- a/readthedocs/templates/account/login.html
+++ b/readthedocs/templates/account/login.html
@@ -32,7 +32,7 @@
 
 <div class="clearfix">
   <ul class="socialaccount_providers">
-    {% include "socialaccount/snippets/provider_list.html" with process="login" next="" verbiage="Sign in with" %}
+    {% include "socialaccount/snippets/provider_list.html" with process="login" next=request.GET.next verbiage="Sign in with" %}
   </ul>
 </div>
 


### PR DESCRIPTION
When a private page is accessed by a non logged in user, the user is redirected to the login view. If the user uses the traditional login, after this the user will be redirected to the page that was trying to access.

If the user uses the social login, it was redirected to /. This PR fixes that to behaves in the same way than regular login.