### PR TITLE
Fix deprecations in management commands

### DIFF
--- a/readthedocs/core/management/commands/clean_builds.py
+++ b/readthedocs/core/management/commands/clean_builds.py
@@ -17,17 +17,21 @@ class Command(BaseCommand):
 
     help = __doc__
 
-    option_list = BaseCommand.option_list + (
-        make_option('--days',
-                    dest='days',
-                    type='int',
-                    default=365,
-                    help='Find builds older than DAYS days, default: 365'),
-        make_option('--dryrun',
-                    action='store_true',
-                    dest='dryrun',
-                    help='Perform dry run on build cleanup'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days',
+            dest='days',
+            type='int',
+            default=365,
+            help='Find builds older than DAYS days, default: 365'
+        )
+
+        parser.add_argument(
+            '--dryrun',
+            action='store_true',
+            dest='dryrun',
+            help='Perform dry run on build cleanup'
+        )
 
     def handle(self, *args, **options):
         """Find stale builds and remove build paths"""

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -18,12 +18,14 @@ log = logging.getLogger(__name__)
 class Command(BaseCommand):
 
     help = __doc__
-    option_list = BaseCommand.option_list + (
-        make_option('-p',
-                    dest='project',
-                    default='',
-                    help='Project to index'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-p',
+            dest='project',
+            default='',
+            help='Project to index'
+        )
 
     def handle(self, *args, **options):
         """Build/index all versions or a single project's version"""

--- a/readthedocs/core/management/commands/update_repos.py
+++ b/readthedocs/core/management/commands/update_repos.py
@@ -26,22 +26,30 @@ class Command(BaseCommand):
     """Management command for rebuilding documentation on projects"""
 
     help = __doc__
-    option_list = BaseCommand.option_list + (
-        make_option('-r',
-                    action='store_true',
-                    dest='record',
-                    default=False,
-                    help='Make a Build'),
-        make_option('-f',
-                    action='store_true',
-                    dest='force',
-                    default=False,
-                    help='Force a build in sphinx'),
-        make_option('-V',
-                    dest='version',
-                    default=None,
-                    help='Build a version, or all versions')
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-r',
+            action='store_true',
+            dest='record',
+            default=False,
+            help='Make a Build'
+        )
+
+        parser.add_argument(
+            '-f',
+            action='store_true',
+            dest='force',
+            default=False,
+            help='Force a build in sphinx'
+        )
+
+        parser.add_argument(
+            '-V',
+            dest='version',
+            default=None,
+            help='Build a version, or all versions'
+        )
 
     def handle(self, *args, **options):
         record = options['record']


### PR DESCRIPTION
Adding arguments via `option_list` was deprecated in django 1.8 and it is removed en django `1.10`

https://docs.djangoproject.com/en/1.9/howto/custom-management-commands/#django.core.management.BaseCommand.option_list

Raised in https://github.com/rtfd/readthedocs.org/pull/4319#issuecomment-401957275