### PR TITLE
Fix issues with search javascript

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/search.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/search.js
@@ -49,7 +49,8 @@ function attach_elastic_search_query(data) {
                             .attr('href', item_url)
                             .html(fields.title)
                         );
-                        if (fields.project !== project) {
+                        // fields.project is returned as an array
+                        if (fields.project.indexOf(project) === -1) {
                             list_item.append(
                                 $('<span>')
                                 .text(" (from project " + fields.project + ")")


### PR DESCRIPTION
A comparison was previously relying on type coercion, and when linting fixes
changed this to an exact comparison operator, this comparison started failing.