### PR TITLE
Revert "Merge pull request #4206 from FlorianKuckelkorn/fix/pip-breaking-change"

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -253,7 +253,7 @@ class Virtualenv(PythonEnvironment):
             'python',
             self.venv_bin(filename='pip'),
             'install',
-            '--only-binary=:all:',
+            '--use-wheel',
             '--upgrade',
             '--cache-dir',
             self.project.pip_cache_path,

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1137,7 +1137,7 @@ class TestPythonEnvironment(TestCase):
             'python',
             mock.ANY,  # pip path
             'install',
-            '--only-binary=:all:',
+            '--use-wheel',
             '--upgrade',
             '--cache-dir',
             mock.ANY,  # cache path


### PR DESCRIPTION
This reverts commit b6de0c4a52ec082e068bda7dae828ec326e951d8, reversing
changes made to 08beab1f9def7c201845fea894880f7b13da9140.

Ref #4206

This breaks because packages with no binary fail to install. This doesn't seem
to be the functionality that we want. `--use-wheel` used a wheel and backed
down to source packages