### PR TITLE
core: fix MultipleObjectsReturned in views.serve.serve.docs

### DIFF
--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -201,14 +201,19 @@ def serve_docs(
     """Map existing proj, lang, version, filename views to the file format."""
     if not version_slug:
         version_slug = project.get_default_version()
+
     try:
-        version = project.versions.public(request.user).get(slug=version_slug)
+        version = project.versions.get(slug=version_slug)
     except Version.DoesNotExist:
-        # Properly raise a 404 if the version doesn't exist (or is inactive) and
-        # a 401 if it does
-        if project.versions.filter(slug=version_slug, active=True).exists():
-            return _serve_401(request, project)
         raise Http404('Version does not exist.')
+
+    # only project admins should see private versions
+    if not AdminPermission.is_member(user=request.user, obj=project):
+        if version.privacy_level == constants.PRIVATE:
+            return _serve_401(request, project)
+        if not version.active:
+            raise Http404('Version does not exist.')
+
     filename = resolve_path(
         subproject or project,  # Resolve the subproject if it exists
         version_slug=version_slug,
@@ -216,9 +221,6 @@ def serve_docs(
         filename=filename,
         subdomain=True,  # subdomain will make it a "full" path without a URL prefix
     )
-    if (version.privacy_level == constants.PRIVATE and
-            not AdminPermission.is_member(user=request.user, obj=project)):
-        return _serve_401(request, project)
     return _serve_symlink_docs(
         request,
         filename=filename,


### PR DESCRIPTION
We get this exception while trying to serve some docs:

```
MultipleObjectsReturned: get() returned more than one Version -- it returned 2!
  File "django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "readthedocs/core/views/serve.py", line 96, in inner_view
    return view_func(request, project=project, *args, **kwargs)
  File "readthedocs/core/views/serve.py", line 74, in inner_view
    return view_func(request, subproject=subproject, *args, **kwargs)
  File "readthedocs/core/views/serve.py", line 156, in serve_docs
    version = project.versions.public(request.user).get(slug=version_slug)
  File "django/db/models/query.py", line 391, in get
    (self.model._meta.object_name, num)
```


The view code looks legit at a first look but there's a huge side
effect of the user filtering in the public() method. It does not
filter the projects by user but it adds to the queryset all the
other user projects which is not what we need here.

Instead simplify the code to:
- return 404 if the requested version does not exist
- return 401 if the version is private and the user is not admin
- serve the file if the version is private and the user is a project admin

Fix #4350