### PR TITLE
Refactor `cofig.py` file into a package

### DIFF
--- a/readthedocs/doc_builder/config/__init__.py
+++ b/readthedocs/doc_builder/config/__init__.py
@@ -1,0 +1,1 @@
+from .wrapper import ConfigWrapper, load_yaml_config

--- a/readthedocs/doc_builder/config/wrapper.py
+++ b/readthedocs/doc_builder/config/wrapper.py
@@ -8,7 +8,7 @@ from builtins import filter, object
 from readthedocs_build.config import load as load_config
 from readthedocs_build.config import BuildConfig, ConfigError, InvalidConfig
 
-from .constants import DOCKER_IMAGE_SETTINGS, DOCKER_IMAGE
+from readthedocs.doc_builder.constants import DOCKER_IMAGE_SETTINGS, DOCKER_IMAGE
 
 
 class ConfigWrapper(object):

--- a/readthedocs/rtd_tests/tests/test_config_wrapper.py
+++ b/readthedocs/rtd_tests/tests/test_config_wrapper.py
@@ -38,7 +38,7 @@ def create_load(config=None):
     return inner
 
 
-@mock.patch('readthedocs.doc_builder.config.load_config')
+@mock.patch('readthedocs.doc_builder.config.wrapper.load_config')
 class LoadConfigTests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
We have a `config.py` that serves as a wrapper around the rtd-build package, I'm refactoring this to be a package due it has the same name `config` that it's used by https://github.com/rtfd/readthedocs-build/. Refs to https://github.com/rtfd/readthedocs-build/issues/50. Kind of this would be refactored later after moving the other repo completely anyway.