### PR TITLE
Calrify docs about how rtd select the stable version

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -44,7 +44,7 @@ Tags and branches
 -----------------
 
 Read the Docs supports two workflows for versioning: based on tags or branches.
-If you have at least one active tag,
+If you have at least one tag,
 tags will take preference over branches when selecting the stable version.
 
 Redirects on root URLs


### PR DESCRIPTION
We don't take into account if the version is active. And we can't do that, this would break existing projects that only have `stable` and `latest` activated.

Closes #4305