### PR TITLE
Support git unicode branches

### DIFF
--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -49,30 +49,34 @@ class TestGitBackend(RTDTestCase):
         self.dummy_conf.submodules.include = ALL
         self.dummy_conf.submodules.exclude = []
 
-    def test_parse_branches(self):
-        data = """
-        develop
-        master
-        release/2.0.0
-        origin/2.0.X
-        origin/HEAD -> origin/master
-        origin/master
-        origin/release/2.0.0
-        origin/release/foo/bar
-        """
-
-        expected_ids = [
-            ('develop', 'develop'),
-            ('master', 'master'),
-            ('release/2.0.0', 'release/2.0.0'),
-            ('origin/2.0.X', '2.0.X'),
-            ('origin/master', 'master'),
-            ('origin/release/2.0.0', 'release/2.0.0'),
-            ('origin/release/foo/bar', 'release/foo/bar'),
+    def test_git_branches(self):
+        repo_path = self.project.repo
+        default_branches = [
+            # comes from ``make_test_git`` function
+            'submodule',
+            'relativesubmodule',
+            'invalidsubmodule',
         ]
-        given_ids = [(x.identifier, x.verbose_name) for x in
-                     self.project.vcs_repo().parse_branches(data)]
-        self.assertEqual(expected_ids, given_ids)
+        branches = [
+            'develop',
+            'master',
+            '2.0.X',
+            'release/2.0.0',
+            'release/foo/bar',
+            'release-ünîø∂é',
+        ]
+        for branch in branches:
+            create_git_branch(repo_path, branch)
+
+        repo = self.project.vcs_repo()
+        # We aren't cloning the repo,
+        # so we need to hack the repo path
+        repo.working_dir = repo_path
+
+        self.assertEqual(
+            set(branches + default_branches),
+            {branch.verbose_name for branch in repo.branches},
+        )
 
     def test_git_checkout(self):
         repo = self.project.vcs_repo()
@@ -90,7 +94,7 @@ class TestGitBackend(RTDTestCase):
         repo.working_dir = repo_path
         self.assertEqual(
             set(['v01', 'v02', 'release-ünîø∂é']),
-            set(vcs.verbose_name for vcs in repo.tags)
+            {vcs.verbose_name for vcs in repo.tags},
         )
 
     def test_check_for_submodules(self):

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -124,7 +124,9 @@ class TestCeleryBuilding(RTDTestCase):
         self.assertTrue(result.successful())
 
     @patch('readthedocs.projects.tasks.api_v2')
-    def test_check_duplicate_reserved_version_latest(self, api_v2):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_check_duplicate_reserved_version_latest(self, checkout_path, api_v2):
+        checkout_path.return_value = self.project.repo
         create_git_branch(self.repo, 'latest')
         create_git_tag(self.repo, 'latest')
 
@@ -144,7 +146,9 @@ class TestCeleryBuilding(RTDTestCase):
         api_v2.project().sync_versions.post.assert_called()
 
     @patch('readthedocs.projects.tasks.api_v2')
-    def test_check_duplicate_reserved_version_stable(self, api_v2):
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_check_duplicate_reserved_version_stable(self, checkout_path, api_v2):
+        checkout_path.return_value = self.project.repo
         create_git_branch(self.repo, 'stable')
         create_git_tag(self.repo, 'stable')
 

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -174,10 +174,14 @@ class Backend(BaseVCS):
     def branches(self):
         repo = git.Repo(self.working_dir)
         versions = []
-        for branch in repo.branches:
+        # ``repo.branches`` returns local branches and
+        # ``repo.remotes.origin.refs`` returns remote branches
+        for branch in repo.branches + repo.remotes.origin.refs:
             verbose_name = branch.name
             if verbose_name.startswith('origin/'):
                 verbose_name = verbose_name.replace('origin/', '')
+            if verbose_name == 'HEAD':
+                continue
             versions.append(VCSVersion(self, str(branch), verbose_name))
         return versions
 

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -174,9 +174,14 @@ class Backend(BaseVCS):
     def branches(self):
         repo = git.Repo(self.working_dir)
         versions = []
+
         # ``repo.branches`` returns local branches and
+        branches = repo.branches
         # ``repo.remotes.origin.refs`` returns remote branches
-        for branch in repo.branches + repo.remotes.origin.refs:
+        if repo.remotes:
+            branches += repo.remotes.origin.refs
+
+        for branch in branches:
             verbose_name = branch.name
             if verbose_name.startswith('origin/'):
                 verbose_name = verbose_name.replace('origin/', '')

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -4,7 +4,6 @@
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
-import csv
 import logging
 import os
 import re
@@ -13,7 +12,6 @@ import git
 from builtins import str
 from django.core.exceptions import ValidationError
 from git.exc import BadName
-from six import PY2, StringIO
 
 from readthedocs.config import ALL
 from readthedocs.projects.exceptions import RepositoryError


### PR DESCRIPTION
Use `gitpython` to get repository branches instead of our custom/hacky csv parser.

With this change, we loose the output from `git branch -r` command shown to the user under the build output.

These changes need more QA:

- repo with Unicode branch imported properly in RTD running Py2 _and_ Py3
- docs for that specific branch are serving without problem (may be affected by #1410)

NOTE: this PR also changes how the branches are parsed and I'm not 100% sure that removing the `origin/` from its name is enough and exactly the same that we were doing before

Ref: #2997 #4052
Fixes: #3060