### PR TITLE
Set valid clone in project instance inside the version object also

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -534,6 +534,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         project_data['has_valid_clone'] = True
         api_v2.project(self.project.pk).put(project_data)
         self.project.has_valid_clone = True
+        self.version.project.has_valid_clone = True
 
     def update_documentation_type(self):
         """


### PR DESCRIPTION
When we set the `has_valid_clone` in the Project instance that we are using for the current Build, we also need to update the project instance that lives inside the Version instance.

Similar to #4080