### PR TITLE
Small footer rework

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -654,8 +654,9 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 #footer a:hover, #footer a:active { color: white; text-decoration: underline; }
 
 /* Social icons */
-#footer .social { font-family: FontAwesome; margin-left: 25px; }
-#footer .social li { float: left; }
+#footer .social { font-family: FontAwesome; text-align: center; margin-top: 30px; }
+#footer .social:after { clear: both; content: ''; display: table; }
+#footer .social li { width: 50px; display: inline-block; }
 #footer .social a { text-decoration: none; opacity: 0.5; }
 #footer .social a:hover, #footer .social a:visited { opacity: 1; }
 #footer .social .icon { display: inline-block; width: 36px; height: 36px; font-size: 24px;}
@@ -666,6 +667,13 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 #footer .footer-bottom { margin-top: 30px; }
 #footer select { float: left; width: 175px; padding: 2px; height: 24px; font-size: 12px; margin-right: 10px; }
 #footer input[type="submit"] { margin-top: 0; padding: 4px; height: 24px; font-size: 12px; line-height: 16px; }
+
+/* Other footer forms */
+#footer #email-signup { margin-bottom: 20px; }
+#footer #email-signup:after { clear: both; content:''; display: table; }
+#footer #email-signup p { padding-right: 10px; font-size: 14px; color: #BCC1C3; }
+#footer label { color: #BCC1C3; font-weight: normal; }
+#footer input[type="text"], #footer input[type="email"] { padding: 4px; font-size: 12px; line-height: 16px; margin-bottom: 5px }
 
 
 /* utils */

--- a/media/css/core.css
+++ b/media/css/core.css
@@ -654,7 +654,7 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 #footer a:hover, #footer a:active { color: white; text-decoration: underline; }
 
 /* Social icons */
-#footer .social { font-family: FontAwesome; text-align: center; margin-top: 30px; }
+#footer .social { font-family: FontAwesome; text-align: center; }
 #footer .social:after { clear: both; content: ''; display: table; }
 #footer .social li { width: 50px; display: inline-block; }
 #footer .social a { text-decoration: none; opacity: 0.5; }

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -287,14 +287,13 @@ class TestProject(TestCase):
             follow=True
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertContains(resp, 'error')
         self.assertContains(
             resp,
             'There is already a &quot;es&quot; translation '
             'for the read-the-docs project'
         )
 
-    def test_user_can_change_project_whith_same_lang(self):
+    def test_user_can_change_project_with_same_lang(self):
         user_a = User.objects.get(username='eric')
         project_a = Project.objects.get(slug='read-the-docs')
         project_b = get(
@@ -322,7 +321,7 @@ class TestProject(TestCase):
             follow=True
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertNotContains(resp, 'error')
+        self.assertNotContains(resp, 'There is already a')
 
     def test_token(self):
         r = self.client.get('/api/v2/project/6/token/', {})

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -108,10 +108,10 @@
           <div id="email-signup">
             <form action="https://readthedocs.us3.list-manage.com/subscribe/post?u=a6a22369cc2b356379cf789ca&amp;id=a85a83a5a5" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
               <div>
-                <h4>Email Newsletter</h4>
-                <p>Sign up for our newsletter to get our latest blog updates delivered to your inbox weekly.</p>
+                <h4>{% trans 'Email Newsletter' %}</h4>
+                <p>{% trans 'Sign up for our newsletter to get our latest blog updates delivered to your inbox weekly.' %}</p>
                 <div>
-                  <label for="mce-EMAIL">Email</label>
+                  <label for="mce-EMAIL">{% trans 'Email' %}</label>
                   <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="you@example.com">
                 </div>
                 <div id="mce-responses" class="clear">
@@ -119,7 +119,7 @@
                   <div class="response" id="mce-success-response" style="display:none"></div>
                 </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
                 <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_a6a22369cc2b356379cf789ca_a85a83a5a5" tabindex="-1" value=""></div>
-                <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+                <div class="clear"><input type="submit" value="{% trans 'Subscribe' %}" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
               </div>
             </form>
           </div>

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -108,7 +108,14 @@
           <div id="email-signup">
             <form action="https://readthedocs.us3.list-manage.com/subscribe/post?u=a6a22369cc2b356379cf789ca&amp;id=a85a83a5a5" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
               <div>
-                <h4>{% trans 'Email Newsletter' %}</h4>
+                <h4>{% trans 'Stay Updated' %}</h4>
+
+                <ul>
+                  <li>
+                    <a href="https://blog.readthedocs.com/">{% trans 'Blog' %}</a>
+                  </li>
+                </ul>
+
                 <p>{% trans 'Sign up for our newsletter to get our latest blog updates delivered to your inbox weekly.' %}</p>
                 <div>
                   <label for="mce-EMAIL">{% trans 'Email' %}</label>
@@ -127,55 +134,45 @@
         </div>
 
         <div class="column-about">
-          <h4>{%  trans "About Us" %}</h4>
+          <h4>{% trans 'Get Involved' %}</h4>
 
           <ul>
             <li>
-              <a href="https://docs.readthedocs.io/en/latest/team.html">{%  trans "Team" %}</a>
+              <a href="https://docs.readthedocs.io/en/latest/getting_started.html">{% trans 'Getting Started Guide' %}</a>
             </li>
             <li>
-              <a href="https://docs.readthedocs.io/en/latest/open-source-philosophy.html">{% trans "Open Source Philosophy" %}</a>
+              <a href="https://docs.readthedocs.io">{% trans 'Documentation' %}</a>
             </li>
             <li>
-              <a href="http://blog.readthedocs.com/">{% trans "Blog" %}</a>
+              <a href="https://docs.readthedocs.io/en/latest/contribute.html">{% trans 'Contributing' %}</a>
             </li>
             <li>
-              <a href="https://docs.readthedocs.io/en/latest/sponsors.html">{% trans "Our Sponsors" %}</a>
+              <a href="https://docs.readthedocs.io/en/latest/team.html">{% trans 'Team' %}</a>
             </li>
             <li>
-              <a href="https://docs.readthedocs.io/en/latest/privacy-policy.html">{% trans "Privacy Policy" %}</a>
+              <a href="https://docs.readthedocs.io/en/latest/open-source-philosophy.html">{% trans 'Open Source Philosophy' %}</a>
             </li>
           </ul>
 
         </div>
 
         <div class="column-rtd">
-          <h4>{%  trans "Read the Docs" %}</h4>
+          <h4>{% trans 'Business Info' %}</h4>
 
           <ul>
             <li>
-              <a href="https://docs.readthedocs.io/en/latest/getting_started.html">{% trans "Getting Started Guide" %}</a>
-            </li>
-            <li>
-              <a href="https://docs.readthedocs.io">{% trans "Documentation" %}</a>
-            </li>
-            <li>
-              <a href="https://docs.readthedocs.io/en/latest/contribute.html">{% trans "Contributing" %}</a>
-            </li>
-            <li>
               {% url "advertising" as advertising_url %}
-              <a href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">{%  trans "Advertise with Us" %}</a>
+              <a href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">{% trans 'Advertise with Us' %}</a>
             </li>
             <li>
-              <a href="https://readthedocs.com">{%  trans "Commercial Support" %}</a>
-            </li>
-            <li>
-              {% url "gold_detail" as gold_detail %}
-              <a href="{{ gold_detail }}">{%  trans "Read the Docs Gold" %}</a>
+              <a href="https://readthedocs.com">{% trans 'Private Hosting' %}</a>
             </li>
             <li>
               {% url "donate" as donate_url %}
-              <a href='{{ donate_url }}'>{% trans "Donate" %}</a>
+              <a href='{{ donate_url }}'>{% trans 'Supporters' %}</a>
+            </li>
+            <li>
+              <a href="https://docs.readthedocs.io/en/latest/privacy-policy.html">{% trans 'Privacy Policy' %}</a>
             </li>
           </ul>
         </div>
@@ -194,11 +191,11 @@
         <div class="footer-bottom">
           <div class="column-copyright">
             <p>
-              <small>&copy; Copyright {% now "Y" %}, {% trans "Read the Docs, Inc & contributors" %}</small>
+              <small>&copy; Copyright {% now "Y" %}, {% trans 'Read the Docs, Inc & contributors' %}</small>
             </p>
 
             <p>
-              <small>{% trans "Version" %} {% readthedocs_version %}</small>
+              <small>{% trans 'Version' %} {% readthedocs_version %}</small>
             </p>
           </div>
 

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -105,12 +105,25 @@
         {% block footer-content %}
 
         <div class="column-logo">
-          <div class="footerlogo"></div>
+          <div id="email-signup">
+            <form action="https://readthedocs.us3.list-manage.com/subscribe/post?u=a6a22369cc2b356379cf789ca&amp;id=a85a83a5a5" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+              <div>
+                <h4>Email Newsletter</h4>
+                <p>Sign up for our newsletter to get our latest blog updates delivered to your inbox weekly.</p>
+                <div>
+                  <label for="mce-EMAIL">Email</label>
+                  <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="you@example.com">
+                </div>
+                <div id="mce-responses" class="clear">
+                  <div class="response" id="mce-error-response" style="display:none"></div>
+                  <div class="response" id="mce-success-response" style="display:none"></div>
+                </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_a6a22369cc2b356379cf789ca_a85a83a5a5" tabindex="-1" value=""></div>
+                <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+              </div>
+            </form>
+          </div>
 
-          <ul class="social">
-            <li><a href="https://github.com/rtfd/readthedocs.org" rel="noopener noreferrer"><span class="icon github"></span></a></li>
-            <li><a href="https://twitter.com/readthedocs" rel="noopener noreferrer"><span class="icon twitter"></span></a></li>
-          </ul>
         </div>
 
         <div class="column-about">
@@ -133,6 +146,7 @@
               <a href="https://docs.readthedocs.io/en/latest/privacy-policy.html">{% trans "Privacy Policy" %}</a>
             </li>
           </ul>
+
         </div>
 
         <div class="column-rtd">
@@ -168,13 +182,23 @@
 
         <div class="clearfix"></div>
 
+        <div class="social-column">
+          <ul class="social">
+            <li><a href="https://github.com/rtfd/readthedocs.org" rel="noopener noreferrer"><span class="icon github"></span></a></li>
+            <li><a href="https://twitter.com/readthedocs" rel="noopener noreferrer"><span class="icon twitter"></span></a></li>
+          </ul>
+        </div>
+
+        <div class="clearfix"></div>
+
         <div class="footer-bottom">
           <div class="column-copyright">
             <p>
-              <small>
-                &copy; Copyright {% now "Y" %}, {% trans "Read the Docs, Inc & contributors" %} -
-                {% trans "Version" %} {% readthedocs_version %}
-              </small>
+              <small>&copy; Copyright {% now "Y" %}, {% trans "Read the Docs, Inc & contributors" %}</small>
+            </p>
+
+            <p>
+              <small>{% trans "Version" %} {% readthedocs_version %}</small>
             </p>
           </div>
 


### PR DESCRIPTION
This reworks the footer specifically to:

- Add an email newsletter signup form. Back in 2014 ([see WayBack Machine](https://web.archive.org/web/20140415000000/http://readthedocs.org:80/)) we had an email newsletter in the footer. It got way too much spam signups and would have cost us money to continue to use it. Our email newsletter is now "double opt-in" meaning not only do users have to type in an email address but they have to confirm their email address by receiving an email and clicking a confirm to sign up to the list. This should drastically reduce the spam signups and increase quality overall.
- Balances the 3 footer columns a bit better
- Centers the social media/github icons
- The version number is on its own line. Previously this wrapped slightly awkwardly.

From a browser perspective, I tested this down to IE11.

## SCREENSHOT
<img width="938" alt="screen shot 2018-05-25 at 4 34 04 pm" src="https://user-images.githubusercontent.com/185043/40569799-78856000-6039-11e8-8e27-388f582fb5af.png">
