### PR TITLE
These links weren't correct after #3632

### DIFF
--- a/docs/badges.rst
+++ b/docs/badges.rst
@@ -71,8 +71,8 @@ since it will stay up to date with your Read the Docs project::
 
 .. _Read the Docs README: https://github.com/rtfd/readthedocs.org/blob/master/README.rst
 .. _project page: https://readthedocs.org/projects/pip/
-.. |green| image:: https://media.readthedocs.org/static/projects/badges/passing.svg
-.. |red| image:: https://media.readthedocs.org/static/projects/badges/failing.svg
-.. |yellow| image:: https://media.readthedocs.org/static/projects/badges/unknown.svg
+.. |green| image:: https://media.readthedocs.org/static/projects/badges/passing-flat.svg
+.. |red| image:: https://media.readthedocs.org/static/projects/badges/failing-flat.svg
+.. |yellow| image:: https://media.readthedocs.org/static/projects/badges/unknown-flat.svg
 .. |nbsp| unicode:: 0xA0
    :trim:


### PR DESCRIPTION
The [badge examples in our docs](https://docs.readthedocs.io/en/latest/badges.html#status-badges) are 404-ing until this is merged.

This doesn't appear to affect badges people are actually using. Just the docs.