### PR TITLE
oauth/services: correct error handling in paginate

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -153,7 +153,6 @@ class Service(object):
                 url,
                 debug_data,
             )
-        else:
             return []
 
     def sync(self):


### PR DESCRIPTION
the else code was dead code as the code in the try block already
returned. Instead return an empty list when it is needed.