### PR TITLE
Skip tags that point to blob objects instead of commits

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -123,11 +123,18 @@ class Backend(BaseVCS):
 
     @property
     def tags(self):
+        versions = []
         repo = git.Repo(self.working_dir)
-        versions = [
-            VCSVersion(self, str(tag.commit), str(tag))
-            for tag in repo.tags
-        ]
+        for tag in repo.tags:
+            try:
+                versions.append(VCSVersion(self, str(tag.commit), str(tag)))
+            except ValueError as e:
+                # ValueError: Cannot resolve commit as tag TAGNAME points to a
+                # blob object - use the `.object` property instead to access it
+                # This is not a real tag for us, so we skip it
+                # https://github.com/rtfd/readthedocs.org/issues/4440
+                log.warning('[Git tag skipped] %s', e)
+                continue
         return versions
 
     @property

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -133,7 +133,7 @@ class Backend(BaseVCS):
                 # blob object - use the `.object` property instead to access it
                 # This is not a real tag for us, so we skip it
                 # https://github.com/rtfd/readthedocs.org/issues/4440
-                log.warning('[Git tag skipped] %s', e)
+                log.warning('Git tag skipped: %s', tag, exc_info=True)
                 continue
         return versions
 


### PR DESCRIPTION
Maybe this is not the best solution ever since we may be skipping other cases also since I'm catching the `ValueError` exception (too general) but initially we want to skip them, log and continue building.

Closes #4440