### PR TITLE
Document expected delay on CNAME change and need for CAA

### DIFF
--- a/docs/alternate_domains.rst
+++ b/docs/alternate_domains.rst
@@ -53,6 +53,8 @@ This service is generously provided by Cloudflare.
     they do not yet allow us to acquire SSL certificates for those domains.
     Simply point the CNAME to ``readthedocs.io``.
 
+    If you change the CNAME, the SSL certificate issuance can take about one hour.
+
 .. important::
 
     Due to a limitation, a domain cannot be proxied on Cloudflare

--- a/docs/alternate_domains.rst
+++ b/docs/alternate_domains.rst
@@ -46,6 +46,10 @@ By default, when you setup a custom domain to host documentation at Read the Doc
 we will attempt to provision a domain validated SSL certificate for the domain.
 This service is generously provided by Cloudflare.
 
+If your domain has configred CAA records, please do not forget to include
+Cloudflare CAA entries, see their `Certification Authority Authorization (CAA)
+FAQ <https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ>`_.
+
 .. note::
 
     Some older setups configured a CNAME record pointing to ``readthedocs.org``


### PR DESCRIPTION
The SSL certificate issuing takes about one hour in this case according to comment in #2652.