### PR TITLE
Downgrade docker to 3.1.3 because of timeouts in EXEC call

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -67,9 +67,10 @@ stripe==1.20.2
 django-formtools==2.1
 
 # docker is pinned to 3.1.3 because we found some strange behavior
-# related to timeouts on EXEC with 3.2.1 that's not present with 3.1.3
+# related to timeouts on EXEC with 3.2.1 and 3.3.0 that's not present
+# with 3.1.3
 # https://github.com/rtfd/readthedocs.org/issues/3999
-docker==3.3.0
+docker==3.1.3
 
 django-textclassifier==1.0
 django-annoying==0.10.4


### PR DESCRIPTION
Related #3999