### PR TITLE
MkDocs yaml issue with custom_dir theme option comment

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -221,6 +221,11 @@ class BaseMkdocs(BaseBuilder):
             # Full nested theme config (the new configuration)
             return theme_setting.get('name') or self.READTHEDOCS_THEME_NAME
 
+        # TODO: this is not the same behavior than before. Now, with a theme:
+        # custom_dir: citrix it will return `readthedocs` while previously it
+        # was returning the theme_dir as theme_name:
+        # https://github.com/rtfd/readthedocs.org/commit/538413cf9f31be96c09f7c44e4832561cd00b0d9#diff-ccc6f61d1c02f524ab7362ee8749ba4bL125
+
         if theme_setting:
             # A string which is the name of the theme
             return theme_setting


### PR DESCRIPTION
This is **not a real PR** but a way to mark in the code where the problem is and do not forget about this issue. Although, Maybe is a non-issue.

Just want to reflect that the behavior changed in this PR https://github.com/rtfd/readthedocs.org/pull/4041 and it could affect some configs at some point.

> I found this while researching about a project with a custom MkDocs theme where the content of the output was not included with MkDocs 0.17 but it was with 0.15