### PR TITLE
Upgrade celery to avoid AtributeError:async

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -39,7 +39,7 @@ defusedxml==0.5.0
 
 # Basic tools
 redis==2.10.6
-celery==4.1.0
+celery==4.1.1
 
 # django-allauth 0.33.0 dropped support for Django 1.9
 # https://django-allauth.readthedocs.io/en/latest/release-notes.html#backwards-incompatible-changes


### PR DESCRIPTION
I was experimenting the same descrived here and this seems to be solution.

I'm not sure why this is not happening in production, though.

https://stackoverflow.com/questions/50444988/celery-attributeerror-async-error