### PR TITLE
Fix error in command

### DIFF
--- a/readthedocs/core/management/commands/update_repos.py
+++ b/readthedocs/core/management/commands/update_repos.py
@@ -28,6 +28,8 @@ class Command(BaseCommand):
     help = __doc__
 
     def add_arguments(self, parser):
+        parser.add_argument('slugs', nargs='+', type=str)
+
         parser.add_argument(
             '-r',
             action='store_true',
@@ -56,7 +58,7 @@ class Command(BaseCommand):
         force = options['force']
         version = options['version']
         if args:
-            for slug in args:
+            for slug in options['slugs']:
                 if version and version != "all":
                     log.info("Updating version %s for %s", version, slug)
                     for version in Version.objects.filter(project__slug=slug, slug=version):


### PR DESCRIPTION
This fix an error introduced in https://github.com/rtfd/readthedocs.org/pull/4321/files#r200705086

From django:

> Now that management commands use argparse for argument parsing, all arguments are passed in **options by default, unless you name your positional arguments to args (compatibility mode). You are encouraged to exclusively use **options for new commands.

This is the only command that I found using `args`, so the others should be fine.