### PR TITLE
Add `trimmed` to all multilines `blocktrans` tags

### DIFF
--- a/readthedocs/gold/templates/gold/projects.html
+++ b/readthedocs/gold/templates/gold/projects.html
@@ -17,7 +17,7 @@ Gold Projects
 
   <h3> {% trans "Existing Projects" %} </h3>
   <p>
-    {% blocktrans count projects=gold_user.num_supported_projects %}
+    {% blocktrans trimmed count projects=gold_user.num_supported_projects %}
       You can adopt one project with your subscription.
     {% plural %}
       You can adopt {{ projects }} projects with your subscription.

--- a/readthedocs/gold/templates/gold/subscription_confirm_delete.html
+++ b/readthedocs/gold/templates/gold/subscription_confirm_delete.html
@@ -9,7 +9,7 @@
   <h2>Cancel Gold Subscription</h2>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Are you sure you want to cancel your subscription?
     {% endblocktrans %}
   </p>

--- a/readthedocs/gold/templates/gold/subscription_detail.html
+++ b/readthedocs/gold/templates/gold/subscription_detail.html
@@ -31,7 +31,7 @@ $(document).ready(function () {
     <h2>{% trans "Gold Subscription" %}</h2>
 
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         Thanks for supporting Read the Docs! It really means a lot to us.
       {% endblocktrans %}
     </p>
@@ -56,7 +56,7 @@ $(document).ready(function () {
 
     <h3>{% trans "Projects" %}</h3>
     <p class="subscription-projects">
-      {% blocktrans count projects=golduser.num_supported_projects %}
+      {% blocktrans trimmed count projects=golduser.num_supported_projects %}
         You can adopt one project with your subscription.
       {% plural %}
         You can adopt {{ projects }} projects with your subscription.

--- a/readthedocs/gold/templates/gold/subscription_form.html
+++ b/readthedocs/gold/templates/gold/subscription_form.html
@@ -37,20 +37,20 @@ $(document).ready(function () {
   <h2>Read the Docs Gold</h2>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Supporting Read the Docs lets us work more on features that people love.
       Your money will go directly to maintenance and development of the
       product.
     {% endblocktrans %}
   </p>
     <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       If you are an individual,
       feel free to give whatever feels right for the value you get out of Read the Docs.
     {% endblocktrans %}
     </p>
     <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       If you are a company using Read the Docs,
       please consider getting a <a href="https://readthedocs.com/services/#open-source-support">commercial support contract</a>.
       This will help us cover our costs,
@@ -63,7 +63,7 @@ $(document).ready(function () {
   <p>{% trans 'Becoming a Gold Member also makes Read the Docs ad-free for as long as you are logged-in.' %}</p>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       You can also make one-time donations on our <a href="https://readthedocs.org/sustainability/">sustainability</a> page.
     {% endblocktrans %}
   </p>
@@ -71,7 +71,7 @@ $(document).ready(function () {
   {% if domains.count %}
   <h3>Domains</h2>
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
     We ask that folks who use custom Domains give Read the Docs $5 per domain they are using.
     This is optional, but it really does help us maintain the site going forward.
     {% endblocktrans %}

--- a/readthedocs/templates/account/login.html
+++ b/readthedocs/templates/account/login.html
@@ -11,7 +11,7 @@
 
 <h1>{% trans "Sign In" %}</h1>
 
-<p><small>{% blocktrans %}If you have not created an account yet, then please
+<p><small>{% blocktrans trimmed %}If you have not created an account yet, then please
 <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</small></p>
 
 <form class="login" method="POST" action="{% url "account_login" %}">
@@ -24,7 +24,7 @@
 
   {% url 'account_reset_password' as password_reset_url %}
   <p>
-    <small>{% blocktrans %}If you forgot your password, <a href="{{ password_reset_url }}">reset it.</a>{% endblocktrans %}</small>
+    <small>{% blocktrans trimmed %}If you forgot your password, <a href="{{ password_reset_url }}">reset it.</a>{% endblocktrans %}</small>
   </p>
 </form>
 

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -72,7 +72,7 @@ $(document).ready(function () {
     </ul>
 
     <div class="build-id">
-      {% blocktrans with build_id=build.pk %}
+      {% blocktrans trimmed with build_id=build.pk %}
         Build #{{ build_id }}
       {% endblocktrans %}
     </div>
@@ -118,7 +118,7 @@ $(document).ready(function () {
         <div class="build-ideas">
           <p>
             {% url 'wipe_version' build.version.project.slug build.version.slug as wipe_url %}
-            {% blocktrans %}
+            {% blocktrans trimmed %}
               Having trouble with your build environment?
               Try <a href="{{ wipe_url }}">resetting it</a>.
             {% endblocktrans %}
@@ -128,7 +128,7 @@ $(document).ready(function () {
         <div class="build-ideas">
           <p>
             {% url 'projects_advanced' build.version.project.slug as advanced_url %}
-            {% blocktrans %}
+            {% blocktrans trimmed %}
               Don't want <em>setup.py install</em> called?
               Change the <strong>Install Project</strong> setting in your <a href="{{ advanced_url }}">advanced settings</a>.
             {% endblocktrans %}

--- a/readthedocs/templates/core/project_bar_base.html
+++ b/readthedocs/templates/core/project_bar_base.html
@@ -28,7 +28,7 @@
 
     {% if project.skip %}
       <p class="build-failure">
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Your project is currently disabled for abuse of the system.
             Please make sure it isn't using unreasonable amounts of resources or triggering lots of builds in a short amount of time.
             Please <a href="https://github.com/rtfd/readthedocs.org/issues">file a ticket</a> to get your project re-enabled.

--- a/readthedocs/templates/core/project_detail_right.html
+++ b/readthedocs/templates/core/project_detail_right.html
@@ -79,7 +79,7 @@
       {% if request.user|is_admin:project %}
 
         {% url 'projects_edit' project.slug as edit_url %}
-          {% blocktrans %}
+          {% blocktrans trimmed %}
           Add some in your <a href="{{ edit_url }}">project settings</a>.
           {% endblocktrans %}
       {% endif %}

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -44,7 +44,7 @@
   <section>
     <h2>{% trans "Technical documentation lives here" %}</h2>
     <p class="lead">
-      {% blocktrans %}
+      {% blocktrans trimmed %}
       Read the Docs simplifies software documentation by automating building,
       versioning, and hosting of your docs for you.
       {% endblocktrans %}
@@ -57,7 +57,7 @@
       <h3>Free docs hosting</h3>
       <p>
         {% with projects_count_intcomma=projects_count|intcomma %}
-        {% blocktrans %}
+        {% blocktrans trimmed %}
         We will host your documentation for free forever.
         There are no tricks. We help {{ projects_count_intcomma }} open source projects
         share their docs.
@@ -68,7 +68,7 @@
     <div class="feature">
       <h3>Webhooks</h3>
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
         Whenever you push code to your favorite version control system,
         whether that is Git, Mercurial, Bazaar, or Subversion, we will
         automatically build your docs so your code and documentation are
@@ -83,7 +83,7 @@
     <div class="feature">
       <h3>Multiple formats</h3>
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
         Of course we build and host your docs for the web, but they are
         also vieweable as PDFs, as single page HTML, and for eReaders.
         No additional configuration is required.
@@ -93,7 +93,7 @@
     <div class="feature">
       <h3>Multiple versions</h3>
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
         We can host and build multiple versions of your docs so having a
         1.0 version of your docs and a 2.0 version of your docs is as easy
         as having a separate branch or tag in your version control system.
@@ -139,7 +139,7 @@
     {% url "donate" as sponsors_url %}
     {% url "gold_detail" as gold_detail %}
 
-    {% blocktrans %}
+    {% blocktrans trimmed %}
     Read the Docs is a huge resource that millions of developers rely on
     for software documentation. It would not be possible without the
     support of our
@@ -150,7 +150,7 @@
     </p>
 
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
       Read the Docs is <strong>community supported</strong>.
       It depends on users like you to contribute to development, support, and operations.
       You can learn more about how to <a href="https://docs.readthedocs.io/en/latest/contribute.html">contribute</a> in our docs.
@@ -160,7 +160,7 @@
     </p>
 
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
       Hosting for the project is graciously provided by <a href="http://www.rackspace.com/cloud/">Rackspace</a>.
       {% endblocktrans %}
     </p>

--- a/readthedocs/templates/notifications/send_notification_form.html
+++ b/readthedocs/templates/notifications/send_notification_form.html
@@ -6,7 +6,7 @@
   <h3>{% trans 'Send Email' %}</h3>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       An email message will be sent to the following email addresses:
     {% endblocktrans %}
   </p>
@@ -18,7 +18,7 @@
     {% with extra_recipients=recipients|slice:"20:" %}
       {% if extra_recipients|length > 0 %}
         <li>
-          {% blocktrans count counter=extra_recipients|length %}
+          {% blocktrans trimmed count counter=extra_recipients|length %}
             And 1 other recipient.
           {% plural %}
             And {{ counter }} other recipients...
@@ -29,7 +29,7 @@
   </ul>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Specify the email content you wish to send:
     {% endblocktrans %}
   </p>

--- a/readthedocs/templates/profiles/private/advertising_profile.html
+++ b/readthedocs/templates/profiles/private/advertising_profile.html
@@ -12,14 +12,14 @@
 
   {% if request.user.gold.exists or request.user.goldonce.exists %}
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         Since you are a Gold Member or Supporter, you are <strong>ad-free</strong> for as long as you are logged-in.
         Thank you for supporting Read the Docs.
       {% endblocktrans%}
     </p>
   {% else %}
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         Read the Docs is an open source project.
         In order to maintain service, we rely on both the
         support of our users, and from sponsor support.
@@ -27,7 +27,7 @@
     </p>
 
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         For more details on advertising on Read the Docs
         including the privacy protections we have in place for users
         and community advertising we run on behalf of the open source community,
@@ -38,7 +38,7 @@
     <p>
       {% url "gold_detail" as gold_detail %}
       {% url "donate" as donate_url %}
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         You can <strong>go ad-free</strong> by becoming a <a href="{{ gold_detail }}">Gold Member</a> or <a href="{{ donate_url }}">Supporter</a> of Read the Docs</a>.
       {% endblocktrans %}
     </p>

--- a/readthedocs/templates/projects/import_basics.html
+++ b/readthedocs/templates/projects/import_basics.html
@@ -5,7 +5,7 @@
   <h3>{% trans "Project Details" %}</h3>
 
   <p class="info">
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       To import a project,
       start by entering a few details about your repository.
       More advanced project options can be configured

--- a/readthedocs/templates/projects/import_extra.html
+++ b/readthedocs/templates/projects/import_extra.html
@@ -5,7 +5,7 @@
   <h3>{% trans "Project Extra Details" %}</h3>
 
   <p class="info">
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Here are a few more project options that you may need to configure.
     {% endblocktrans %}
   </p>

--- a/readthedocs/templates/projects/integration_generic_webhook_detail.html
+++ b/readthedocs/templates/projects/integration_generic_webhook_detail.html
@@ -4,7 +4,7 @@
 
 {% block integration_details %}
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       The following parameters are configured for this integration:
     {% endblocktrans %}
   </p>

--- a/readthedocs/templates/projects/integration_webhook_detail.html
+++ b/readthedocs/templates/projects/integration_webhook_detail.html
@@ -10,7 +10,7 @@
 
 {% block project-integrations-active %}active{% endblock %}
 {% block project_edit_content_header %}
-  {% blocktrans with type=integration.get_integration_type_display %}
+  {% blocktrans trimmed with type=integration.get_integration_type_display %}
     Integration - {{ type }}
   {% endblocktrans %}
 {% endblock %}
@@ -18,7 +18,7 @@
 {% block project_edit_content %}
   {% if integration.has_sync and integration.can_sync %}
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         This webhook was configured when this project was imported. If this
         integration is not functioning correctly, try resyncing the webhook:
       {% endblocktrans %}
@@ -39,7 +39,7 @@
     {% endcomment %}
     {% if integration.has_sync and not integration.can_sync %}
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           This integration was created automatically from an existing webhook
           configured on your repository. To make any changes to this webhook,
           you'll need to update the configuration there. You can use the
@@ -48,7 +48,7 @@
       </p>
     {% else %}
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           To manually configure this webhook with your provider, use the
           following address:
         {% endblocktrans %}
@@ -63,7 +63,7 @@
     {% block integration_details %}{% endblock %}
 
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         For more information on manually configuring a webhook, refer to
         <a href="https://docs.readthedocs.io/en/latest/webhooks.html">
           our webhook documentation
@@ -80,7 +80,7 @@
         <li class="module-item">
           <span class="status status-{% if exchange.failed %}fail{% else %}pass{% endif %}">{{ exchange.status_code }}</span>
           <a href="{% url 'projects_integrations_exchanges_detail' project_slug=project.slug integration_pk=integration.pk exchange_pk=exchange.pk %}">
-            {% blocktrans with date=exchange.date|timesince %}
+            {% blocktrans trimmed with date=exchange.date|timesince %}
               {{ date }} ago
             {% endblocktrans %}
           </a>

--- a/readthedocs/templates/projects/onboard_detail.html
+++ b/readthedocs/templates/projects/onboard_detail.html
@@ -8,7 +8,7 @@
     {% if not onboard.build %}
       <h2>{% trans "Start building your documentation" %}</h2>
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           This project has not been built yet.
           Try building the latest version now,
           or if you would like to build a specific version,
@@ -30,7 +30,7 @@
 
           <form method="get" action="{{ project.get_docs_url }}">
             <p>
-            {% blocktrans %}
+            {% blocktrans trimmed %}
               Your documentation has been built.
               Ensure your documentation is kept up to date with every commit to
               your repository, by
@@ -46,7 +46,7 @@
 
           <form method="get" action="{% url "builds_detail" project_slug=project.slug build_pk=onboard.build.pk %}">
             <p>
-            {% blocktrans %}
+            {% blocktrans trimmed %}
               There was a problem building your documentation,
               you can see what went wrong in the build output.
               If you need more help, check out some of the
@@ -62,7 +62,7 @@
         <h2>{% trans "Your documentation is building" %}</h2>
 
         <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           You'll be able to view your documentation in a minute or two,
           once your project is done building.
         {% endblocktrans %}

--- a/readthedocs/templates/projects/onboard_import.html
+++ b/readthedocs/templates/projects/onboard_import.html
@@ -7,7 +7,7 @@
   {% with getting_started_url="http://docs.readthedocs.io/en/latest/getting_started.html" %}
     <form method="get" action="{% url "projects_import" %}">
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           You don't have any projects yet, but you can start building documentation by importing one.
           Not sure how to start documenting your project?
           Check out the <a href="{{ getting_started_url }}">Getting Started Guide</a> to learn how.
@@ -16,7 +16,7 @@
 
       <p>
         {% url "projects_import_demo" as import_demo_url %}
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           Want to try a demo? <a href="{{ import_demo_url }}">Import our own demo project</a>.
         {% endblocktrans %}
       </p>

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -13,7 +13,7 @@
 
 {% block project_edit_content %}
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Read the Docs is an open source project.
       In order to maintain service, we rely on both the
       support of our users, and from sponsor support.
@@ -21,7 +21,7 @@
   </p>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       We will periodically run advertisements on built documentation pages for
       sponsors, however we have strict guidelines on advertisements:
     {% endblocktrans %}
@@ -29,17 +29,17 @@
 
   <ul class="project-ads-guidelines">
     <li>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         We don't give sponsors access to user information
       {% endblocktrans %}
     </li>
     <li>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         We only report the number of impressions and number of ad clicks
       {% endblocktrans %}
     </li>
     <li>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         We only allow and image and text, no Javascript besides our existing
         tracking
       {% endblocktrans %}
@@ -47,7 +47,7 @@
   </ul>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       For more details on advertising on Read the Docs
       including the privacy protections we have in place for users
       and community advertising we run on behalf of the open source community,
@@ -58,7 +58,7 @@
   <h4>{% trans "Opting out" %}</h4>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       If you do not wish to support Read the Docs with use of this ad space,
       we ask that you help support Read the Docs in one of following ways:
     {% endblocktrans %}
@@ -66,7 +66,7 @@
 
   <ul class="module-list project-ads-support">
     <li class="module-item">
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         If you have an open source project, and can contribute financially,
         consider a gold subscription. Gold subscribers can disable ads for
         projects they author.
@@ -78,7 +78,7 @@
     </li>
 
     <li class="module-item">
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         If your project is an open source project, you most certainly also
         lack funding.  If you can't contribute financially to Read the Docs,
         consider donating your time. We can always use help with support
@@ -91,7 +91,7 @@
     </li>
 
     <li class="module-item">
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         If you are part of a company that uses Read the Docs to host
         documentation for a commercial product, we offer paid plans that
         offer email support, additional build resources, and features like
@@ -107,7 +107,7 @@
   <h4>{% trans "Still can't help?" %}</h4>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       If you can't contribute your support for your open source project, but
       are conflicted by allowing support through advertising, we still would
       like to give you the option to disable showing promotions inside your
@@ -117,7 +117,7 @@
   </p>
 
   <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       If you are a company hosting commercial documentation on our community
       site, but can't offer support for Read the Docs, we do not allow
       removing sponsor advertisements on your documentation. This goes

--- a/readthedocs/templates/projects/project_dashboard_base.html
+++ b/readthedocs/templates/projects/project_dashboard_base.html
@@ -74,7 +74,7 @@
                         {% else %}
                           <span class="right quiet">
                             <span class="build-count">
-                              {% blocktrans count counter=builds %}
+                              {% blocktrans trimmed count counter=builds %}
                                 1 build
                               {% plural %}
                                 {{ builds }} builds
@@ -134,7 +134,7 @@
         <h3>{% trans "Connect your Accounts" %}</h3>
 
         <p>
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Have a GitHub account? Connect your account and import your existing projects automatically.
           {% endblocktrans %}
         </p>
@@ -152,7 +152,7 @@
     <div class="module info info-docs">
       <h3>{% trans "Learn More" %}</h3>
       <p>
-        {% blocktrans with rtd_docs_url="http://docs.readthedocs.io/en/latest/index.html" %}
+        {% blocktrans trimmed with rtd_docs_url="http://docs.readthedocs.io/en/latest/index.html" %}
           Check out the <a href="{{ rtd_docs_url }}">documentation for Read the Docs</a>.
           It contains lots of information about how to get the most out of RTD.
         {% endblocktrans %}

--- a/readthedocs/templates/projects/project_import.html
+++ b/readthedocs/templates/projects/project_import.html
@@ -81,7 +81,7 @@
                 <li class="module-item">
                   {% if has_connected_accounts %}
                     <p>
-                      {% blocktrans with binding='data-bind="click: sync_projects"' trimmed %}
+                      {% blocktrans trimmed with binding='data-bind="click: sync_projects"' %}
                         No remote repositories found,
                         try <a href="#" {{ binding }}>refreshing your accounts</a>.
                       {% endblocktrans %}

--- a/readthedocs/templates/security.html
+++ b/readthedocs/templates/security.html
@@ -8,7 +8,7 @@
 
 <h2>{% trans 'Security at Read the Docs' %}</h2>
 
-{% blocktrans %}
+{% blocktrans trimmed %}
   For more details on security at Read the Docs or to report a security issue, please see our <a href="https://docs.readthedocs.io/en/latest/security.html">security policy</a>.
 {% endblocktrans %}
 

--- a/readthedocs/templates/socialaccount/connections.html
+++ b/readthedocs/templates/socialaccount/connections.html
@@ -13,7 +13,7 @@
   <div class="module connected-services">
     <div class="module-wrapper">
       <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           The following services are currently connected to your account:
         {% endblocktrans %}
       </p>
@@ -47,7 +47,7 @@
 
                   {% if base_account.provider == 'bitbucket' %}
                     <p class="help error">
-                      {% blocktrans %}
+                      {% blocktrans trimmed %}
                         The API version this connection uses is no longer
                         supported, please reconnect your Bitbucket account.
                       {% endblocktrans %}

--- a/readthedocs/templates/socialaccount/snippets/provider_list.html
+++ b/readthedocs/templates/socialaccount/snippets/provider_list.html
@@ -11,7 +11,7 @@
            class="socialaccount-provider {{ provider.id }} {{ brand.id }} button"
            href="{% provider_login_url provider.id openid=brand.openid_url process=process next=next %}"
            >
-           {% blocktrans with brand_name=brand.name verbiage=verbiage|default:'Connect to' %}
+           {% blocktrans trimmed with brand_name=brand.name verbiage=verbiage|default:'Connect to' %}
              {{ verbiage }} {{ brand_name }}
            {% endblocktrans %}
         </a>
@@ -24,7 +24,7 @@
          class="socialaccount-provider {{ provider.id }} button"
          href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params next=next %}"
          >
-         {% blocktrans with provider_name=provider.name verbiage=verbiage|default:'Connect to' %}
+         {% blocktrans trimmed with provider_name=provider.name verbiage=verbiage|default:'Connect to' %}
            {{ verbiage }} {{ provider_name }}
          {% endblocktrans %}
       </a>

--- a/readthedocs/templates/wipe_version.html
+++ b/readthedocs/templates/wipe_version.html
@@ -13,19 +13,19 @@
 {% block content %}
 
 <h3>
-{% blocktrans with slug=version.slug %}
+{% blocktrans trimmed with slug=version.slug %}
     Remove build environment for <em>{{ slug }}</em> version.
 {% endblocktrans %}
 </h3>
 
 {% if deleted %}
     <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
         Your project environment has been wiped.
     {% endblocktrans %}
     </p>
 {% else %}
-    {% blocktrans %}
+    {% blocktrans trimmed %}
         Having trouble getting your documentation build to complete?  By clicking on the button below you'll clean out your build checkouts and environment, but not your generated documentation.
     {% endblocktrans %}
 


### PR DESCRIPTION
Following what @ewjoachim said in #4471,

> Now I think most of these problems are pretty much stemming from the usage of blocktrans without trimmed, and that makes the translation quite more complex to write. There are some other issues, though.

I updated all our templates to add `trimmed` to all multilines `blocktrans` tag.

~~This PR should be merged before #4478 I suppose, so we don't override the resources twice.~~