### PR TITLE
Override versions.html template for specific RTD functionality

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -132,6 +132,15 @@ if 'html_context' in globals():
 else:
     html_context = context
 
+# Add custom RTD templates
+if using_rtd_theme:
+    if 'templates_path' in globals():
+        templates_path.append('{{ template_path }}')
+    else:
+        templates_path = [
+            '{{ template_path }}',
+        ]
+
 # Add custom RTD extension
 if 'extensions' in globals():
     # Insert at the beginning because it can interfere

--- a/readthedocs/templates/sphinx/versions.html
+++ b/readthedocs/templates/sphinx/versions.html
@@ -1,0 +1,12 @@
+{# Template override to avoid adding static version menu into Read the Docs production sites  #}
+{# Add rst-badge after rst-versions for small badge style. #}
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Read the Docs</span>
+    v: {{ current_version }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {# This content is injected by an AJAX call to readthedocs.org/readthedocs.com #}
+  </div>
+</div>


### PR DESCRIPTION
Sphinx RTD theme uses a `versions.html` template to generate the version menu if `READTHEDOCS` variable is True. Since this is something specific to Read the Docs and that variable is going to be removed soon from the theme, we are overriding this template to maintain our current functionality.

Also, the static content generated in this menu is removed to avoid showing invalid links/data in case the AJAX fails for any reason. If this happen, the menu just won't show any information.

Related https://github.com/rtfd/sphinx_rtd_theme/pull/578