### PR TITLE
Remove Django deprecation warning

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -36,7 +36,6 @@ class CommunityBaseSettings(Settings):
 
     # Debug settings
     DEBUG = True
-    TEMPLATE_DEBUG = DEBUG
     TASTYPIE_FULL_DEBUG = True
 
     # Domains and URLs


### PR DESCRIPTION
The warning was

> The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default
TEMPLATES dict: TEMPLATE_DEBUG.

And we already have the debug option there

https://github.com/rtfd/readthedocs.org/blob/b05c82acc69e492533da9b7e3e40fef2456af6de/readthedocs/settings/base.py#L176

Also, there is a warning about Guardian

> Guardian authentication backend is not hooked. You can add this in settings as eg: `AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend', 'guardian.backends.ObjectPermissionBackend')`.

I think that setting is used in production, right?