### PR TITLE
Update to Django 1.10

### DIFF
--- a/readthedocs/core/fixtures/eric.json
+++ b/readthedocs/core/fixtures/eric.json
@@ -12,7 +12,7 @@
             "last_login": "2010-08-14 01:51:05",
             "groups": [],
             "user_permissions": [],
-            "password": "sha1$035cb$156ad6cb44332fb4f24bcb634142a67435be0b37",
+            "password": "pbkdf2_sha256$30000$Vs87OlKZEzCb$nUw1o5pGQw7ff/QhnleSpUOupBaT1DogZrVaoZyQRyc=",
             "email": "e@e.co",
             "date_joined": "2010-08-14 01:50:58"
         }
@@ -30,7 +30,7 @@
             "last_login": "2010-08-14 01:51:05",
             "groups": [],
             "user_permissions": [],
-            "password": "sha1$035cb$156ad6cb44332fb4f24bcb634142a67435be0b37",
+            "password": "pbkdf2_sha256$30000$Vs87OlKZEzCb$nUw1o5pGQw7ff/QhnleSpUOupBaT1DogZrVaoZyQRyc=",
             "email": "e@etest.co",
             "date_joined": "2010-08-14 01:50:58"
         }
@@ -48,7 +48,7 @@
             "last_login": "2010-08-14 01:51:05",
             "groups": [],
             "user_permissions": [],
-            "password": "sha1$035cb$156ad6cb44332fb4f24bcb634142a67435be0b37",
+            "password": "pbkdf2_sha256$30000$Vs87OlKZEzCb$nUw1o5pGQw7ff/QhnleSpUOupBaT1DogZrVaoZyQRyc=",
             "email": "e@e.co",
             "date_joined": "2010-08-14 01:50:58"
         }

--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -1,19 +1,21 @@
 """Middleware for core app."""
 
-from __future__ import absolute_import
-from builtins import object
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals)
+
 import logging
 
-from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import cache
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
-from django.core.urlresolvers import set_urlconf, get_urlconf
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.urlresolvers import get_urlconf, set_urlconf
 from django.http import Http404, HttpResponseBadRequest
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.translation import ugettext_lazy as _
 
 from readthedocs.core.utils import cname_to_slug
-from readthedocs.projects.models import Project, Domain
+from readthedocs.projects.models import Domain, Project
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +32,7 @@ SINGLE_VERSION_URLCONF = getattr(
 )
 
 
-class SubdomainMiddleware(object):
+class SubdomainMiddleware(MiddlewareMixin):
 
     """Middleware to display docs for non-dashboard domains."""
 
@@ -138,12 +140,12 @@ class SubdomainMiddleware(object):
         return response
 
 
-class SingleVersionMiddleware(object):
+class SingleVersionMiddleware(MiddlewareMixin):
 
     """
     Reset urlconf for requests for 'single_version' docs.
 
-    In settings.MIDDLEWARE_CLASSES, SingleVersionMiddleware must follow after
+    In settings.MIDDLEWARE, SingleVersionMiddleware must follow after
     SubdomainMiddleware.
     """
 
@@ -192,7 +194,7 @@ class SingleVersionMiddleware(object):
 
 
 # Forked from old Django
-class ProxyMiddleware(object):
+class ProxyMiddleware(MiddlewareMixin):
 
     """
     Middleware that sets REMOTE_ADDR based on HTTP_X_FORWARDED_FOR, if the.

--- a/readthedocs/projects/fixtures/test_data.json
+++ b/readthedocs/projects/fixtures/test_data.json
@@ -281,7 +281,7 @@
             "last_login": "2010-08-14 01:51:05",
             "groups": [],
             "user_permissions": [],
-            "password": "sha1$efaa6$17551368b198ef0dffcbf388908b7a609ec22eb1",
+            "password": "pbkdf2_sha256$30000$Vs87OlKZEzCb$nUw1o5pGQw7ff/QhnleSpUOupBaT1DogZrVaoZyQRyc=",
             "email": "e@etest.co",
             "date_joined": "2010-08-14 01:50:58"
         }

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -126,7 +126,7 @@ class CommunityBaseSettings(Settings):
     def USE_PROMOS(self):  # noqa
         return 'readthedocsext.donate' in self.INSTALLED_APPS
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         'readthedocs.core.middleware.ProxyMiddleware',
         'readthedocs.core.middleware.FooterNoSessionMiddleware',
         'django.middleware.locale.LocaleMiddleware',

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ Pygments==2.2.0
 
 mkdocs==0.17.3
 
-django==1.9.13
+django==1.10.8
 six==1.11.0
 future==0.16.0
 


### PR DESCRIPTION
Closes #4174 

Things we need to check:

- [ ] https://docs.djangoproject.com/en/2.0/releases/1.10/#removed-weak-password-hashers-from-the-default-password-hashers-setting we are using a salted sha1 to hash the user passwords (at least in our tests fixtures), these hashes were removed in 1.10. We need to check if we have these hashes in the db (I'm not sure and the docs didn't mention, but what will happen to this users? the change is automatically? Are their required to change the password?). EDIT: We need to update those https://github.com/rtfd/readthedocs.org/issues/4174#issuecomment-402035608
- [ ] we need to upgrade tastypie, because of https://docs.djangoproject.com/en/2.0/releases/1.10/#features-removed-in-1-10 (tastpie 0.13.1 uses get_all_field_names() we need to update to 0.13.2/3) This is blocked because of https://github.com/rtfd/readthedocs.org/issues/3570#issuecomment-401184862
- [x] Make sure we are using a supported postgres version https://docs.djangoproject.com/en/2.0/releases/1.10/#dropped-support-for-postgresql-9-1
- [ ] A new migration for users was added in this version