### PR TITLE
Revert "projects: serve badge with same protocol as site"

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -89,9 +89,14 @@ class ProjectDetailView(BuildTriggerMixin, ProjectOnboardMixin, DetailView):
         context['versions'] = Version.objects.public(
             user=self.request.user, project=project)
 
+        protocol = 'http'
+        if self.request.is_secure():
+            protocol = 'https'
+
         version_slug = project.get_default_version()
 
-        context['badge_url'] = '//%s%s?version=%s' % (
+        context['badge_url'] = '%s://%s%s?version=%s' % (
+            protocol,
             settings.PRODUCTION_DOMAIN,
             reverse('project_badge', args=[project.slug]),
             project.get_default_version(),


### PR DESCRIPTION
Without a protocol users can't copy/paste the badge generated code anymore. Fixes #4337.

Is there a better solution?

Reverts rtfd/readthedocs.org#4228