### PR TITLE
Do not access database from builds to check ad-free

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -172,7 +172,7 @@ class BaseMkdocs(BaseBuilder):
             'docroot': docs_dir,
             'source_suffix': ".md",
             'api_host': getattr(settings, 'PUBLIC_API_URL', 'https://readthedocs.org'),
-            'ad_free': self.project.ad_free or self.project.gold_owners.exists(),
+            'ad_free': not self.project.show_advertising,
             'commit': self.version.project.vcs_repo(self.version.slug).commit,
             'global_analytics_code': getattr(settings, 'GLOBAL_ANALYTICS_CODE', 'UA-17997319-1'),
             'user_analytics_code': analytics_code,

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -115,7 +115,7 @@ context = {
     'using_theme': (html_theme == "default"),
     'new_theme': (html_theme == "sphinx_rtd_theme"),
     'source_suffix': SUFFIX,
-    'ad_free': {% if project.gold_owners.exists or project.ad_free %}True{% else %}False{% endif %},
+    'ad_free': {% if project.show_advertising %}False{% else %}True{% endif %},
     'user_analytics_code': '{{ project.analytics_code|default_if_none:'' }}',
     'global_analytics_code': '{{ settings.GLOBAL_ANALYTICS_CODE }}',
     'commit': {% if project.repo_type == 'git' %}'{{ commit|slice:"8" }}'{% else %}'{{ commit }}'{% endif %},

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -849,6 +849,18 @@ class Project(models.Model):
         """
         return positive if self.has_feature(feature) else negative
 
+    @property
+    def show_advertising(self):
+        """
+        Whether this project is ad-free
+
+        :return: ``True`` if advertising should be shown and ``False`` otherwise
+        """
+        if self.ad_free or self.gold_owners.exists():
+            return False
+
+        return True
+
 
 class APIProject(Project):
 

--- a/readthedocs/restapi/serializers.py
+++ b/readthedocs/restapi/serializers.py
@@ -43,6 +43,11 @@ class ProjectAdminSerializer(ProjectSerializer):
         slug_field='feature_id',
     )
 
+    show_advertising = serializers.SerializerMethodField()
+
+    def get_show_advertising(self, obj):
+        return obj.show_advertising
+
     class Meta(ProjectSerializer.Meta):
         fields = ProjectSerializer.Meta.fields + (
             'enable_epub_build',
@@ -62,7 +67,7 @@ class ProjectAdminSerializer(ProjectSerializer):
             'features',
             'has_valid_clone',
             'has_valid_webhook',
-            'ad_free',
+            'show_advertising',
         )
 
 

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -906,7 +906,6 @@ class APIVersionTests(TestCase):
             'id': 18,
             'active': True,
             'project': {
-                'ad_free': False,
                 'analytics_code': None,
                 'canonical_url': 'http://readthedocs.org/docs/pip/en/latest/',
                 'cdn_enabled': False,
@@ -932,6 +931,7 @@ class APIVersionTests(TestCase):
                 'repo': 'https://github.com/pypa/pip',
                 'repo_type': 'git',
                 'requirements_file': None,
+                'show_advertising': True,
                 'skip': False,
                 'slug': 'pip',
                 'suffix': '.rst',


### PR DESCRIPTION
There was an issue with the previous fix in https://github.com/rtfd/readthedocs.org/pull/4329 which resulted in builders trying to access the database (`project.gold_owners.exists` makes a query). The builders don't have access to the database so this was a problem. Instead, this returns a `show_advertising` field on the API which checks both `project.ad_free` and `project.gold_owners.exists`.

The end result is that ad-free projects -- whether marked ad-free at the database level or because they have a Gold sponsor -- should not show the ad-block nag.

Fixes #4218