### PR TITLE
Allow enforcing HTTPS for custom domains

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -147,6 +147,8 @@ class ResolverBase(object):
         canonical_project = self._get_canonical_project(project)
         custom_domain = self._get_project_custom_domain(canonical_project)
 
+        # This duplication from resolve_domain is for performance purposes
+        # in order to check whether a custom domain should be HTTPS
         if custom_domain:
             domain = custom_domain.domain
         elif self._use_subdomain():

--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -184,7 +184,7 @@ class DomainAdmin(admin.ModelAdmin):
     list_display = ('domain', 'project', 'https', 'count')
     search_fields = ('domain', 'project__slug')
     raw_id_fields = ('project',)
-    list_filter = ('canonical',)
+    list_filter = ('canonical', 'https')
     model = Domain
 
 

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -634,7 +634,7 @@ class DomainForm(forms.ModelForm):
 
     class Meta(object):
         model = Domain
-        exclude = ['machine', 'cname', 'count', 'https']
+        exclude = ['machine', 'cname', 'count']
 
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop('project', None)

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -985,7 +985,7 @@ class Domain(models.Model):
     https = models.BooleanField(
         _('Use HTTPS'),
         default=False,
-        help_text=_('SSL is enabled for this domain')
+        help_text=_('Always use HTTPS for this domain')
     )
     count = models.IntegerField(default=0, help_text=_(
         'Number of times this domain has been hit'),)

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -472,6 +472,22 @@ class ResolverTests(ResolverBase):
             self.assertEqual(url, 'http://docs.foobar.com/en/latest/')
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
+    def test_resolver_domain_https(self):
+        self.domain = fixture.get(
+            Domain,
+            domain='docs.foobar.com',
+            project=self.pip,
+            https=True,
+            canonical=True,
+        )
+        with override_settings(USE_SUBDOMAIN=False):
+            url = resolve(project=self.pip)
+            self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
+        with override_settings(USE_SUBDOMAIN=True):
+            url = resolve(project=self.pip)
+            self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
+
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
     def test_resolver_subproject(self):
         with override_settings(USE_SUBDOMAIN=False):
             url = resolve(project=self.subproject)
@@ -740,21 +756,21 @@ class TestSubprojectsWithTranslations(TestCase):
             domain='docs.example.com',
             canonical=True,
             cname=True,
-            https=True,
+            https=False,
             project=self.superproject_en,
         )
 
         url = resolve(self.superproject_en, filename='')
-        self.assertEqual(url, 'https://docs.example.com/en/latest/')
+        self.assertEqual(url, 'http://docs.example.com/en/latest/')
 
         url = resolve(self.superproject_es, filename='')
-        self.assertEqual(url, 'https://docs.example.com/es/latest/')
+        self.assertEqual(url, 'http://docs.example.com/es/latest/')
 
         # yapf: disable
         url = resolve(self.subproject_en, filename='')
         self.assertEqual(
             url,
-            ('https://docs.example.com/projects/'
+            ('http://docs.example.com/projects/'
              '{subproject.slug}/en/latest/').format(
                  subproject=self.subproject_en,
             ),
@@ -763,7 +779,7 @@ class TestSubprojectsWithTranslations(TestCase):
         url = resolve(self.subproject_es, filename='')
         self.assertEqual(
             url,
-            ('https://docs.example.com/projects/'
+            ('http://docs.example.com/projects/'
              '{subproject.slug}/es/latest/').format(
                  subproject=self.subproject_en,
             ),

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -745,16 +745,16 @@ class TestSubprojectsWithTranslations(TestCase):
         )
 
         url = resolve(self.superproject_en, filename='')
-        self.assertEqual(url, 'http://docs.example.com/en/latest/')
+        self.assertEqual(url, 'https://docs.example.com/en/latest/')
 
         url = resolve(self.superproject_es, filename='')
-        self.assertEqual(url, 'http://docs.example.com/es/latest/')
+        self.assertEqual(url, 'https://docs.example.com/es/latest/')
 
         # yapf: disable
         url = resolve(self.subproject_en, filename='')
         self.assertEqual(
             url,
-            ('http://docs.example.com/projects/'
+            ('https://docs.example.com/projects/'
              '{subproject.slug}/en/latest/').format(
                  subproject=self.subproject_en,
             ),
@@ -763,7 +763,7 @@ class TestSubprojectsWithTranslations(TestCase):
         url = resolve(self.subproject_es, filename='')
         self.assertEqual(
             url,
-            ('http://docs.example.com/projects/'
+            ('https://docs.example.com/projects/'
              '{subproject.slug}/es/latest/').format(
                  subproject=self.subproject_en,
             ),

--- a/readthedocs/templates/projects/domain_form.html
+++ b/readthedocs/templates/projects/domain_form.html
@@ -21,6 +21,14 @@
 {% endblock %}
 
 {% block project_edit_content %}
+  {% if domain.domainssl %}
+    {# This references optional code to get the SSL certificate status #}
+    <p>
+      <strong>HTTPS status: </strong>
+      <span>{{ domain.domainssl.status }}</span>
+    </p>
+  {% endif %}
+
   {% if domain %}
     {% url 'projects_domains_edit' project.slug domain.pk as action_url %}
   {% else %}


### PR DESCRIPTION
This allows users to mark a domain as HTTPS and then all links to its documentation will be HTTPS links instead of HTTP links.

Personally I don't love these changes to the resolver but I believe the resolver needs a larger refactor for performance reasons anyway (https://github.com/rtfd/readthedocs.org/issues/3712). If there's a better way to add this functionality without adding more SQL queries and degrading performance of a very performance sensitive bit of code, please let me know or feel free to add to this.

Fixes https://github.com/rtfd/readthedocs.org/issues/2236

## Screenshot

<img width="882" alt="screen shot 2018-08-06 at 3 17 06 pm" src="https://user-images.githubusercontent.com/185043/43743726-dae0c240-998b-11e8-990a-abf5c25f4e6a.png">
