### PR TITLE
Use quiet mode to retrieve branches from mercurial

### DIFF
--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -46,7 +46,16 @@ class Backend(BaseVCS):
         return self.parse_branches(stdout)
 
     def parse_branches(self, data):
-        """Stable / default"""
+        """
+        Parses output of `hg branches --quiet`, eg:
+
+            default
+            0.2
+            0.1
+
+        Into VCSVersion objects with branch name as verbose_name and
+        identifier.
+        """
         names = [name.lstrip() for name in data.splitlines()]
         return [VCSVersion(self, name, name) for name in names if name]
 

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -38,7 +38,8 @@ class Backend(BaseVCS):
 
     @property
     def branches(self):
-        retcode, stdout = self.run('hg', 'branches', record_as_success=True)[:2]
+        retcode, stdout = self.run(
+            'hg', 'branches', '--quiet', record_as_success=True)[:2]
         # error (or no tags found)
         if retcode != 0:
             return []


### PR DESCRIPTION
Without the quiet mode, the current revision of the branch is also
displayed which breaks parse_branches.