### PR TITLE
Start running our doc builds in nitpicky mode.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,10 @@ commands =
     py.test {posargs}
 
 [testenv:docs]
-description = build readthedocs documentation
+description = build readthedocs documentation in nitpicky mode -- warn on errors
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -W -n -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:docs-lint]
 description = run linter (rstcheck) to ensure there aren't errors on our docs


### PR DESCRIPTION
This should catch any missing references and other issues.

It's expected to fail currently, and we should update this branch until
things pass properly.