### PR TITLE
Make `get_version` usable from a specified path

### DIFF
--- a/readthedocs/__init__.py
+++ b/readthedocs/__init__.py
@@ -9,14 +9,15 @@ from future.moves.configparser import RawConfigParser
 from readthedocs.worker import app  # noqa
 
 
-def get_version():
+def get_version(setupcfg_path):
     """Return package version from setup.cfg."""
-    setupcfg_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '..', 'setup.cfg'),
-    )
     config = RawConfigParser()
     config.read(setupcfg_path)
     return config.get('metadata', 'version')
 
 
-__version__ = get_version()
+__version__ = get_version(
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', 'setup.cfg'),
+    ),
+)

--- a/readthedocs/analytics/tasks.py
+++ b/readthedocs/analytics/tasks.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from readthedocs import get_version
+import readthedocs
 from readthedocs.worker import app
 
 from .utils import send_to_analytics
@@ -21,7 +21,7 @@ DEFAULT_PARAMETERS = {
 
     # Application info
     'an': 'Read the Docs',
-    'av': get_version(),    # App version
+    'av': readthedocs.__version__,    # App version
 }
 
 


### PR DESCRIPTION
Allow to use the `get_version` util by passing a path to a standard `setup.cfg` file instead of guess it as a relative path from current `__file__`.