### PR TITLE
Use the latest YouTube share URL

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -136,7 +136,7 @@ how to use this well on our :doc:`versions` page.
 
 If you have any more trouble, don't hesitate to reach out to us. The :doc:`support` page has more information on getting in touch.
 
-.. _a screencast: https://www.youtube.com/watch?feature=player_embedded&v=oJsUvBQyHBs
+.. _a screencast: https://youtu.be/oJsUvBQyHBs
 .. _Python: https://www.python.org/
 .. _Sphinx: http://sphinx-doc.org/
 .. _Markdown: http://daringfireball.net/projects/markdown/syntax


### PR DESCRIPTION
Hello,

This is my first `readthedocs.org` pull request! 🎉 

I updated the YouTube screencast URL because YouTube uses a new sharing URL:

![screenshot_2018-06-08 sphinx read the docs - youtube](https://user-images.githubusercontent.com/5073946/41170781-20ff89ee-6b4e-11e8-86bd-df778b3a4d92.png)

--[Suriyaa Sundararuban](https://about.suriyaa.tk/)