### PR TITLE
Use resolver module to resolve version URL during doc build

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -19,6 +19,7 @@ from django.utils.translation import ugettext
 from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
+from readthedocs.core.resolver import resolve_path
 from readthedocs.core.utils import broadcast
 from readthedocs.projects.constants import (
     BITBUCKET_URL, GITHUB_URL, GITLAB_URL, PRIVACY_CHOICES, PRIVATE)
@@ -150,6 +151,9 @@ class Version(models.Model):
         # Therefore just return the identifier to make a safe guess.
         log.debug('TODO: Raise an exception here. Testing what cases it happens')
         return self.identifier
+
+    def get_url(self):
+        return resolve_path(self.project, version_slug=self.slug)
 
     def get_absolute_url(self):
         if not self.built and not self.uploaded:

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -82,7 +82,7 @@ context = {
     'MEDIA_URL': "{{ settings.MEDIA_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
     'versions': [{% for version in versions %}
-    ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}
+    ("{{ version.slug }}", "{{ version.get_url }}"),{% endfor %}
     ],
     'downloads': [ {% for key, val in downloads.items %}
     ("{{ key }}", "{{ val }}"),{% endfor %}


### PR DESCRIPTION
This fixes version URLs when USE_SUBDOMAIN is disabled.
Also tested with subdomains enabled.