### PR TITLE
Fix broken link

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -144,7 +144,7 @@ If you have any more trouble, don't hesitate to reach out to us. The :doc:`suppo
 .. _install Sphinx: http://sphinx-doc.org/latest/install.html
 .. _install Mkdocs: http://www.mkdocs.org/#installation
 .. _reStructuredText: http://sphinx-doc.org/rest.html
-.. _this template: http://docs.writethedocs.org/guide/writing/beginners-guide-to-docs/#id1
+.. _this template: http://www.writethedocs.org/guide/writing/beginners-guide-to-docs/#id1
 .. _Sign up: http://readthedocs.org/accounts/signup
 .. _log in: http://readthedocs.org/accounts/login
 .. _dashboard: http://readthedocs.org/dashboard

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -144,8 +144,8 @@ If you have any more trouble, don't hesitate to reach out to us. The :doc:`suppo
 .. _install Sphinx: http://sphinx-doc.org/latest/install.html
 .. _install Mkdocs: http://www.mkdocs.org/#installation
 .. _reStructuredText: http://sphinx-doc.org/rest.html
-.. _this template: http://www.writethedocs.org/guide/writing/beginners-guide-to-docs/#id1
-.. _Sign up: http://readthedocs.org/accounts/signup
-.. _log in: http://readthedocs.org/accounts/login
-.. _dashboard: http://readthedocs.org/dashboard
-.. _Import: http://readthedocs.org/dashboard/import
+.. _this template: https://www.writethedocs.org/guide/writing/beginners-guide-to-docs/#id1
+.. _Sign up: https://readthedocs.org/accounts/signup
+.. _log in: https://readthedocs.org/accounts/login
+.. _dashboard: https://readthedocs.org/dashboard
+.. _Import: https://readthedocs.org/dashboard/import


### PR DESCRIPTION
All of docs.writethedocs.org gives access denied, but the content can be found at www.writethedocs.org
Someone with contacts at writethedocs.org should recommend they redirect docs to www in addition though; there's probably lots of other links out there.