### PR TITLE
Disable the ad block nag for ad-free projects

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
@@ -54,7 +54,8 @@ function get() {
     var config = Object.create(configMethods);
 
     var defaults = {
-        api_host: 'https://readthedocs.org'
+        api_host: 'https://readthedocs.org',
+        ad_free: false,
     };
 
     $.extend(config, defaults, window.READTHEDOCS_DATA);

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -261,7 +261,7 @@ function init() {
         error: function (xhr, textStatus, errorThrown) {
             console.error('Error loading Read the Docs promo');
 
-            if (xhr && xhr.status === 404 && rtd.api_host === 'https://readthedocs.org') {
+            if (!rtddata.ad_free && xhr && xhr.status === 404 && rtd.api_host === 'https://readthedocs.org') {
                 adblock_admonition();
                 adblock_nag();
             }

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -175,6 +175,7 @@ class BaseMkdocs(BaseBuilder):
             'commit': self.version.project.vcs_repo(self.version.slug).commit,
             'global_analytics_code': getattr(settings, 'GLOBAL_ANALYTICS_CODE', 'UA-17997319-1'),
             'user_analytics_code': analytics_code,
+            'ad_free': self.version.project.ad_free,
         }
         data_json = json.dumps(readthedocs_data, indent=4)
         data_ctx = {


### PR DESCRIPTION
This PR disables the ad block nag if the project is ad free by setting a flag in `READTHEDOCS_DATA`. There is still a server side API call to get the ad which checks whether a user or project has gone Gold. This call can be blocked by some ad blockers.

There will be a corresponding PR in the sphinx build extensions: https://github.com/rtfd/readthedocs-sphinx-ext

Fixes #4218 for ad-free projects. Ad-free users will still need to disable their ad blocker.