### PR TITLE
Add `has_valid_clone` and `has_valid_webhook` to ProjectAdminSerializer

### DIFF
--- a/readthedocs/restapi/serializers.py
+++ b/readthedocs/restapi/serializers.py
@@ -60,6 +60,8 @@ class ProjectAdminSerializer(ProjectSerializer):
             'requirements_file',
             'python_interpreter',
             'features',
+            'has_valid_clone',
+            'has_valid_webhook',
         )
 
 

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -735,6 +735,8 @@ class APIVersionTests(TestCase):
                 'enable_epub_build': True,
                 'enable_pdf_build': True,
                 'features': ['allow_deprecated_webhooks'],
+                'has_valid_clone': False,
+                'has_valid_webhook': False,
                 'id': 6,
                 'install_project': False,
                 'language': 'en',


### PR DESCRIPTION
This is needed to be able to update the `has_valid_clone` field from the UpdateDocsTask when a build is triggered but also it's good information to have over the API.

Closes #4106