### PR TITLE
Wrap notifications HTML code into a block

### DIFF
--- a/readthedocs/templates/401.html
+++ b/readthedocs/templates/401.html
@@ -10,6 +10,8 @@
   {% include "error_header.html" %}
 {% endblock %}
 
+{% block notify %}{% endblock %}
+
 {# Hide the language select form so we don't set a CSRF cookie #}
 {% block language-select-form %}{% endblock %}
 

--- a/readthedocs/templates/404.html
+++ b/readthedocs/templates/404.html
@@ -10,6 +10,8 @@
   {% include "error_header.html" %}
 {% endblock %}
 
+{% block notify %}{% endblock %}
+
 {# Hide the language select form so we don't set a CSRF cookie #}
 {% block language-select-form %}{% endblock %}
 

--- a/readthedocs/templates/500.html
+++ b/readthedocs/templates/500.html
@@ -1,13 +1,15 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-    {% block title %}
-      {% trans "Server Error" %}
-    {% endblock %}
+{% block title %}
+  {% trans "Server Error" %}
+{% endblock %}
 
-    {% block header-wrapper %}
-      {% include "error_header.html" %}
-    {% endblock %}
+{% block header-wrapper %}
+  {% include "error_header.html" %}
+{% endblock %}
+
+{% block notify %}{% endblock %}
 
 {# Hide the language select form so we don't set a CSRF cookie #}
 {% block language-select-form %}{% endblock %}

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -84,15 +84,19 @@
     <div id="content">
       <div class="wrapper">
 
-        {% if messages %}
-          <ul class="notifications">
-            {% for message in messages %}
-              <li class="notification notification-{{ message.level }}" {% if message.pk %}data-dismiss-url="{% url 'message_mark_read' message.pk %}{% endif %}">
-                {{ message }}
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
+        <!-- BEGIN notify -->
+        {% block notify %}
+          {% if messages %}
+            <ul class="notifications">
+              {% for message in messages %}
+                <li class="notification notification-{{ message.level }}" {% if message.pk %}data-dismiss-url="{% url 'message_mark_read' message.pk %}{% endif %}">
+                  {{ message }}
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% endblock %}
+        <!-- END notify -->
 
         {% block content-header %}
         {% endblock %}


### PR DESCRIPTION
This block is override in error pages to be none and do not show notifications on these pages.

Related work in corporate site https://github.com/rtfd/readthedocs-corporate/pull/356