### PR TITLE
Remove CSS override that doesn't exist.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ locale_dirs = [
 gettext_compact = False
 
 html_theme = 'sphinx_rtd_theme'
-#html_static_path = ['_static']
+# html_static_path = ['_static']
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_logo = 'img/logo.svg'
 html_theme_options = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ locale_dirs = [
 gettext_compact = False
 
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+#html_static_path = ['_static']
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_logo = 'img/logo.svg'
 html_theme_options = {
@@ -79,6 +79,3 @@ html_theme_options = {
     'display_version': False,
 }
 
-
-def setup(app):
-    app.add_stylesheet('custom.css')

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -51,6 +51,8 @@ class CommunityDevSettings(CommunityBaseSettings):
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super(CommunityDevSettings, self).LOGGING
         logging['formatters']['default']['format'] = '[%(asctime)s] ' + self.LOG_FORMAT
+        # Allow Sphinx and other tools to create loggers
+        logging['disable_existing_loggers'] = False
         return logging
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 description = build readthedocs documentation
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -n -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:docs-lint]
 description = run linter (rstcheck) to ensure there aren't errors on our docs

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 description = build readthedocs documentation
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:docs-lint]
 description = run linter (rstcheck) to ensure there aren't errors on our docs

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 description = build readthedocs documentation
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -n -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:docs-lint]
 description = run linter (rstcheck) to ensure there aren't errors on our docs


### PR DESCRIPTION
Also remove static path file.

This also fixes a bug that was causing logging to not be happening in Sphinx. This now properly shows errors, so that we can fix them. 