### PR TITLE
Fix a proxy model bug related to ad-free

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -884,7 +884,6 @@ class APIProject(Project):
 
     def __init__(self, *args, **kwargs):
         self.features = kwargs.pop('features', [])
-        self.ad_free = (not kwargs.pop('show_advertising', True))
         # These fields only exist on the API return, not on the model, so we'll
         # remove them to avoid throwing exceptions due to unexpected fields
         for key in ['users', 'resource_uri', 'absolute_url', 'downloads',
@@ -894,6 +893,9 @@ class APIProject(Project):
             except KeyError:
                 pass
         super(APIProject, self).__init__(*args, **kwargs)
+
+        # Overwrite the database property with the value from the API
+        self.ad_free = (not kwargs.pop('show_advertising', True))
 
     def save(self, *args, **kwargs):
         return 0

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -884,6 +884,7 @@ class APIProject(Project):
 
     def __init__(self, *args, **kwargs):
         self.features = kwargs.pop('features', [])
+        self.ad_free = (not kwargs.pop('show_advertising', True))
         # These fields only exist on the API return, not on the model, so we'll
         # remove them to avoid throwing exceptions due to unexpected fields
         for key in ['users', 'resource_uri', 'absolute_url', 'downloads',
@@ -899,6 +900,11 @@ class APIProject(Project):
 
     def has_feature(self, feature_id):
         return feature_id in self.features
+
+    @property
+    def show_advertising(self):
+        """Whether this project is ad-free (don't access the database)"""
+        return not self.ad_free
 
 
 @python_2_unicode_compatible

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -574,13 +574,15 @@ class APITests(TestCase):
         api_project = APIProject(**project_data)
         self.assertEqual(api_project.slug, 'test-project')
         self.assertEquals(api_project.features, [])
-        self.assertEqual(api_project.ad_free, False)
+        self.assertFalse(api_project.ad_free)
+        self.assertTrue(api_project.show_advertising)
 
         project_data['features'] = ['test-feature']
         project_data['show_advertising'] = False
         api_project = APIProject(**project_data)
         self.assertEquals(api_project.features, ['test-feature'])
-        self.assertEqual(api_project.ad_free, True)
+        self.assertTrue(api_project.ad_free)
+        self.assertFalse(api_project.show_advertising)
 
 
 class APIImportTests(TestCase):

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -573,14 +573,14 @@ class APITests(TestCase):
 
         api_project = APIProject(**project_data)
         self.assertEqual(api_project.slug, 'test-project')
-        self.assertEquals(api_project.features, [])
+        self.assertEqual(api_project.features, [])
         self.assertFalse(api_project.ad_free)
         self.assertTrue(api_project.show_advertising)
 
         project_data['features'] = ['test-feature']
         project_data['show_advertising'] = False
         api_project = APIProject(**project_data)
-        self.assertEquals(api_project.features, ['test-feature'])
+        self.assertEqual(api_project.features, ['test-feature'])
         self.assertTrue(api_project.ad_free)
         self.assertFalse(api_project.show_advertising)
 

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -20,7 +20,7 @@ from rest_framework.test import APIClient
 from readthedocs.builds.models import Build, BuildCommandResult, Version
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
-from readthedocs.projects.models import Feature, Project
+from readthedocs.projects.models import Feature, Project, APIProject
 from readthedocs.restapi.views.integrations import GitHubWebhookView
 from readthedocs.restapi.views.task_views import get_status_data
 
@@ -563,6 +563,24 @@ class APITests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.data['results']), 25)  # page_size
         self.assertIn('?page=2', resp.data['next'])
+
+    def test_init_api_project(self):
+        project_data = {
+            'name': 'Test Project',
+            'slug': 'test-project',
+            'show_advertising': True,
+        }
+
+        api_project = APIProject(**project_data)
+        self.assertEqual(api_project.slug, 'test-project')
+        self.assertEquals(api_project.features, [])
+        self.assertEqual(api_project.ad_free, False)
+
+        project_data['features'] = ['test-feature']
+        project_data['show_advertising'] = False
+        api_project = APIProject(**project_data)
+        self.assertEquals(api_project.features, ['test-feature'])
+        self.assertEqual(api_project.ad_free, True)
 
 
 class APIImportTests(TestCase):


### PR DESCRIPTION
This correctly initializes and tests the APIProject proxy model with respect to ad-free projects.

- Correctly set ad-free status based on data in the API response
- Adds a pretty minimal test for initializing the APIProject proxy models

Related to #4387

This has been edited...