### PR TITLE
Replace old mimeparse package with python-mimeparse

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -59,7 +59,6 @@ pytz==2018.4
 beautifulsoup4==4.6.0
 Unipath==1.1
 django-kombu==0.9.4
-python-mimeparse==1.6.0
 mock==2.0.0
 
 # stripe 1.20.2 is the latest compatible with our code base (otherwise

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -59,7 +59,7 @@ pytz==2018.4
 beautifulsoup4==4.6.0
 Unipath==1.1
 django-kombu==0.9.4
-mimeparse==0.1.3
+python-mimeparse==1.6.0
 mock==2.0.0
 
 # stripe 1.20.2 is the latest compatible with our code base (otherwise


### PR DESCRIPTION
Note! These packages occupy the same namespace. You might need to uninstall
`mimeparse` and reinstall `python-mimeparse`.

Refs #3570 

### Deployment notes

The old package `mimeparse` is not py3 compatible, but `django-mailgun` brings in it's own dependency of `python-mimeparse`, which is py3 compatible. This might not affect our RS cluster, but does affect our Azure cluster. Actions required on our Azure cluster were to manually remove `mimeparse` and install `python-mimeparse`, as these packages are forks and provide the same namespace. We aren't upgrading the `django-mailgun` package here though, so might not be required for RS deployments.
