### PR TITLE
Add client ID to Google Analytics requests

### DIFF
--- a/readthedocs/analytics/utils.py
+++ b/readthedocs/analytics/utils.py
@@ -57,6 +57,9 @@ def anonymize_user_agent(user_agent):
 
 def send_to_analytics(data):
     """Sends data to Google Analytics"""
+    if data.get('uip') and data.get('ua'):
+        data['cid'] = generate_client_id(data['uip'], data['ua'])
+
     if 'uip' in data:
         # Anonymize IP address if applicable
         data['uip'] = anonymize_ip_address(data['uip'])


### PR DESCRIPTION
This almost reverts #4347 but is slightly different as it sends a client ID instead of a user ID.

Google's [documentation](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid) says that the client ID should be a UUID but in my testing and in Google's own JavaScript implementation this works without that being the case.