### PR TITLE
Use PATHs to call clear_artifacts

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -157,7 +157,7 @@ def project_version_detail(request, project_slug, version_slug):
             if 'active' in form.changed_data and version.active is False:
                 log.info('Removing files for version %s', version.slug)
                 broadcast(
-                    type='app', task=tasks.clear_artifacts, args=[version.pk])
+                    type='app', task=tasks.clear_artifacts, args=[version.get_artifact_paths()])
                 version.built = False
                 version.save()
         url = reverse('project_version_list', args=[project.slug])
@@ -649,7 +649,7 @@ def project_version_delete_html(request, project_slug, version_slug):
     if not version.active:
         version.built = False
         version.save()
-        broadcast(type='app', task=tasks.clear_artifacts, args=[version.pk])
+        broadcast(type='app', task=tasks.clear_artifacts, args=[version.get_artifact_paths()])
     else:
         return HttpResponseBadRequest(
             "Can't delete HTML for an active version.")

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -60,14 +60,14 @@ class TestCeleryBuilding(RTDTestCase):
         directory = self.project.get_production_media_path(type_='pdf', version_slug=version.slug)
         os.makedirs(directory)
         self.assertTrue(exists(directory))
-        result = tasks.clear_artifacts.delay(version_pk=version.pk)
+        result = tasks.clear_artifacts.delay(paths=version.get_artifact_paths())
         self.assertTrue(result.successful())
         self.assertFalse(exists(directory))
 
         directory = version.project.rtd_build_path(version=version.slug)
         os.makedirs(directory)
         self.assertTrue(exists(directory))
-        result = tasks.clear_artifacts.delay(version_pk=version.pk)
+        result = tasks.clear_artifacts.delay(paths=version.get_artifact_paths())
         self.assertTrue(result.successful())
         self.assertFalse(exists(directory))
 


### PR DESCRIPTION
Use a list of PATHs Instead of using a ``Version.pk`` when calling `clear_artifacts`. This is because in the ``Version.delete`` method, the Version object is removed immediately after broadcasting the ``clear_artifacts`` task and that could produce a race condition.

With this change, we calculate all the PATHs needed _before_ broadcasting the task and _before_ deleting the object from the database.