### PR TITLE
Fix triggering a build for a skipped project

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -168,6 +168,11 @@ def trigger_build(project, version=None, record=True, force=False):
         force,
         immutable=True,
     )
+
+    if update_docs_task is None:
+        # Current project is skipped
+        return None
+
     return update_docs_task.apply_async()
 
 


### PR DESCRIPTION
I introduced a bug when doing the rework of trigger_build and prepare_build.

This PR skip the build properly when `Project.skip=True` keeping the same behavior.