### PR TITLE
Fix prospector dependencies

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -4,6 +4,7 @@ maxcdn
 # https://github.com/PyCQA/pylint-django/issues/117
 astroid==1.6.1
 pylint
-prospector
 pylint-django
+pylint-celery
+prospector
 pyflakes


### PR DESCRIPTION
Due https://github.com/PyCQA/prospector/commit/f866efc762c323779d283457abb86271b514d957#diff-2eeaed663bd0d25b7e608891384b7298 pylint-django and pylint-celery aren't installed by default.

There isn't a changelog for the 0.12.9 version but it was released on pypi :/