### PR TITLE
Make tests extensible from corporate site

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,7 +30,12 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     if not config.option.searchtests:
         # Include ``not search``` to parameters so search tests do not perform
-        setattr(config.option, 'markexpr', 'not search')
+        markexpr = getattr(config.option, 'markexpr')
+        if markexpr:
+            markexpr += ' and not search'
+        else:
+            markexpr = 'not search'
+        setattr(config.option, 'markexpr', markexpr.strip())
 
     for option, value in PYTEST_OPTIONS:
         setattr(config.option, option, value)

--- a/conftest.py
+++ b/conftest.py
@@ -1,17 +1,32 @@
-import logging
-
+# -*- coding: utf-8 -*-
 import pytest
+
+PYTEST_OPTIONS = (
+    # Options to set test environment
+    ('community', True),
+    ('corporate', False),
+    ('environment', 'readthedocs'),
+
+    ('url_scheme', 'http'),
+)
 
 
 def pytest_addoption(parser):
-    parser.addoption('--including-search', action='store_true', dest="searchtests",
-                     default=False, help="enable search tests")
+    parser.addoption(
+        '--including-search',
+        action='store_true',
+        dest='searchtests',
+        default=False, help='enable search tests',
+    )
 
 
 def pytest_configure(config):
     if not config.option.searchtests:
-        # Include `not search` to parameters so that search test do not perform
+        # Include ``not search``` to parameters so search tests do not perform
         setattr(config.option, 'markexpr', 'not search')
+
+    for option, value in PYTEST_OPTIONS:
+        setattr(config.option, option, value)
 
 
 @pytest.fixture(autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,21 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-PYTEST_OPTIONS = (
-    # Options to set test environment
-    ('community', True),
-    ('corporate', False),
-    ('environment', 'readthedocs'),
+try:
+    # TODO: this file is read/executed even when called from ``readthedocsinc``,
+    # so it's overriding the options that we are defining in the ``conftest.py``
+    # from the corporate site. We need to find a better way to avoid this.
+    import readthedocsinc
+    PYTEST_OPTIONS = ()
+except ImportError:
+    PYTEST_OPTIONS = (
+        # Options to set test environment
+        ('community', True),
+        ('corporate', False),
+        ('environment', 'readthedocs'),
 
-    ('url_scheme', 'http'),
-)
+        ('url_scheme', 'http'),
+    )
 
 
 def pytest_addoption(parser):

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -1,28 +1,27 @@
+# -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
 
 import os
-import json
 import shutil
 from os.path import exists
+import pytest
 from tempfile import mkdtemp
 
 from django.contrib.auth.models import User
 from django_dynamic_fixture import get
 from mock import patch, MagicMock
 
-from readthedocs.builds.constants import BUILD_STATE_INSTALLING, BUILD_STATE_FINISHED, LATEST
+from readthedocs.builds.constants import LATEST
 from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.builds.models import Build
 from readthedocs.projects.models import Project
 from readthedocs.projects import tasks
 
 from readthedocs.rtd_tests.utils import (
-    create_git_branch, create_git_tag, delete_git_branch, delete_git_tag)
+    create_git_branch, create_git_tag, delete_git_branch)
 from readthedocs.rtd_tests.utils import make_test_git
 from readthedocs.rtd_tests.base import RTDTestCase
 from readthedocs.rtd_tests.mocks.mock_api import mock_api
-
-from readthedocs.doc_builder.environments import BuildEnvironment
 
 
 class TestCeleryBuilding(RTDTestCase):
@@ -131,6 +130,7 @@ class TestCeleryBuilding(RTDTestCase):
             )
         self.assertTrue(result.successful())
 
+    @pytest.mark.community
     @patch('readthedocs.projects.tasks.api_v2')
     def test_check_duplicate_reserved_version_latest(self, api_v2):
         create_git_branch(self.repo, 'latest')
@@ -151,6 +151,7 @@ class TestCeleryBuilding(RTDTestCase):
         sync_repository.sync_repo()
         api_v2.project().sync_versions.post.assert_called()
 
+    @pytest.mark.community
     @patch('readthedocs.projects.tasks.api_v2')
     def test_check_duplicate_reserved_version_stable(self, api_v2):
         create_git_branch(self.repo, 'stable')
@@ -170,6 +171,7 @@ class TestCeleryBuilding(RTDTestCase):
         # TODO: Check that we can build properly after
         # deleting the tag.
 
+    @pytest.mark.community
     @patch('readthedocs.projects.tasks.api_v2')
     def test_check_duplicate_no_reserved_version(self, api_v2):
         create_git_branch(self.repo, 'no-reserved')

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -4,7 +4,6 @@ from __future__ import division, print_function, unicode_literals
 import os
 import shutil
 from os.path import exists
-import pytest
 from tempfile import mkdtemp
 
 from django.contrib.auth.models import User
@@ -130,7 +129,6 @@ class TestCeleryBuilding(RTDTestCase):
             )
         self.assertTrue(result.successful())
 
-    @pytest.mark.community
     @patch('readthedocs.projects.tasks.api_v2')
     def test_check_duplicate_reserved_version_latest(self, api_v2):
         create_git_branch(self.repo, 'latest')
@@ -151,7 +149,6 @@ class TestCeleryBuilding(RTDTestCase):
         sync_repository.sync_repo()
         api_v2.project().sync_versions.post.assert_called()
 
-    @pytest.mark.community
     @patch('readthedocs.projects.tasks.api_v2')
     def test_check_duplicate_reserved_version_stable(self, api_v2):
         create_git_branch(self.repo, 'stable')
@@ -171,7 +168,6 @@ class TestCeleryBuilding(RTDTestCase):
         # TODO: Check that we can build properly after
         # deleting the tag.
 
-    @pytest.mark.community
     @patch('readthedocs.projects.tasks.api_v2')
     def test_check_duplicate_no_reserved_version(self, api_v2):
         create_git_branch(self.repo, 'no-reserved')

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -163,7 +163,7 @@ class LoadConfigTests(TestCase):
         self.assertEqual(config.extra_requirements, [])
 
     def test_conda(self, load_config):
-        to_find = 'urls.py'
+        to_find = '__init__.py'
         load_config.side_effect = create_load({
             'conda': {
                 'file': to_find
@@ -179,7 +179,7 @@ class LoadConfigTests(TestCase):
         self.assertEqual(config.conda_file, None)
 
     def test_requirements_file(self, load_config):
-        requirements_file = 'wsgi.py'
+        requirements_file = '__init__.py'
         load_config.side_effect = create_load({
             'requirements_file': requirements_file
         })

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import mock
 
+from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -9,9 +11,25 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.core.templatetags import core_tags
 
 
-@override_settings(USE_SUBDOMAIN=False, PUBLIC_DOMAIN='readthedocs.org')
+@override_settings(USE_SUBDOMAIN=False, PRODUCTION_DOMAIN='readthedocs.org')
 class CoreTagsTests(TestCase):
     fixtures = ["eric", "test_data"]
+
+    # Determine if we are under community (http) or corporate site (https)
+    scheme = 'https' if settings.CELERY_APP_NAME == 'readthedocsinc' else 'http'
+
+    pip_latest_url = '{scheme}://readthedocs.org/docs/pip/en/latest/'.format(scheme=scheme)
+    pip_latest_fr_url = '{scheme}://readthedocs.org/docs/pip/fr/latest/'.format(scheme=scheme)
+    pip_abc_url = '{scheme}://readthedocs.org/docs/pip/en/abc/'.format(scheme=scheme)
+    pip_abc_fr_url = '{scheme}://readthedocs.org/docs/pip/fr/abc/'.format(scheme=scheme)
+    pip_abc_xyz_page_url = '{scheme}://readthedocs.org/docs/pip/en/abc/xyz.html'.format(scheme=scheme)
+    pip_abc_xyz_fr_page_url = '{scheme}://readthedocs.org/docs/pip/fr/abc/xyz.html'.format(scheme=scheme)
+    pip_abc_xyz_dir_url = '{scheme}://readthedocs.org/docs/pip/en/abc/xyz/'.format(scheme=scheme)
+    pip_abc_xyz_fr_dir_url = '{scheme}://readthedocs.org/docs/pip/fr/abc/xyz/'.format(scheme=scheme)
+    pip_abc_xyz_document = '{scheme}://readthedocs.org/docs/pip/en/abc/index.html#document-xyz'.format(scheme=scheme)
+    pip_abc_xyz_fr_document = '{scheme}://readthedocs.org/docs/pip/fr/abc/index.html#document-xyz'.format(scheme=scheme)
+    pip_latest_document_url = '{scheme}://readthedocs.org/docs/pip/en/latest/document/'.format(scheme=scheme)
+    pip_latest_document_page_url = '{scheme}://readthedocs.org/docs/pip/en/latest/document.html'.format(scheme=scheme)
 
     def setUp(self):
         with mock.patch('readthedocs.projects.models.broadcast'):
@@ -22,164 +40,164 @@ class CoreTagsTests(TestCase):
     def test_project_only(self):
         proj = Project.objects.get(slug='pip')
         url = core_tags.make_document_url(proj)
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
         url = core_tags.make_document_url(proj, '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
 
     def test_project_only_htmldir(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'sphinx_htmldir'
         url = core_tags.make_document_url(proj)
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
         url = core_tags.make_document_url(proj, '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
 
     def test_project_only_singlehtml(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'sphinx_singlehtml'
         url = core_tags.make_document_url(proj)
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
         url = core_tags.make_document_url(proj, '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
 
     def test_translation_project_only(self):
         proj = Project.objects.get(slug='pip-fr')
         url = core_tags.make_document_url(proj)
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/latest/')
+        self.assertEqual(url, self.pip_latest_fr_url)
         url = core_tags.make_document_url(proj, '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/latest/')
+        self.assertEqual(url, self.pip_latest_fr_url)
 
     def test_translation_project_only_htmldir(self):
         proj = Project.objects.get(slug='pip-fr')
         proj.documentation_type = 'sphinx_htmldir'
         url = core_tags.make_document_url(proj)
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/latest/')
+        self.assertEqual(url, self.pip_latest_fr_url)
         url = core_tags.make_document_url(proj, '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/latest/')
+        self.assertEqual(url, self.pip_latest_fr_url)
 
     def test_translation_project_only_singlehtml(self):
         proj = Project.objects.get(slug='pip-fr')
         proj.documentation_type = 'sphinx_singlehtml'
         url = core_tags.make_document_url(proj)
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/latest/')
+        self.assertEqual(url, self.pip_latest_fr_url)
         url = core_tags.make_document_url(proj, '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/latest/')
+        self.assertEqual(url, self.pip_latest_fr_url)
 
     def test_project_and_version(self):
         proj = Project.objects.get(slug='pip')
         url = core_tags.make_document_url(proj, 'abc')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
         url = core_tags.make_document_url(proj, 'abc', '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
 
     def test_project_and_version_htmldir(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'sphinx_htmldir'
         url = core_tags.make_document_url(proj, 'abc')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
         url = core_tags.make_document_url(proj, 'abc', '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
 
     def test_project_and_version_singlehtml(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'sphinx_singlehtml'
         url = core_tags.make_document_url(proj, 'abc')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
         url = core_tags.make_document_url(proj, 'abc', '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
 
     def test_translation_project_and_version(self):
         proj = Project.objects.get(slug='pip-fr')
         url = core_tags.make_document_url(proj, 'abc')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
         url = core_tags.make_document_url(proj, 'abc', '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
 
     def test_translation_project_and_version_htmldir(self):
         proj = Project.objects.get(slug='pip-fr')
         proj.documentation_type = 'sphinx_htmldir'
         url = core_tags.make_document_url(proj, 'abc')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
         url = core_tags.make_document_url(proj, 'abc', '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
 
     def test_translation_project_and_version_singlehtml(self):
         proj = Project.objects.get(slug='pip-fr')
         proj.documentation_type = 'sphinx_singlehtml'
         url = core_tags.make_document_url(proj, 'abc')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
         url = core_tags.make_document_url(proj, 'abc', '')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
 
     def test_project_and_version_and_page(self):
         proj = Project.objects.get(slug='pip')
         url = core_tags.make_document_url(proj, 'abc', 'xyz')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/xyz.html')
+        self.assertEqual(url, self.pip_abc_xyz_page_url)
         url = core_tags.make_document_url(proj, 'abc', 'index')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
 
     def test_project_and_version_and_page_htmldir(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'sphinx_htmldir'
         url = core_tags.make_document_url(proj, 'abc', 'xyz')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/xyz/')
+        self.assertEqual(url, self.pip_abc_xyz_dir_url)
         url = core_tags.make_document_url(proj, 'abc', 'index')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
 
     def test_project_and_version_and_page_signlehtml(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'sphinx_singlehtml'
         url = core_tags.make_document_url(proj, 'abc', 'xyz')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/index.html#document-xyz')
+        self.assertEqual(url, self.pip_abc_xyz_document)
         url = core_tags.make_document_url(proj, 'abc', 'index')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/abc/')
+        self.assertEqual(url, self.pip_abc_url)
 
     def test_translation_project_and_version_and_page(self):
         proj = Project.objects.get(slug='pip-fr')
         url = core_tags.make_document_url(proj, 'abc', 'xyz')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/xyz.html')
+        self.assertEqual(url, self.pip_abc_xyz_fr_page_url)
         url = core_tags.make_document_url(proj, 'abc', 'index')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
 
     def test_translation_project_and_version_and_page_htmldir(self):
         proj = Project.objects.get(slug='pip-fr')
         proj.documentation_type = 'sphinx_htmldir'
         url = core_tags.make_document_url(proj, 'abc', 'xyz')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/xyz/')
+        self.assertEqual(url, self.pip_abc_xyz_fr_dir_url)
         url = core_tags.make_document_url(proj, 'abc', 'index')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
 
     def test_translation_project_and_version_and_page_singlehtml(self):
         proj = Project.objects.get(slug='pip-fr')
         proj.documentation_type = 'sphinx_singlehtml'
         url = core_tags.make_document_url(proj, 'abc', 'xyz')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/index.html#document-xyz')
+        self.assertEqual(url, self.pip_abc_xyz_fr_document)
         url = core_tags.make_document_url(proj, 'abc', 'index')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/fr/abc/')
+        self.assertEqual(url, self.pip_abc_fr_url)
 
     def test_mkdocs(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
         url = core_tags.make_document_url(proj, LATEST, 'document')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/document/')
+        self.assertEqual(url, self.pip_latest_document_url)
 
     def test_mkdocs_no_directory_urls(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
         url = core_tags.make_document_url(proj, LATEST, 'document.html')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/document.html')
+        self.assertEqual(url, self.pip_latest_document_page_url)
 
     def test_mkdocs_index(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
         url = core_tags.make_document_url(proj, LATEST, 'index')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
 
     def test_mkdocs_index_no_directory_urls(self):
         proj = Project.objects.get(slug='pip')
         proj.documentation_type = 'mkdocs'
         url = core_tags.make_document_url(proj, LATEST, 'index.html')
-        self.assertEqual(url, 'http://readthedocs.org/docs/pip/en/latest/')
+        self.assertEqual(url, self.pip_latest_url)
 
     def test_restructured_text(self):
         value = '*test*'

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -17,7 +17,7 @@ class CoreTagsTests(TestCase):
     fixtures = ["eric", "test_data"]
 
     def setUp(self):
-        url_base = '{scheme}://{domain}/docs/pip{{ version }}'.format(
+        url_base = '{scheme}://{domain}/docs/pip{{version}}'.format(
             scheme=pytest.config.option.url_scheme,
             domain=settings.PRODUCTION_DOMAIN,
         )

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import mock
+import pytest
 
 from django.conf import settings
 from django.test import TestCase
@@ -15,23 +16,25 @@ from readthedocs.core.templatetags import core_tags
 class CoreTagsTests(TestCase):
     fixtures = ["eric", "test_data"]
 
-    # Determine if we are under community (http) or corporate site (https)
-    scheme = 'https' if settings.CELERY_APP_NAME == 'readthedocsinc' else 'http'
-
-    pip_latest_url = '{scheme}://readthedocs.org/docs/pip/en/latest/'.format(scheme=scheme)
-    pip_latest_fr_url = '{scheme}://readthedocs.org/docs/pip/fr/latest/'.format(scheme=scheme)
-    pip_abc_url = '{scheme}://readthedocs.org/docs/pip/en/abc/'.format(scheme=scheme)
-    pip_abc_fr_url = '{scheme}://readthedocs.org/docs/pip/fr/abc/'.format(scheme=scheme)
-    pip_abc_xyz_page_url = '{scheme}://readthedocs.org/docs/pip/en/abc/xyz.html'.format(scheme=scheme)
-    pip_abc_xyz_fr_page_url = '{scheme}://readthedocs.org/docs/pip/fr/abc/xyz.html'.format(scheme=scheme)
-    pip_abc_xyz_dir_url = '{scheme}://readthedocs.org/docs/pip/en/abc/xyz/'.format(scheme=scheme)
-    pip_abc_xyz_fr_dir_url = '{scheme}://readthedocs.org/docs/pip/fr/abc/xyz/'.format(scheme=scheme)
-    pip_abc_xyz_document = '{scheme}://readthedocs.org/docs/pip/en/abc/index.html#document-xyz'.format(scheme=scheme)
-    pip_abc_xyz_fr_document = '{scheme}://readthedocs.org/docs/pip/fr/abc/index.html#document-xyz'.format(scheme=scheme)
-    pip_latest_document_url = '{scheme}://readthedocs.org/docs/pip/en/latest/document/'.format(scheme=scheme)
-    pip_latest_document_page_url = '{scheme}://readthedocs.org/docs/pip/en/latest/document.html'.format(scheme=scheme)
-
     def setUp(self):
+        url_base = '{scheme}://{domain}/docs/pip{{ version }}'.format(
+            scheme=pytest.config.option.url_scheme,
+            domain=settings.PRODUCTION_DOMAIN,
+        )
+
+        self.pip_latest_url = url_base.format(version='/en/latest/')
+        self.pip_latest_fr_url = url_base.format(version='/fr/latest/')
+        self.pip_abc_url = url_base.format(version='/en/abc/')
+        self.pip_abc_fr_url = url_base.format(version='/fr/abc/')
+        self.pip_abc_xyz_page_url = url_base.format(version='/en/abc/xyz.html')
+        self.pip_abc_xyz_fr_page_url = url_base.format(version='/fr/abc/xyz.html')
+        self.pip_abc_xyz_dir_url = url_base.format(version='/en/abc/xyz/')
+        self.pip_abc_xyz_fr_dir_url = url_base.format(version='/fr/abc/xyz/')
+        self.pip_abc_xyz_document = url_base.format(version='/en/abc/index.html#document-xyz')
+        self.pip_abc_xyz_fr_document = url_base.format(version='/fr/abc/index.html#document-xyz')
+        self.pip_latest_document_url = url_base.format(version='/en/latest/document/')
+        self.pip_latest_document_page_url = url_base.format(version='/en/latest/document.html')
+
         with mock.patch('readthedocs.projects.models.broadcast'):
             self.client.login(username='eric', password='test')
             self.pip = Project.objects.get(slug='pip')

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 import mock
 from django.test import TestCase
+from django.test.utils import override_settings
 from django_dynamic_fixture import get
 from mock import patch
 
@@ -115,6 +116,7 @@ class SphinxSearchBuilderTest(TestCase):
         self.assertTrue(os.path.exists(dest_other))
 
 
+@override_settings(PRODUCTION_DOMAIN='readthedocs.org')
 class MkdocsBuilderTest(TestCase):
 
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 import json
 
@@ -7,6 +9,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from django_dynamic_fixture import get
+import pytest
 
 from readthedocs.core.middleware import SubdomainMiddleware
 from readthedocs.projects.models import Project, Domain
@@ -102,6 +105,7 @@ class FormTests(TestCase):
         self.assertEqual(domain.domain, 'example2.com')
 
 
+@pytest.mark.only_community
 class TestAPI(TestCase):
 
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -105,7 +105,7 @@ class FormTests(TestCase):
         self.assertEqual(domain.domain, 'example2.com')
 
 
-@pytest.mark.only_community
+@pytest.mark.community
 class TestAPI(TestCase):
 
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -9,7 +9,6 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from django_dynamic_fixture import get
-import pytest
 
 from readthedocs.core.middleware import SubdomainMiddleware
 from readthedocs.projects.models import Project, Domain
@@ -105,7 +104,6 @@ class FormTests(TestCase):
         self.assertEqual(domain.domain, 'example2.com')
 
 
-@pytest.mark.community
 class TestAPI(TestCase):
 
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 
 from django.http import Http404
+from django.conf import settings
 from django.core.cache import cache
 from django.core.urlresolvers import get_urlconf, set_urlconf
 from django.test import TestCase
@@ -21,7 +24,7 @@ from readthedocs.rtd_tests.utils import create_user
 @override_settings(USE_SUBDOMAIN=True)
 class MiddlewareTests(TestCase):
 
-    urlconf_subdomain = 'readthedocs.core.urls.subdomain'
+    urlconf_subdomain = settings.SUBDOMAIN_URLCONF
 
     def setUp(self):
         self.factory = RequestFactory()

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -21,6 +21,8 @@ from readthedocs.rtd_tests.utils import create_user
 @override_settings(USE_SUBDOMAIN=True)
 class MiddlewareTests(TestCase):
 
+    urlconf_subdomain = 'readthedocs.core.urls.subdomain'
+
     def setUp(self):
         self.factory = RequestFactory()
         self.middleware = SubdomainMiddleware()
@@ -38,8 +40,8 @@ class MiddlewareTests(TestCase):
     def test_proper_subdomain(self):
         request = self.factory.get(self.url, HTTP_HOST='pip.readthedocs.org')
         self.middleware.process_request(request)
-        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
         self.assertEqual(request.subdomain, True)
+        self.assertEqual(request.urlconf, self.urlconf_subdomain)
         self.assertEqual(request.slug, 'pip')
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
@@ -69,7 +71,7 @@ class MiddlewareTests(TestCase):
     def test_subdomain_different_length(self):
         request = self.factory.get(self.url, HTTP_HOST='pip.prod.readthedocs.org')
         self.middleware.process_request(request)
-        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
+        self.assertEqual(request.urlconf, self.urlconf_subdomain)
         self.assertEqual(request.subdomain, True)
         self.assertEqual(request.slug, 'pip')
 
@@ -78,7 +80,7 @@ class MiddlewareTests(TestCase):
 
         request = self.factory.get(self.url, HTTP_HOST='docs.foobar.com')
         self.middleware.process_request(request)
-        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
+        self.assertEqual(request.urlconf, self.urlconf_subdomain)
         self.assertEqual(request.domain_object, True)
         self.assertEqual(request.slug, 'pip')
 
@@ -92,14 +94,14 @@ class MiddlewareTests(TestCase):
         cache.get = lambda x: 'my_slug'
         request = self.factory.get(self.url, HTTP_HOST='my.valid.homename')
         self.middleware.process_request(request)
-        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
+        self.assertEqual(request.urlconf, self.urlconf_subdomain)
         self.assertEqual(request.cname, True)
         self.assertEqual(request.slug, 'my_slug')
 
     def test_request_header(self):
         request = self.factory.get(self.url, HTTP_HOST='some.random.com', HTTP_X_RTD_SLUG='pip')
         self.middleware.process_request(request)
-        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
+        self.assertEqual(request.urlconf, self.urlconf_subdomain)
         self.assertEqual(request.cname, True)
         self.assertEqual(request.rtdheader, True)
         self.assertEqual(request.slug, 'pip')
@@ -109,14 +111,14 @@ class MiddlewareTests(TestCase):
         cache.get = lambda x: x.split('.')[0]
         request = self.factory.get(self.url, HTTP_HOST='PIP.RANDOM.COM')
         self.middleware.process_request(request)
-        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
+        self.assertEqual(request.urlconf, self.urlconf_subdomain)
         self.assertEqual(request.cname, True)
         self.assertEqual(request.slug, 'pip')
 
     def test_request_header_uppercase(self):
         request = self.factory.get(self.url, HTTP_HOST='some.random.com', HTTP_X_RTD_SLUG='PIP')
         self.middleware.process_request(request)
-        self.assertEqual(request.urlconf, 'readthedocs.core.urls.subdomain')
+        self.assertEqual(request.urlconf, self.urlconf_subdomain)
         self.assertEqual(request.cname, True)
         self.assertEqual(request.rtdheader, True)
         self.assertEqual(request.slug, 'pip')

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -155,12 +155,12 @@ class NotificationBackendTests(TestCase):
         self.assertEqual(PersistentMessage.objects.filter(read=False).count(), 1)
 
         self.client.force_login(user)
-        response = self.client.get('/')
+        response = self.client.get('/dashboard/')
         self.assertContains(response, 'Test success message')
         self.assertEqual(PersistentMessage.objects.count(), 1)
         self.assertEqual(PersistentMessage.objects.filter(read=True).count(), 1)
 
-        response = self.client.get('/')
+        response = self.client.get('/dashboard/')
         self.assertNotContains(response, 'Test success message')
 
 

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -20,6 +20,7 @@ from readthedocs.builds.models import Build
         'readthedocs.notifications.backends.EmailBackend',
         'readthedocs.notifications.backends.SiteBackend',
     ],
+    PRODUCTION_DOMAIN='readthedocs.org',
 )
 @mock.patch('readthedocs.notifications.notification.render_to_string')
 @mock.patch.object(Notification, 'send')

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
-import pytest
 
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 from readthedocs.oauth.services import (
@@ -57,7 +56,6 @@ class GitHubOAuthTests(TestCase):
             repo.ssh_url, 'ssh://git@github.com:testuser/testrepo.git')
         self.assertEqual(repo.html_url, 'https://github.com/testuser/testrepo')
 
-    @pytest.mark.community
     def test_make_project_fail(self):
         repo_json = {
             'name': '',
@@ -284,7 +282,6 @@ class BitbucketOAuthTests(TestCase):
             repo.html_url,
             'https://bitbucket.org/tutorials/tutorials.bitbucket.org')
 
-    @pytest.mark.community
     def test_make_project_fail(self):
         data = self.repo_response_data.copy()
         data['is_private'] = True
@@ -453,7 +450,6 @@ class GitLabOAuthTests(TestCase):
         self.assertTrue(repo.admin)
         self.assertFalse(repo.private)
 
-    @pytest.mark.community
     def test_make_private_project_fail(self):
         repo = self.service.create_repository(
             self.get_private_repo_data(), organization=self.org,

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -57,7 +57,7 @@ class GitHubOAuthTests(TestCase):
             repo.ssh_url, 'ssh://git@github.com:testuser/testrepo.git')
         self.assertEqual(repo.html_url, 'https://github.com/testuser/testrepo')
 
-    @pytest.mark.only_community
+    @pytest.mark.community
     def test_make_project_fail(self):
         repo_json = {
             'name': '',
@@ -284,7 +284,7 @@ class BitbucketOAuthTests(TestCase):
             repo.html_url,
             'https://bitbucket.org/tutorials/tutorials.bitbucket.org')
 
-    @pytest.mark.only_community
+    @pytest.mark.community
     def test_make_project_fail(self):
         data = self.repo_response_data.copy()
         data['is_private'] = True
@@ -453,7 +453,7 @@ class GitLabOAuthTests(TestCase):
         self.assertTrue(repo.admin)
         self.assertFalse(repo.private)
 
-    @pytest.mark.only_community
+    @pytest.mark.community
     def test_make_private_project_fail(self):
         repo = self.service.create_repository(
             self.get_private_repo_data(), organization=self.org,

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
+import pytest
 
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 from readthedocs.oauth.services import (
@@ -56,6 +57,7 @@ class GitHubOAuthTests(TestCase):
             repo.ssh_url, 'ssh://git@github.com:testuser/testrepo.git')
         self.assertEqual(repo.html_url, 'https://github.com/testuser/testrepo')
 
+    @pytest.mark.only_community
     def test_make_project_fail(self):
         repo_json = {
             'name': '',
@@ -282,6 +284,7 @@ class BitbucketOAuthTests(TestCase):
             repo.html_url,
             'https://bitbucket.org/tutorials/tutorials.bitbucket.org')
 
+    @pytest.mark.only_community
     def test_make_project_fail(self):
         data = self.repo_response_data.copy()
         data['is_private'] = True
@@ -450,6 +453,7 @@ class GitLabOAuthTests(TestCase):
         self.assertTrue(repo.admin)
         self.assertFalse(repo.private)
 
+    @pytest.mark.only_community
     def test_make_private_project_fail(self):
         repo = self.service.create_repository(
             self.get_private_repo_data(), organization=self.org,

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -176,7 +176,7 @@ class GitLabWebHookTest(BasePostCommitTest):
         self.assertEqual(r.status_code, 403)
 
 
-class GitHubPostCommitTest(BasePostCommitTest):
+class GitHubWebHookTest(BasePostCommitTest):
     fixtures = ["eric"]
 
     def setUp(self):
@@ -391,7 +391,7 @@ class CorePostCommitTest(BasePostCommitTest):
         self.assertEqual(r.status_code, 403)
 
 
-class BitBucketHookTests(BasePostCommitTest):
+class BitBucketWebHookTest(BasePostCommitTest):
 
     def setUp(self):
         self._setup()

--- a/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
+++ b/readthedocs/rtd_tests/tests/test_post_commit_hooks.py
@@ -32,7 +32,14 @@ class BasePostCommitTest(TestCase):
         self.mocks = [mock.patch('readthedocs.core.views.hooks.trigger_build')]
         self.patches = [m.start() for m in self.mocks]
 
-        self.feature = Feature.objects.get(feature_id=Feature.ALLOW_DEPRECATED_WEBHOOKS)
+        # Remove all possible Features added by a migration
+        Feature.objects.all().delete()
+
+        self.feature = get(
+            Feature,
+            feature_id=Feature.ALLOW_DEPRECATED_WEBHOOKS,
+            default_true=True,
+        )
         self.feature.projects.add(self.pip)
         self.feature.projects.add(self.rtfd)
         self.feature.projects.add(self.sphinx)

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -127,7 +127,7 @@ class TestProject(ProjectMixin, TestCase):
 
 # Most of these tests don't handle Corporate permissions (Organizations, Teams,
 # etc) in a proper way
-@pytest.mark.only_community
+@pytest.mark.community
 class TestProjectTranslations(TestCase, ProjectMixin):
 
     def test_translations(self):

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -4,7 +4,6 @@ from __future__ import (
 
 import datetime
 import json
-import pytest
 
 from django.contrib.auth.models import User
 from django.forms.models import model_to_dict
@@ -126,9 +125,6 @@ class TestProject(ProjectMixin, TestCase):
             self.pip.conf_file()
 
 
-# Most of these tests don't handle Corporate permissions (Organizations, Teams,
-# etc) in a proper way
-@pytest.mark.community
 class TestProjectTranslations(ProjectMixin, TestCase):
 
     def test_translations(self):

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -24,13 +24,14 @@ from readthedocs.rtd_tests.mocks.paths import fake_paths_by_regex
 
 class ProjectMixin(object):
 
+    fixtures = ['eric', 'test_data']
+
     def setUp(self):
         self.client.login(username='eric', password='test')
         self.pip = Project.objects.get(slug='pip')
 
 
 class TestProject(ProjectMixin, TestCase):
-    fixtures = ['eric', 'test_data']
 
     def test_valid_versions(self):
         r = self.client.get('/api/v2/project/6/valid_versions/', {})

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -129,7 +129,7 @@ class TestProject(ProjectMixin, TestCase):
 # Most of these tests don't handle Corporate permissions (Organizations, Teams,
 # etc) in a proper way
 @pytest.mark.community
-class TestProjectTranslations(TestCase, ProjectMixin):
+class TestProjectTranslations(ProjectMixin, TestCase):
 
     def test_translations(self):
         main_project = get(Project)

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -73,14 +73,15 @@ class TestProjectForms(TestCase):
             ('user@one-ssh.domain.com:22/_ssh/docs', True),
          ] + common_urls
 
-        for url, valid in public_urls:
-            initial = {
-                'name': 'foo',
-                'repo_type': 'git',
-                'repo': url,
-            }
-            form = ProjectBasicsForm(initial)
-            self.assertEqual(form.is_valid(), valid, msg=url)
+        with override_settings(ALLOW_PRIVATE_REPOS=False):
+            for url, valid in public_urls:
+                initial = {
+                    'name': 'foo',
+                    'repo_type': 'git',
+                    'repo': url,
+                }
+                form = ProjectBasicsForm(initial)
+                self.assertEqual(form.is_valid(), valid, msg=url)
 
         with override_settings(ALLOW_PRIVATE_REPOS=True):
             for url, valid in private_urls:

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -4,7 +4,6 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import mock
-import pytest
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -95,7 +94,6 @@ class TestProjectForms(TestCase):
                 self.assertEqual(form.is_valid(), valid, msg=url)
 
 
-@pytest.mark.community
 class TestTranslationForms(TestCase):
 
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -4,6 +4,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import mock
+import pytest
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -94,6 +95,7 @@ class TestProjectForms(TestCase):
                 self.assertEqual(form.is_valid(), valid, msg=url)
 
 
+@pytest.mark.community
 class TestTranslationForms(TestCase):
 
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -93,7 +93,7 @@ class TestProjectForms(TestCase):
                 self.assertEqual(form.is_valid(), valid, msg=url)
 
 
-class TestTranslationForm(TestCase):
+class TestTranslationForms(TestCase):
 
     def setUp(self):
         self.user_a = get(User)

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Utility functions for use in tests."""
 
 from __future__ import (
@@ -5,7 +6,7 @@ from __future__ import (
 
 import logging
 import subprocess
-from os import chdir, environ, getcwd, mkdir
+from os import chdir, environ, mkdir
 from os.path import abspath
 from os.path import join as pjoin
 from shutil import copytree
@@ -23,11 +24,12 @@ def get_readthedocs_app_path():
     """
     Return the absolute path of the ``readthedocs`` app.
     """
-    path = getcwd()
-    if path.endswith('readthedocsinc'):
-        # readthedocs-corporate
-        path = pjoin(path, '..', '..', 'readthedocs.org', 'readthedocs')
-        return path
+
+    try:
+        import readthedocs
+        path = readthedocs.__path__[0]
+    except (IndexError, ImportError):
+        raise Exception('Unable to find "readthedocs" path module')
 
     return path
 

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -19,6 +19,19 @@ from readthedocs.doc_builder.base import restoring_chdir
 log = logging.getLogger(__name__)
 
 
+def get_readthedocs_app_path():
+    """
+    Return the absolute path of the ``readthedocs`` app.
+    """
+    path = getcwd()
+    if path.endswith('readthedocsinc'):
+        # readthedocs-corporate
+        path = pjoin(path, '..', '..', 'readthedocs.org', 'readthedocs')
+        return path
+
+    return path
+
+
 def check_output(command, env=None):
     output = subprocess.Popen(
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -30,7 +43,7 @@ def check_output(command, env=None):
 
 def make_test_git():
     directory = mkdtemp()
-    path = getcwd()
+    path = get_readthedocs_app_path()
     sample = abspath(pjoin(path, 'rtd_tests/fixtures/sample_repo'))
     directory = pjoin(directory, 'sample_repo')
     copytree(sample, directory)
@@ -140,7 +153,7 @@ def delete_git_branch(directory, branch):
 
 def make_test_hg():
     directory = mkdtemp()
-    path = getcwd()
+    path = get_readthedocs_app_path()
     sample = abspath(pjoin(path, 'rtd_tests/fixtures/sample_repo'))
     directory = pjoin(directory, 'sample_repo')
     copytree(sample, directory)

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -41,6 +41,7 @@ def check_output(command, env=None):
     return output
 
 
+@restoring_chdir
 def make_test_git():
     directory = mkdtemp()
     path = get_readthedocs_app_path()
@@ -104,7 +105,6 @@ def make_test_git():
 
     # Checkout to master branch again
     check_output(['git', 'checkout', 'master'], env=env)
-    chdir(path)
     return directory
 
 
@@ -151,6 +151,7 @@ def delete_git_branch(directory, branch):
     check_output(command, env=env)
 
 
+@restoring_chdir
 def make_test_hg():
     directory = mkdtemp()
     path = get_readthedocs_app_path()
@@ -162,7 +163,6 @@ def make_test_hg():
     log.info(check_output(['hg', 'init'] + [directory]))
     log.info(check_output(['hg', 'add', '.']))
     log.info(check_output(['hg', 'commit', '-u', hguser, '-m"init"']))
-    chdir(path)
     return directory
 
 

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -14,7 +14,6 @@ from readthedocs.search.tests.utils import get_search_query_from_project_file
 
 @pytest.mark.django_db
 @pytest.mark.search
-@pytest.mark.community
 class TestElasticSearch(object):
 
     url = reverse_lazy('search')

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -2,7 +2,7 @@
 
 import pytest
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse_lazy
 from django_dynamic_fixture import G
 from pyquery import PyQuery as pq
 
@@ -17,8 +17,7 @@ from readthedocs.search.tests.utils import get_search_query_from_project_file
 @pytest.mark.community
 class TestElasticSearch(object):
 
-    def setUp(self):
-        self.url = reverse('search')
+    url = reverse_lazy('search')
 
     def _reindex_elasticsearch(self, es_index):
         call_command('reindex_elasticsearch')

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 from django.core.management import call_command
 from django.core.urlresolvers import reverse
@@ -12,8 +14,11 @@ from readthedocs.search.tests.utils import get_search_query_from_project_file
 
 @pytest.mark.django_db
 @pytest.mark.search
+@pytest.mark.community
 class TestElasticSearch(object):
-    url = reverse('search')
+
+    def setUp(self):
+        self.url = reverse('search')
 
     def _reindex_elasticsearch(self, es_index):
         call_command('reindex_elasticsearch')


### PR DESCRIPTION
This PR allows us to import the community test suite under the corporate test suite and extend them as well as skip some test cases that are specific for the community site and we don't need in the corporate project.

Related https://github.com/readthedocs/readthedocs-corporate/pull/329
Related https://github.com/readthedocs/readthedocs-corporate/pull/330