### PR TITLE
Ignore migrations from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+  */**/migrations/*

--- a/tox.ini
+++ b/tox.ini
@@ -52,5 +52,5 @@ deps =
 whitelist_externals = echo
 commands =
     py.test --disable-pytest-warnings \
-        --cov-report=term --cov-report=html --cov=. {posargs}
+        --cov-report=term --cov-report=html --cov-config {toxinidir}/.coveragerc --cov=.  {posargs}
     echo Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html


### PR DESCRIPTION
This ignores the files from the migration folders, so we have a better coverage report. In the future would be nice to integrate coverage into the CI pipeline.