### PR TITLE
Upgrade packages with pur

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,13 +1,10 @@
 # Base packages
-pip==10.0.0
+pip==10.0.1
 appdirs==1.4.3
-virtualenv==15.2.0
+virtualenv==16.0.0
 docutils==0.14
 Sphinx==1.7.4
-
-# 0.3.0 breaks sidebar
-# https://github.com/rtfd/sphinx_rtd_theme/issues/610
-sphinx_rtd_theme==0.2.5b1
+sphinx_rtd_theme==0.3.1
 
 Pygments==2.2.0
 
@@ -24,7 +21,7 @@ readthedocs-build<2.1
 django-tastypie==0.13.0
 
 django-guardian==1.4.9
-django-extensions==2.0.6
+django-extensions==2.0.7
 
 # djangorestframework 3.7.x drops support for django 1.9.x
 djangorestframework==3.6.4
@@ -39,7 +36,7 @@ defusedxml==0.5.0
 
 # Basic tools
 redis==2.10.6
-celery==4.1.0
+celery==4.1.1
 
 # django-allauth 0.33.0 dropped support for Django 1.9
 # https://django-allauth.readthedocs.io/en/latest/release-notes.html#backwards-incompatible-changes
@@ -49,7 +46,7 @@ dnspython==1.15.0
 
 # VCS
 httplib2==0.11.3
-GitPython==2.1.9
+GitPython==2.1.10
 
 # Search
 elasticsearch==1.5.0
@@ -74,7 +71,7 @@ django-formtools==2.1
 # docker is pinned to 3.1.3 because we found some strange behavior
 # related to timeouts on EXEC with 3.2.1 that's not present with 3.1.3
 # https://github.com/rtfd/readthedocs.org/issues/3999
-docker==3.1.3
+docker==3.3.0
 
 django-textclassifier==1.0
 django-annoying==0.10.4


### PR DESCRIPTION
$ pur --skip django-tastypie,django,docker-py,elasticsearch,pyelasticsearch,commonmark,stripe,djangorestframework,mkdocs,django-allauth

Closes #4125 