### PR TITLE
Use autosectionlabel in the privacy policy

### DIFF
--- a/docs/advertising-details.rst
+++ b/docs/advertising-details.rst
@@ -110,7 +110,7 @@ Do Not Track Policy
 -------------------
 
 Read the Docs supports Do Not Track (DNT) and respects users' tracking preferences.
-For more details, see the :ref:`Do Not Track section <privacy-policy-do-not-track>`
+For more details, see the :ref:`Do Not Track section <privacy-policy:Do Not Track>`
 of our privacy policy.
 
 

--- a/docs/guides/google-analytics.rst
+++ b/docs/guides/google-analytics.rst
@@ -18,5 +18,5 @@ and sometimes can take up to a day before it starts reporting data.
    for the purpose of analytics.
 
    For more details, see the
-   :ref:`Do Not Track section <privacy-policy-do-not-track>`
+   :ref:`Do Not Track section <privacy-policy:Do Not Track>`
    of our privacy policy.

--- a/docs/privacy-policy.rst
+++ b/docs/privacy-policy.rst
@@ -223,7 +223,6 @@ We do not sell that content; it is yours.
 Our use of cookies and tracking
 -------------------------------
 
-.. _privacy-policy-do-not-track:
 
 Do Not Track
 ~~~~~~~~~~~~
@@ -236,7 +235,7 @@ For Read the Docs, this means:
 
 * We **do not** do behavioral ad targeting regardless of your DNT preference.
 * When DNT is enabled, both logged-in and logged-out users
-  are considered opted-out of :ref:`analytics <privacy-policy-analytics>`.
+  are considered opted-out of :ref:`analytics <privacy-policy:Google Analytics>`.
 * Regardless of DNT preference, our logs that contain IP addresses
   and user agent strings are deleted after 10 days unless a DNT exception applies.
 * Our full DNT policy is `available here`_.


### PR DESCRIPTION
The changes for adding autosectionlabel (#4146) didn't apply to the Do Not Track PR (#4046) as they were merged around the same time.

This simply applies the same style.

As this is just a formatting change, there's no need to change the date on the privacy policy.