### PR TITLE
Fix issues building static assets

### DIFF
--- a/docs/development/standards.rst
+++ b/docs/development/standards.rst
@@ -63,9 +63,6 @@ To install these tools and dependencies::
 
     npm install
 
-This will install locally to the project, not globally. You can install globally
-if you wish, otherwise make sure ``node_modules/.bin`` is in your PATH.
-
 Next, install front end dependencies::
 
     bower install
@@ -79,18 +76,23 @@ source file that will compile over your changes.
 To test changes while developing, which will watch source files for changes and
 compile as necessary, you can run `Gulp`_ with our development target::
 
-    gulp dev
+    npm run dev
 
 Once you are satisfied with your changes, finalize the bundles (this will
 minify library sources)::
 
-    gulp build
+    npm run build
 
 If you updated any of our vendor libraries, compile those::
 
-    gulp vendor
+    npm run vendor
 
 Make sure to check in both files under ``static`` and ``static-src``.
+
+.. note::
+
+    We run Gulp  through an ``npm`` script in order to ensure
+    that the correct version from ``package.json`` is used.
 
 Making Changes
 --------------

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.0.1",
   "description": "Read the Docs build dependencies",
   "author": "Anthony Johnson <anthony@readthedocs.com>",
+  "scripts": {
+    "build": "gulp build",
+    "dev": "gulp dev",
+    "lint": "gulp lint",
+    "vendor": "gulp vendor"
+  },
   "dependencies": {
     "bowser": "^1.9.3",
     "cssfilter": "0.0.8",
@@ -22,12 +28,12 @@
     "gulp-less": "^3.0.3",
     "gulp-rename": "^1.2.2",
     "gulp-run": "^1.6.6",
-    "gulp-uglify": "^1.2.0",
+    "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.3",
     "gulp-watch": "^4.3.3",
     "less": "^2.7.3",
-    "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-buffer": "^1.0.1",
+    "vinyl-source-stream": "^2.0.0"
   },
   "resolutions": {
     "natives": "1.1.3"


### PR DESCRIPTION
This makes a few changes to how our static assets are built that fixes some version incompatibility issues.

* Run `gulp` through an NPM script which ensures that the version from `node_modules/.bin/` is used
* Upgrade vinyl and gulp-uglify

## Testing

After pulling these changes, you'll need to run 

    $ npm install               # updates dependencies
    $ npm run build             # outputs compiled files

After running this, `git status` should show the following as modified (at least):

	modified:   readthedocs/builds/static/builds/js/detail.js
	modified:   readthedocs/core/static/core/js/readthedocs-doc-embed.js
	modified:   readthedocs/core/static/core/js/site.js
	modified:   readthedocs/gold/static/gold/js/gold.js
	modified:   readthedocs/projects/static/projects/js/import.js
	modified:   readthedocs/projects/static/projects/js/tools.js

I tested this under a couple different Node/NPM version combinations:

* Node v10.5.0 with NPM 6.1.0 (latest released version)
* Node v8.11.3 with NPM 5.6.0 (latest LTS version)

Fixes #4280