### PR TITLE
Allow filtering versions by active

### DIFF
--- a/docs/api/v2.rst
+++ b/docs/api/v2.rst
@@ -168,6 +168,8 @@ Version list
     :>json array results: Array of ``Version`` objects.
 
     :query string project__slug: Narrow to the versions for a specific ``Project``
+    :query boolean active: Pass ``true`` or ``false`` to show only active or inactive versions.
+        By default, the API returns all versions.
 
 .. _api-version-detail:
 

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -233,7 +233,7 @@ class VersionViewSet(UserSelectViewSet):
     serializer_class = VersionSerializer
     admin_serializer_class = VersionAdminSerializer
     model = Version
-    filter_fields = ('project__slug',)
+    filter_fields = ('active', 'project__slug',)
 
 
 class BuildViewSetBase(UserSelectViewSet):


### PR DESCRIPTION
This allows making an API requests like:

* http://localhost:8000/api/v2/version/?project__slug=pip&active=true
* http://localhost:8000/api/v2/version/?project__slug=pip&active=false

I believe performance should be ok given this is just a boolean field.