### PR TITLE
Do not overwrite sphinx context variables feature

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -140,7 +140,7 @@ class BaseSphinx(BaseBuilder):
                 Feature.BUILD_JSON_ARTIFACTS_WITH_HTML
             ),
             'dont_overwrite_sphinx_context': self.project.has_feature(
-                Feature.DONT_OVERWRITE_SPINX_CONTEXT
+                Feature.DONT_OVERWRITE_SPHINX_CONTEXT
             ),
         }
 

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -139,6 +139,9 @@ class BaseSphinx(BaseBuilder):
             'generate_json_artifacts': self.project.has_feature(
                 Feature.BUILD_JSON_ARTIFACTS_WITH_HTML
             ),
+            'dont_overwrite_sphinx_context': self.project.has_feature(
+                Feature.DONT_OVERWRITE_SPINX_CONTEXT
+            ),
         }
 
         finalize_sphinx_context_data.send(

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -128,7 +128,13 @@ context = {
 {% block extra_context %}{% endblock %}
 
 if 'html_context' in globals():
+    {% if dont_overwrite_sphinx_context %}
+    for key in context:
+        if key not in html_context:
+            html_context[key] = context[key]
+    {% else %}
     html_context.update(context)
+    {% endif %}
 else:
     html_context = context
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1021,6 +1021,7 @@ class Feature(models.Model):
     PIP_ALWAYS_UPGRADE = 'pip_always_upgrade'
     SKIP_SUBMODULES = 'skip_submodules'
     BUILD_JSON_ARTIFACTS_WITH_HTML = 'build_json_artifacts_with_html'
+    DONT_OVERWRITE_SPINX_CONTEXT = 'dont_overwrite_sphinx_context'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1030,6 +1031,8 @@ class Feature(models.Model):
         (SKIP_SUBMODULES, _('Skip git submodule checkout')),
         (BUILD_JSON_ARTIFACTS_WITH_HTML, _(
             'Build the json artifacts with the html build step')),
+        (DONT_OVERWRITE_SPINX_CONTEXT, _(
+            'Do not overwrite context vars in conf.py with Read the Docs context',)),
     )
 
     projects = models.ManyToManyField(

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1021,7 +1021,7 @@ class Feature(models.Model):
     PIP_ALWAYS_UPGRADE = 'pip_always_upgrade'
     SKIP_SUBMODULES = 'skip_submodules'
     BUILD_JSON_ARTIFACTS_WITH_HTML = 'build_json_artifacts_with_html'
-    DONT_OVERWRITE_SPINX_CONTEXT = 'dont_overwrite_sphinx_context'
+    DONT_OVERWRITE_SPHINX_CONTEXT = 'dont_overwrite_sphinx_context'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1031,7 +1031,7 @@ class Feature(models.Model):
         (SKIP_SUBMODULES, _('Skip git submodule checkout')),
         (BUILD_JSON_ARTIFACTS_WITH_HTML, _(
             'Build the json artifacts with the html build step')),
-        (DONT_OVERWRITE_SPINX_CONTEXT, _(
+        (DONT_OVERWRITE_SPHINX_CONTEXT, _(
             'Do not overwrite context vars in conf.py with Read the Docs context',)),
     )
 


### PR DESCRIPTION
This adds a feature flag (default off) that changes how `html_context` variables are clobbered in `conf.py`. By default, we clobber whatever the user may have in `html_context` if it matches variable names set by Read the Docs. This changes the setting to respect what a user may have and only overwrite if the user didn't set anything.