### PR TITLE
Cache node_modules to speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
   directories:
     - ~/.cache/pip
     - ~/.nvm/nvm.sh
+    - ~/.npm
 install:
   - ./scripts/travis/install_elasticsearch.sh
   - pip install tox-travis


### PR DESCRIPTION
The CI process is a little slow, even sometimes it fails because of timeout downloading node packages. A downside of this change: we need to remember to clear the cache if there is a change in js dependencies (which is not so common).