### PR TITLE
Add SNI support for API HTTPS endpoint

### DIFF
--- a/readthedocs/api/client.py
+++ b/readthedocs/api/client.py
@@ -1,11 +1,15 @@
-"""Slumber API client"""
-from __future__ import absolute_import
+# -*- coding: utf-8 -*-
+
+"""Slumber API client."""
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals)
+
 import logging
 
-from slumber import API
-from requests import Session
 from django.conf import settings
-
+from requests import Session
+from requests_toolbelt.adapters import host_header_ssl
+from slumber import API
 
 log = logging.getLogger(__name__)
 
@@ -17,16 +21,17 @@ API_HOST = getattr(settings, 'SLUMBER_API_HOST', 'https://readthedocs.org')
 
 def setup_api():
     session = Session()
+    session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
     session.headers.update({'Host': PRODUCTION_DOMAIN})
     api_config = {
         'base_url': '%s/api/v1/' % API_HOST,
         'session': session,
     }
     if USER and PASS:
-        log.debug("Using slumber with user %s, pointed at %s", USER, API_HOST)
+        log.debug('Using slumber with user %s, pointed at %s', USER, API_HOST)
         session.auth = (USER, PASS)
     else:
-        log.warning("SLUMBER_USERNAME/PASSWORD settings are not set")
+        log.warning('SLUMBER_USERNAME/PASSWORD settings are not set')
     return API(**api_config)
 
 

--- a/readthedocs/api/client.py
+++ b/readthedocs/api/client.py
@@ -21,7 +21,7 @@ API_HOST = getattr(settings, 'SLUMBER_API_HOST', 'https://readthedocs.org')
 
 def setup_api():
     session = Session()
-    session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
+    session.mount(API_HOST, host_header_ssl.HostHeaderSSLAdapter())
     session.headers.update({'Host': PRODUCTION_DOMAIN})
     api_config = {
         'base_url': '%s/api/v1/' % API_HOST,

--- a/readthedocs/restapi/client.py
+++ b/readthedocs/restapi/client.py
@@ -1,14 +1,18 @@
+# -*- coding: utf-8 -*-
+
 """Simple client to access our API with Slumber credentials."""
 
-from __future__ import absolute_import
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals)
+
 import logging
 
-from slumber import API, serialize
 import requests
 from django.conf import settings
-from rest_framework.renderers import JSONRenderer
+from requests_toolbelt.adapters import host_header_ssl
 from rest_framework.parsers import JSONParser
-
+from rest_framework.renderers import JSONRenderer
+from slumber import API, serialize
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +24,7 @@ PASS = getattr(settings, 'SLUMBER_PASSWORD', None)
 
 class DrfJsonSerializer(serialize.JsonSerializer):
 
-    """Additional serialization help from the DRF parser/renderer"""
+    """Additional serialization help from the DRF parser/renderer."""
 
     key = 'json-drf'
 
@@ -33,6 +37,7 @@ class DrfJsonSerializer(serialize.JsonSerializer):
 
 def setup_api():
     session = requests.Session()
+    session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
     session.headers.update({'Host': PRODUCTION_DOMAIN})
     retry_adapter = requests.adapters.HTTPAdapter(max_retries=3)
     session.mount(API_HOST, retry_adapter)
@@ -43,15 +48,19 @@ def setup_api():
             serializers=[
                 serialize.JsonSerializer(),
                 DrfJsonSerializer(),
-            ]
+            ],
         ),
         'session': session,
     }
     if USER and PASS:
-        log.debug("Using slumber v2 with user %s, pointed at %s", USER, API_HOST)
+        log.debug(
+            'Using slumber v2 with user %s, pointed at %s',
+            USER,
+            API_HOST,
+        )
         session.auth = (USER, PASS)
     else:
-        log.warning("SLUMBER_USERNAME/PASSWORD settings are not set")
+        log.warning('SLUMBER_USERNAME/PASSWORD settings are not set')
     return API(**api_config)
 
 

--- a/readthedocs/restapi/client.py
+++ b/readthedocs/restapi/client.py
@@ -37,10 +37,13 @@ class DrfJsonSerializer(serialize.JsonSerializer):
 
 def setup_api():
     session = requests.Session()
-    session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
+    session.mount(
+        API_HOST,
+        host_header_ssl.HostHeaderSSLAdapter(
+            max_retries=3,
+        ),
+    )
     session.headers.update({'Host': PRODUCTION_DOMAIN})
-    retry_adapter = requests.adapters.HTTPAdapter(max_retries=3)
-    session.mount(API_HOST, retry_adapter)
     api_config = {
         'base_url': '%s/api/v2/' % API_HOST,
         'serializer': serialize.Serializer(

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -30,6 +30,7 @@ django-vanilla-views==1.0.5
 jsonfield==2.0.2
 
 requests==2.18.4
+requests-toolbelt==0.8.0
 slumber==0.7.1
 lxml==4.2.1
 defusedxml==0.5.0


### PR DESCRIPTION
This allows us to use a production internal loadbalancer without forcing
`readthedocs.org` resolves to the internal loadbalancer.