### PR TITLE
[Fix #4407] Port Project Search for Elasticsearch 6.x

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -28,6 +28,7 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version
 from readthedocs.builds.views import BuildTriggerMixin
 from readthedocs.projects.models import ImportedFile, Project
+from readthedocs.search.documents import PageDocument
 from readthedocs.search.indexes import PageIndex
 from readthedocs.search.views import LOG_TEMPLATE
 
@@ -205,6 +206,7 @@ def elastic_project_search(request, project_slug):
     project = get_object_or_404(queryset, slug=project_slug)
     version_slug = request.GET.get('version', LATEST)
     query = request.GET.get('q', None)
+    results = None
     if query:
         user = ''
         if request.user.is_authenticated():
@@ -220,48 +222,11 @@ def elastic_project_search(request, project_slug):
             ))
 
     if query:
-
-        kwargs = {}
-        body = {
-            'query': {
-                'bool': {
-                    'should': [
-                        {'match': {'title': {'query': query, 'boost': 10}}},
-                        {'match': {'headers': {'query': query, 'boost': 5}}},
-                        {'match': {'content': {'query': query}}},
-                    ]
-                }
-            },
-            'highlight': {
-                'fields': {
-                    'title': {},
-                    'headers': {},
-                    'content': {},
-                }
-            },
-            'fields': ['title', 'project', 'version', 'path'],
-            'filter': {
-                'and': [
-                    {'term': {'project': project_slug}},
-                    {'term': {'version': version_slug}},
-                ]
-            },
-            'size': 50,  # TODO: Support pagination.
-        }
-
-        # Add routing to optimize search by hitting the right shard.
-        kwargs['routing'] = project_slug
-
-        results = PageIndex().search(body, **kwargs)
-    else:
-        results = {}
-
-    if results:
-        # pre and post 1.0 compat
-        for num, hit in enumerate(results['hits']['hits']):
-            for key, val in list(hit['fields'].items()):
-                if isinstance(val, list):
-                    results['hits']['hits'][num]['fields'][key] = val[0]
+        req = PageDocument.simple_search(query=query)
+        filtered_query = (req.filter('term', project=project.slug)
+                             .filter('term', version=version_slug))
+        paginated_query = filtered_query[:50]
+        results = paginated_query.execute()
 
     return render(
         request,

--- a/readthedocs/templates/search/elastic_project_search.html
+++ b/readthedocs/templates/search/elastic_project_search.html
@@ -44,14 +44,16 @@
               <div class="module-list-wrapper">
 
                 <ul>
-                  {% for result in results.hits.hits %}
+                  {% for result in results %}
                         <li class="module-item">
                           <p class="module-item-title">
-                            <a href="{% doc_url project result.fields.version result.fields.path %}?highlight={{ query }}">{{ result.fields.project }} - {{ result.fields.title|safe }}</a>
+                            <a href="{% doc_url project result.version result.path %}?highlight={{ query }}">{{ result.project }} - {{ result.title|safe }}</a>
                           </p>
-                          <p>
-                            {{ result.highlight.content.0|safe }}
-                          </p>
+                          {% for fragment in result.meta.highlight.content|slice:":3" %}
+                            <p>
+                              {{ fragment|safe }}
+                            </p>
+                          {% endfor %}
                         </li>
                   {% empty %}
                     <li class="module-item"><span class="quiet">{% trans "No results found. Bummer." %}</span></li>


### PR DESCRIPTION
This was missed from our intial stage while we port our search infra to Elasticsearch 6.x
Its similar to the File Search that we ported in #4211
Its needed to be merged before we deploy new search to production.
This fixes #4407. @ericholscher r?