### PR TITLE
Use "npm run lint" from tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install --lts
   - nvm use --lts
-  - npm install -g bower gulp
+  - npm install -g bower
   - npm install
   - bower install
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,9 @@ commands =
     --die-on-tool-error {posargs}
 
 [testenv:eslint]
-description = run the JavaScript linter (requires gulp installed)
+description = run the JavaScript linter (requires `npm install`)
 commands =
-    gulp lint
+    npm run lint
 
 [testenv:coverage]
 description = run test suite with code coverage for the application with {basepython}


### PR DESCRIPTION
Gulp doesn't need to be globally installed or the PATH tweaked in order to run `eslint` tests. The NPM scripts will use the correct gulp installed as part of `npm install`.