### PR TITLE
doc_builder: clarify sphinx backend append_conf docstring

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -150,7 +150,7 @@ class BaseSphinx(BaseBuilder):
         return data
 
     def append_conf(self, **__):
-        """Modify given ``conf.py`` file from a whitelisted user's project."""
+        """Find or create a ``conf.py`` with a rendered ``doc_builder/conf.py.tmpl`` appended"""
         try:
             self.version.get_conf_py_path()
         except ProjectConfigurationError:


### PR DESCRIPTION
The idea is to put emphasis on the fact that conf.py.tmpl is key as extension point for people running the platform.