### PR TITLE
Remove the UID from the GA measurement protocol

### DIFF
--- a/readthedocs/analytics/utils.py
+++ b/readthedocs/analytics/utils.py
@@ -57,9 +57,6 @@ def anonymize_user_agent(user_agent):
 
 def send_to_analytics(data):
     """Sends data to Google Analytics"""
-    if data.get('uip') and data.get('ua'):
-        data['uid'] = generate_client_id(data['uip'], data['ua'])
-
     if 'uip' in data:
         # Anonymize IP address if applicable
         data['uip'] = anonymize_ip_address(data['uip'])


### PR DESCRIPTION
This is a workaround for a [bug in the GA measurement protocol](https://issuetracker.google.com/issues/35353093). Specifically it causes events to only show up in real-time reports and not regular reports.

As a result of this workaround, there will be no handling of session data and all users will be treated as "new" as opposed to returning. Another possible workaround is to use the [`cid` parameter](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid) which would involve constructing a deterministic UUID. 
