### PR TITLE
Set full `source_file` path for default configuration

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -4,6 +4,8 @@
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
+from os import path
+
 from readthedocs.config import BuildConfig, ConfigError, InvalidConfig
 from readthedocs.config import load as load_config
 
@@ -68,7 +70,7 @@ def load_yaml_config(version):
         config = BuildConfig(
             env_config=env_config,
             raw_config={},
-            source_file='empty',
+            source_file=path.join(checkout_path, 'empty'),
             source_position=0,
         )
         config.validate()

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1153,7 +1153,10 @@ class TestPythonEnvironment(TestCase):
             if arg is not mock.ANY:
                 self.assertTrue(arg_mock.startswith(arg))
 
-    def test_install_core_requirements_sphinx(self):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_install_core_requirements_sphinx(self, checkout_path):
+        tmpdir = tempfile.mkdtemp()
+        checkout_path.return_value = tmpdir
         python_env = Virtualenv(
             version=self.version_sphinx,
             build_env=self.build_env_mock,
@@ -1171,7 +1174,10 @@ class TestPythonEnvironment(TestCase):
         self.build_env_mock.run.assert_called_once()
         self.assertArgsStartsWith(args, self.build_env_mock.run)
 
-    def test_install_core_requirements_mkdocs(self):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_install_core_requirements_mkdocs(self, checkout_path):
+        tmpdir = tempfile.mkdtemp()
+        checkout_path.return_value = tmpdir
         python_env = Virtualenv(
             version=self.version_mkdocs,
             build_env=self.build_env_mock
@@ -1187,7 +1193,8 @@ class TestPythonEnvironment(TestCase):
         self.build_env_mock.run.assert_called_once()
         self.assertArgsStartsWith(args, self.build_env_mock.run)
 
-    def test_install_user_requirements(self):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_install_user_requirements(self, checkout_path):
         """
         If a projects does not specify a requirements file,
         RTD will choose one automatically.
@@ -1198,6 +1205,8 @@ class TestPythonEnvironment(TestCase):
         - ``pip_requirements.txt``
         - ``requirements.txt``
         """
+        tmpdir = tempfile.mkdtemp()
+        checkout_path.return_value = tmpdir
         self.build_env_mock.project = self.project_sphinx
         self.build_env_mock.version = self.version_sphinx
         python_env = Virtualenv(
@@ -1267,7 +1276,10 @@ class TestPythonEnvironment(TestCase):
             python_env.install_user_requirements()
         self.build_env_mock.run.assert_not_called()
 
-    def test_install_core_requirements_sphinx_conda(self):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_install_core_requirements_sphinx_conda(self, checkout_path):
+        tmpdir = tempfile.mkdtemp()
+        checkout_path.return_value = tmpdir
         python_env = Conda(
             version=self.version_sphinx,
             build_env=self.build_env_mock,
@@ -1307,7 +1319,10 @@ class TestPythonEnvironment(TestCase):
             mock.call(*args_pip, bin_path=mock.ANY)
         ])
 
-    def test_install_core_requirements_mkdocs_conda(self):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_install_core_requirements_mkdocs_conda(self, checkout_path):
+        tmpdir = tempfile.mkdtemp()
+        checkout_path.return_value = tmpdir
         python_env = Conda(
             version=self.version_mkdocs,
             build_env=self.build_env_mock,
@@ -1343,7 +1358,10 @@ class TestPythonEnvironment(TestCase):
             mock.call(*args_pip, bin_path=mock.ANY)
         ])
 
-    def test_install_user_requirements_conda(self):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_install_user_requirements_conda(self, checkout_path):
+        tmpdir = tempfile.mkdtemp()
+        checkout_path.return_value = tmpdir
         python_env = Conda(
             version=self.version_sphinx,
             build_env=self.build_env_mock,


### PR DESCRIPTION
This was introduced in #4298. I can't replicate this locally (I think this is something to do with the builds being executed in another server). But debugging this I think I found the problem.

Before #4298 the `requirements_file` wasn't validated, but now it is. For the validation, we use the dir name of the `source_file`. This was `''` (empty/cwd). To fix this I'm passing the full `source_file` as the checkout path of the build.

This only affects people using the web interface to set the requirements file.

As workaround users can use a configuration file to set the `requirements_file` setting

Fix #4378 