### PR TITLE
oauth/services: don't abuse log.exception

### DIFF
--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -230,7 +230,7 @@ class BitbucketService(Service):
                 project,
             )
         else:
-            log.exception(
+            log.error(
                 'Bitbucket webhook creation failed for project: %s',
                 project,
             )
@@ -287,7 +287,7 @@ class BitbucketService(Service):
                 project,
             )
         else:
-            log.exception(
+            log.error(
                 'Bitbucket webhook update failed for project: %s',
                 project,
             )

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -214,7 +214,7 @@ class GitHubService(Service):
                 project,
             )
         else:
-            log.exception(
+            log.error(
                 'GitHub webhook creation failed for project: %s',
                 project,
             )
@@ -274,7 +274,7 @@ class GitHubService(Service):
                 project,
             )
         else:
-            log.exception(
+            log.error(
                 'GitHub webhook update failed for project: %s',
                 project,
             )

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -305,7 +305,7 @@ class GitLabService(Service):
                 project,
             )
         else:
-            log.exception(
+            log.error(
                 'GitLab webhook creation failed for project: %s',
                 project,
             )
@@ -363,7 +363,7 @@ class GitLabService(Service):
             log.exception(
                 'GitLab webhook update failed for project: %s', project)
         else:
-            log.exception(
+            log.error(
                 'GitLab webhook update failed for project: %s',
                 project,
             )


### PR DESCRIPTION
log.exception should not be used outside exception handlers