### PR TITLE
Use the latest theme version in the default builder

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -245,7 +245,7 @@ class Virtualenv(PythonEnvironment):
                     positive='sphinx<2',
                     negative='sphinx==1.7.4',
                 ),
-                'sphinx-rtd-theme<0.3',
+                'sphinx-rtd-theme==0.3.1',
                 'readthedocs-sphinx-ext<0.6'
             ])
 

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -245,7 +245,7 @@ class Virtualenv(PythonEnvironment):
                     positive='sphinx<2',
                     negative='sphinx==1.7.4',
                 ),
-                'sphinx-rtd-theme==0.3.1',
+                'sphinx-rtd-theme<0.4',
                 'readthedocs-sphinx-ext<0.6'
             ])
 

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -885,7 +885,7 @@ class TestPythonEnvironment(TestCase):
             'commonmark==0.5.4',
             'recommonmark==0.4.0',
             'sphinx==1.7.4',
-            'sphinx-rtd-theme==0.3.1',
+            'sphinx-rtd-theme<0.4',
             'readthedocs-sphinx-ext<0.6',
         ]
         requirements = self.base_requirements + requirements_sphinx

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -885,7 +885,7 @@ class TestPythonEnvironment(TestCase):
             'commonmark==0.5.4',
             'recommonmark==0.4.0',
             'sphinx==1.7.4',
-            'sphinx-rtd-theme<0.3',
+            'sphinx-rtd-theme==0.3.1',
             'readthedocs-sphinx-ext<0.6',
         ]
         requirements = self.base_requirements + requirements_sphinx


### PR DESCRIPTION
This will use the latest theme across the whole site unless people are pinned to a specific version. I believe this is sufficiently stable to roll out to a wider audience. While 0.3.0 had a number of issues, the biggest complaint we are seeing in 0.3.1 is the lack of highlighting (surprising since that never worked from the dawn of history until a week ago).

https://sphinx-rtd-theme.readthedocs.io/en/latest/changelog.html#v0-3-1

Fixes #4072
Fixes #4050