### PR TITLE
Update the sphinx-doc.org links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ Then we build documentation and host it for you.
 Think of it as *Continuous Documentation*.
 
 .. _Read the docs: http://readthedocs.org/
-.. _Sphinx: http://sphinx.pocoo.org/
-.. _reStructuredText: http://sphinx.pocoo.org/rest.html
+.. _Sphinx: http://www.sphinx-doc.org/
+.. _reStructuredText: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _Subversion: http://subversion.tigris.org/
 .. _Bazaar: http://bazaar.canonical.com/
 .. _Git: http://git-scm.com/


### PR DESCRIPTION
It looks like they moved off of pocoo.org and onto their own domain, so figured it would be best to follow.