### PR TITLE
Add optional pipenv install stage

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -103,6 +103,18 @@ class ConfigWrapper(object):
         return self._project.requirements_file
 
     @property
+    def pipenv_enabled(self):
+        if 'enabled' in self._yaml_config.get('pipenv', {}):
+            return self._yaml_config['pipenv']['enabled']
+        return False
+
+    @property
+    def pipenv_options(self):
+        if 'options' in self._yaml_config.get('pipenv', {}):
+            return self._yaml_config['pipenv']['options']
+        return []
+
+    @property
     def formats(self):
         if 'formats' in self._yaml_config:
             return self._yaml_config['formats']

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -234,6 +234,9 @@ class Virtualenv(PythonEnvironment):
             'recommonmark==0.4.0',
         ]
 
+        if self.config.pipenv_enabled:
+            requirements.append('pipenv==2018.5.18')
+
         if self.project.documentation_type == 'mkdocs':
             requirements.append('mkdocs==0.17.3')
         else:
@@ -298,6 +301,22 @@ class Virtualenv(PythonEnvironment):
                 self.project.pip_cache_path,
                 '-r{0}'.format(requirements_file_path),
             ]
+            self.build_env.run(
+                *args,
+                cwd=self.checkout_path,
+                bin_path=self.venv_bin()
+            )
+
+    def install_from_pipfile(self):
+        if self.config.pipenv_enabled:
+            args = [
+                'python',
+                self.venv_bin(filename='pipenv'),
+                'install',
+                '--system',
+            ]
+            if self.config.pipenv_options:
+                args.extend(self.config.pipenv_options)
             self.build_env.run(
                 *args,
                 cwd=self.checkout_path,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -617,6 +617,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             self.python_env.save_environment_json()
             self.python_env.install_core_requirements()
             self.python_env.install_user_requirements()
+            self.python_env.install_from_pipfile()
             self.python_env.install_package()
 
     def build_docs(self):

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1343,6 +1343,67 @@ class TestPythonEnvironment(TestCase):
         python_env.install_user_requirements()
         self.build_env_mock.run.assert_not_called()
 
+    def test_pipenv_install(self):
+        config_data = {
+            'pipenv': {
+                'enabled': True,
+                'options': [],
+            },
+        }
+        yaml_config = create_load(config_data)()[0]
+        config = ConfigWrapper(
+                version=self.version_sphinx, yaml_config=yaml_config)
+        python_env = Virtualenv(
+            version=self.version_sphinx,
+            build_env=self.build_env_mock,
+            config=config,
+        )
+
+        args = [
+            'python',
+            mock.ANY,  # pipenv path
+            'install',
+            '--system',
+        ]
+
+        python_env.install_from_pipfile()
+        self.build_env_mock.run.assert_called_with(
+            *args, cwd=mock.ANY, bin_path=mock.ANY
+        )
+
+    def test_pipenv_install_with_options(self):
+        options = [
+            '--dev',
+            '--skip-lock'
+        ]
+        config_data = {
+            'pipenv': {
+                'enabled': True,
+                'options': options,
+            },
+        }
+        yaml_config = create_load(config_data)()[0]
+        config = ConfigWrapper(
+            version=self.version_sphinx, yaml_config=yaml_config)
+        python_env = Virtualenv(
+            version=self.version_sphinx,
+            build_env=self.build_env_mock,
+            config=config,
+        )
+
+        args = [
+            'python',
+            mock.ANY,  # pipenv path
+            'install',
+            '--system',
+        ]
+        args.extend(options)
+
+        python_env.install_from_pipfile()
+        self.build_env_mock.run.assert_called_with(
+            *args, cwd=mock.ANY, bin_path=mock.ANY
+        )
+
 
 class AutoWipeEnvironmentBase(object):
     fixtures = ['test_data']


### PR DESCRIPTION
Hi!

I have a patch here for #3181. I went into some detail of my thought process on that issue, so I will do a quick summary of what I've done in this patch:
 - A new `pipenv` section in the top level of the YAML configuration, with keys `enabled` (bool) and `options` (list of strings). Here is an example:
    ```yaml
    pipenv:
        enabled: True
        options:
        - "--dev"
        - "--ignore-pipfile"
    ```
 - If `pipenv.enabled` is True, `pipenv==2018.5.18` (the current latest version) will be installed along with the core requirements
 - If `pipenv.enabled` is True, whilst setting up the python environment, *after* installing the user requirements and *before* installing the package, the `pipenv install --system {pipenv.options}` command will be run.

### Notes
- I have a patch ready for the readthedocs-build repository to go along with this one, should the green light be given here.
- As of right now, I have not written documentation for this feature, I wanted to get some feedback on this implementation first :smiley:

Thank you maintainers for the work you put into this wonderful service :heart: