### PR TITLE
More tags when logging errors to Sentry

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -450,7 +450,15 @@ class BuildEnvironment(BaseEnvironment):
                           .format(project=self.project.slug,
                                   version=self.version.slug,
                                   msg=exc_value),
-                          exc_info=True)
+                          exc_info=True,
+                          extra={
+                              'stack': True,
+                              'tags': {
+                                  'build': self.build.get('id'),
+                                  'project': self.project.slug,
+                                  'version': self.version.slug,
+                              },
+                          })
                 self.failure = exc_value
             return True
 
@@ -546,8 +554,12 @@ class BuildEnvironment(BaseEnvironment):
                     str(self.failure),
                     extra={
                         'stack': True,
-                        'tags': {'build': self.build['id']},
-                    }
+                        'tags': {
+                            'build': self.build.get('id'),
+                            'project': self.project.slug,
+                            'version': self.version.slug,
+                        },
+                    },
                 )
                 self.failure = BuildEnvironmentError(
                     BuildEnvironmentError.GENERIC_WITH_BUILD_ID.format(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -346,7 +346,14 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         except Exception as e:  # noqa
             log.exception(
                 'An unhandled exception was raised during build setup',
-                extra={'tags': {'build': build_pk}}
+                extra={
+                    'stack': True,
+                    'tags': {
+                        'build': build_pk,
+                        'project': self.project.slug,
+                        'version': self.version.slug,
+                    },
+                },
             )
             self.setup_env.failure = BuildEnvironmentError(
                 BuildEnvironmentError.GENERIC_WITH_BUILD_ID.format(
@@ -363,7 +370,14 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             except Exception as e:  # noqa
                 log.exception(
                     'An unhandled exception was raised during project build',
-                    extra={'tags': {'build': build_pk}}
+                    extra={
+                        'stack': True,
+                        'tags': {
+                            'build': build_pk,
+                            'project': self.project.slug,
+                            'version': self.version.slug,
+                        },
+                    },
                 )
                 self.build_env.failure = BuildEnvironmentError(
                     BuildEnvironmentError.GENERIC_WITH_BUILD_ID.format(


### PR DESCRIPTION
This helps us to filter different kind of random/unhandled errors by tags and make debugging easier.