### PR TITLE
Mark some BuildEnvironmentError exceptions as Warning and do not log them

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -726,13 +726,7 @@ class DockerBuildEnvironment(BuildEnvironment):
             if not all([exc_type, exc_value, tb]):
                 exc_type, exc_value, tb = sys.exc_info()
 
-        ret = self.handle_exception(exc_type, exc_value, tb)
-        self.update_build(BUILD_STATE_FINISHED)
-        log.info(LOG_TEMPLATE
-                 .format(project=self.project.slug,
-                         version=self.version.slug,
-                         msg='Build finished'))
-        return ret
+        return super(DockerBuildEnvironment, self).__exit__(exc_type, exc_value, tb)
 
     def get_client(self):
         """Create Docker client connection."""

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -457,14 +457,18 @@ class BuildEnvironment(BaseEnvironment):
 
     def handle_exception(self, exc_type, exc_value, _):
         """
-        Exception handling for __enter__ and __exit__
+        Exception handling for __enter__ and __exit__.
 
         This reports on the exception we're handling and special cases
-        subclasses of BuildEnvironmentException.  For
+        subclasses of BuildEnvironmentException. For
         :py:class:`BuildEnvironmentWarning`, exit this context gracefully, but
-        don't mark the build as a failure.  For all other exception classes,
+        don't mark the build as a failure. For all other exception classes,
         including :py:class:`BuildEnvironmentError`, the build will be marked as
         a failure and the context will be gracefully exited.
+
+        If the exception's type is :py:class:`BuildEnvironmentWarning` or it's
+        an exception marked as ``WARNING_EXCEPTIONS`` we log the problem as a
+        WARNING, otherwise we log it as an ERROR.
         """
         if exc_type is not None:
             log_level_function = None

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -590,10 +590,10 @@ class BuildEnvironment(BaseEnvironment):
             # BuildEnvironmentError
             if not isinstance(
                     self.failure,
-                (
-                    BuildEnvironmentException,
-                    BuildEnvironmentWarning,
-                ),
+                    (
+                        BuildEnvironmentException,
+                        BuildEnvironmentWarning,
+                    ),
             ):
                 log.error(
                     'Build failed with unhandled exception: %s',

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -472,8 +472,10 @@ class BuildEnvironment(BaseEnvironment):
                 log_level_function = log.warning
             elif exc_type in self.WARNING_EXCEPTIONS:
                 log_level_function = log.warning
+                self.failure = exc_value
             else:
                 log_level_function = log.error
+                self.failure = exc_value
 
             log_level_function(
                 LOG_TEMPLATE.format(
@@ -491,7 +493,6 @@ class BuildEnvironment(BaseEnvironment):
                     },
                 },
             )
-            self.failure = exc_value
             return True
 
     def record_command(self, command):

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -9,9 +9,10 @@ from django.utils.translation import ugettext_noop
 class BuildEnvironmentException(Exception):
 
     message = None
+    status_code = None
 
     def __init__(self, message=None, **kwargs):
-        self.status_code = kwargs.pop('status_code', 1)
+        self.status_code = kwargs.pop('status_code', None) or self.status_code or 1
         message = message or self.get_default_message()
         super(BuildEnvironmentException, self).__init__(message, **kwargs)
 
@@ -35,6 +36,7 @@ class BuildEnvironmentCreationFailed(BuildEnvironmentError):
 class VersionLockedError(BuildEnvironmentError):
 
     message = ugettext_noop('Version locked, retrying in 5 minutes.')
+    status_code = 423
 
 
 class ProjectBuildsSkippedError(BuildEnvironmentError):

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -31,5 +31,33 @@ class BuildEnvironmentCreationFailed(BuildEnvironmentError):
     )
 
 
+class VersionLockedError(BuildEnvironmentError):
+
+    message = ugettext_noop(
+        'Version locked, retrying in 5 minutes.',
+    )
+
+
+class ProjectBuildsSkippedError(BuildEnvironmentError):
+
+    message = ugettext_noop(
+        'Builds for this project are temporarily disabled',
+    )
+
+
+class YAMLParseError(BuildEnvironmentError):
+
+    GENERIC_WITH_PARSE_EXCEPTION = ugettext_noop(
+        'Problem parsing YAML configuration. {exception}',
+    )
+
+
+class BuildTimeoutError(BuildEnvironmentError):
+
+    message = ugettext_noop(
+        'Build exited due to time out',
+    )
+
+
 class BuildEnvironmentWarning(BuildEnvironmentException):
     pass

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -1,4 +1,7 @@
+# -*- coding: utf-8 -*-
 """Exceptions raised when building documentation."""
+
+from __future__ import division, print_function, unicode_literals
 
 from django.utils.translation import ugettext_noop
 
@@ -19,30 +22,24 @@ class BuildEnvironmentException(Exception):
 class BuildEnvironmentError(BuildEnvironmentException):
 
     GENERIC_WITH_BUILD_ID = ugettext_noop(
-        "There was a problem with Read the Docs while building your documentation. "
-        "Please report this to us with your build id ({build_id})."
+        'There was a problem with Read the Docs while building your documentation. '
+        'Please report this to us with your build id ({build_id}).',
     )
 
 
 class BuildEnvironmentCreationFailed(BuildEnvironmentError):
 
-    message = ugettext_noop(
-        "Build environment creation failed"
-    )
+    message = ugettext_noop('Build environment creation failed')
 
 
 class VersionLockedError(BuildEnvironmentError):
 
-    message = ugettext_noop(
-        'Version locked, retrying in 5 minutes.',
-    )
+    message = ugettext_noop('Version locked, retrying in 5 minutes.')
 
 
 class ProjectBuildsSkippedError(BuildEnvironmentError):
 
-    message = ugettext_noop(
-        'Builds for this project are temporarily disabled',
-    )
+    message = ugettext_noop('Builds for this project are temporarily disabled')
 
 
 class YAMLParseError(BuildEnvironmentError):
@@ -54,9 +51,7 @@ class YAMLParseError(BuildEnvironmentError):
 
 class BuildTimeoutError(BuildEnvironmentError):
 
-    message = ugettext_noop(
-        'Build exited due to time out',
-    )
+    message = ugettext_noop('Build exited due to time out')
 
 
 class BuildEnvironmentWarning(BuildEnvironmentException):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Tasks related to projects.
 
@@ -25,29 +26,27 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
-from readthedocs.config import ConfigError
 from slumber.exceptions import HttpClientError
 
-from .constants import LOG_TEMPLATE
-from .exceptions import RepositoryError
-from .models import ImportedFile, Project, Domain, Feature
-from .signals import before_vcs, after_vcs, before_build, after_build, files_changed
 from readthedocs.builds.constants import (
     BUILD_STATE_BUILDING, BUILD_STATE_CLONING, BUILD_STATE_FINISHED,
     BUILD_STATE_INSTALLING, LATEST, LATEST_VERBOSE_NAME, STABLE_VERBOSE_NAME)
 from readthedocs.builds.models import APIVersion, Build, Version
 from readthedocs.builds.signals import build_complete
 from readthedocs.builds.syncers import Syncer
+from readthedocs.config import ConfigError
 from readthedocs.core.resolver import resolve_path
 from readthedocs.core.symlink import PublicSymlink, PrivateSymlink
 from readthedocs.core.utils import send_email, broadcast
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.constants import DOCKER_LIMITS
-from readthedocs.doc_builder.environments import (LocalBuildEnvironment,
-                                                  DockerBuildEnvironment)
-from readthedocs.doc_builder.exceptions import BuildEnvironmentError, VersionLockedError, ProjectBuildsSkippedError, YAMLParseError, BuildTimeoutError
+from readthedocs.doc_builder.environments import (
+    DockerBuildEnvironment, LocalBuildEnvironment)
+from readthedocs.doc_builder.exceptions import (
+    BuildEnvironmentError, BuildTimeoutError, ProjectBuildsSkippedError,
+    VersionLockedError, YAMLParseError)
 from readthedocs.doc_builder.loader import get_builder_class
-from readthedocs.doc_builder.python_environments import Virtualenv, Conda
+from readthedocs.doc_builder.python_environments import Conda, Virtualenv
 from readthedocs.projects.models import APIProject
 from readthedocs.restapi.client import api as api_v2
 from readthedocs.restapi.utils import index_search_request
@@ -55,6 +54,11 @@ from readthedocs.search.parse_json import process_all_json_files
 from readthedocs.vcs_support import utils as vcs_support_utils
 from readthedocs.worker import app
 
+from .constants import LOG_TEMPLATE
+from .exceptions import RepositoryError
+from .models import Domain, Feature, ImportedFile, Project
+from .signals import (
+    after_build, after_vcs, before_build, before_vcs, files_changed)
 
 log = logging.getLogger(__name__)
 
@@ -455,8 +459,14 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             env_cls = DockerBuildEnvironment
         else:
             env_cls = LocalBuildEnvironment
-        self.build_env = env_cls(project=self.project, version=self.version, config=self.config,
-                                 build=self.build, record=record, environment=env_vars)
+        self.build_env = env_cls(
+            project=self.project,
+            version=self.version,
+            config=self.config,
+            build=self.build,
+            record=record,
+            environment=env_vars,
+        )
 
         # Environment used for building code, usually with Docker
         with self.build_env:
@@ -468,9 +478,11 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             if self.config.use_conda:
                 self._log('Using conda')
                 python_env_cls = Conda
-            self.python_env = python_env_cls(version=self.version,
-                                             build_env=self.build_env,
-                                             config=self.config)
+            self.python_env = python_env_cls(
+                version=self.version,
+                build_env=self.build_env,
+                config=self.config,
+            )
 
             try:
                 self.setup_python_environment()
@@ -706,11 +718,11 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         """
         Build search data with separate build.
 
-        Unless the project has the feature to allow
-        building the JSON search artifacts in the html build step.
+        Unless the project has the feature to allow building the JSON search
+        artifacts in the html build step.
         """
         build_json_in_html_builder = self.project.has_feature(
-            Feature.BUILD_JSON_ARTIFACTS_WITH_HTML
+            Feature.BUILD_JSON_ARTIFACTS_WITH_HTML,
         )
         if self.build_search and build_json_in_html_builder:
             # Already built in the html step
@@ -753,7 +765,10 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         only raise a warning exception here. A hard error will halt the build
         process.
         """
-        builder = get_builder_class(builder_class)(self.build_env, python_env=self.python_env)
+        builder = get_builder_class(builder_class)(
+            self.build_env,
+            python_env=self.python_env
+        )
         success = builder.build()
         builder.move()
         return success
@@ -828,42 +843,69 @@ def move_files(version_pk, hostname, html=False, localmedia=False, search=False,
     :type epub: bool
     """
     version = Version.objects.get(pk=version_pk)
-    log.debug(LOG_TEMPLATE.format(project=version.project.slug, version=version.slug,
-                                  msg='Moving files'))
+    log.debug(
+        LOG_TEMPLATE.format(
+            project=version.project.slug,
+            version=version.slug,
+            msg='Moving files',
+        )
+    )
 
     if html:
         from_path = version.project.artifact_path(
-            version=version.slug, type_=version.project.documentation_type)
+            version=version.slug,
+            type_=version.project.documentation_type,
+        )
         target = version.project.rtd_build_path(version.slug)
         Syncer.copy(from_path, target, host=hostname)
 
     if 'sphinx' in version.project.documentation_type:
         if search:
             from_path = version.project.artifact_path(
-                version=version.slug, type_='sphinx_search')
+                version=version.slug,
+                type_='sphinx_search',
+            )
             to_path = version.project.get_production_media_path(
-                type_='json', version_slug=version.slug, include_file=False)
+                type_='json',
+                version_slug=version.slug,
+                include_file=False,
+            )
             Syncer.copy(from_path, to_path, host=hostname)
 
         if localmedia:
             from_path = version.project.artifact_path(
-                version=version.slug, type_='sphinx_localmedia')
+                version=version.slug,
+                type_='sphinx_localmedia',
+            )
             to_path = version.project.get_production_media_path(
-                type_='htmlzip', version_slug=version.slug, include_file=False)
+                type_='htmlzip',
+                version_slug=version.slug,
+                include_file=False,
+            )
             Syncer.copy(from_path, to_path, host=hostname)
 
         # Always move PDF's because the return code lies.
         if pdf:
-            from_path = version.project.artifact_path(version=version.slug,
-                                                      type_='sphinx_pdf')
+            from_path = version.project.artifact_path(
+                version=version.slug,
+                type_='sphinx_pdf',
+            )
             to_path = version.project.get_production_media_path(
-                type_='pdf', version_slug=version.slug, include_file=False)
+                type_='pdf',
+                version_slug=version.slug,
+                include_file=False,
+            )
             Syncer.copy(from_path, to_path, host=hostname)
         if epub:
-            from_path = version.project.artifact_path(version=version.slug,
-                                                      type_='sphinx_epub')
+            from_path = version.project.artifact_path(
+                version=version.slug,
+                type_='sphinx_epub',
+            )
             to_path = version.project.get_production_media_path(
-                type_='epub', version_slug=version.slug, include_file=False)
+                type_='epub',
+                version_slug=version.slug,
+                include_file=False,
+            )
             Syncer.copy(from_path, to_path, host=hostname)
 
 
@@ -968,22 +1010,36 @@ def fileify(version_pk, commit):
     project = version.project
 
     if not commit:
-        log.info(LOG_TEMPLATE
-                 .format(project=project.slug, version=version.slug,
-                         msg=('Imported File not being built because no commit '
-                              'information')))
+        log.info(
+            LOG_TEMPLATE.format(
+                project=project.slug,
+                version=version.slug,
+                msg=(
+                    'Imported File not being built because no commit '
+                    'information'
+                ),
+            )
+        )
         return
 
     path = project.rtd_build_path(version.slug)
     if path:
-        log.info(LOG_TEMPLATE
-                 .format(project=version.project.slug, version=version.slug,
-                         msg='Creating ImportedFiles'))
+        log.info(
+            LOG_TEMPLATE.format(
+                project=version.project.slug,
+                version=version.slug,
+                msg='Creating ImportedFiles',
+            )
+        )
         _manage_imported_files(version, path, commit)
     else:
-        log.info(LOG_TEMPLATE
-                 .format(project=project.slug, version=version.slug,
-                         msg='No ImportedFile files'))
+        log.info(
+            LOG_TEMPLATE.format(
+                project=project.slug,
+                version=version.slug,
+                msg='No ImportedFile files',
+            )
+        )
 
 
 def _manage_imported_files(version, path, commit):
@@ -1049,8 +1105,13 @@ def email_notification(version, build, email):
     :param build: :py:class:`Build` instance that failed
     :param email: Email recipient address
     """
-    log.debug(LOG_TEMPLATE.format(project=version.project.slug, version=version.slug,
-                                  msg='sending email to: %s' % email))
+    log.debug(
+        LOG_TEMPLATE.format(
+            project=version.project.slug,
+            version=version.slug,
+            msg='sending email to: %s' % email,
+        )
+    )
 
     # We send only what we need from the Django model objects here to avoid
     # serialization problems in the ``readthedocs.core.tasks.send_email_task``
@@ -1106,11 +1167,15 @@ def webhook_notification(version, build, hook_url):
             'id': build.id,
             'success': build.success,
             'date': build.date.strftime('%Y-%m-%d %H:%M:%S'),
-        }
+        },
     })
-    log.debug(LOG_TEMPLATE
-              .format(project=project.slug, version='',
-                      msg='sending notification to: %s' % hook_url))
+    log.debug(
+        LOG_TEMPLATE.format(
+            project=project.slug,
+            version='',
+            msg='sending notification to: %s' % hook_url,
+        )
+    )
     try:
         requests.post(hook_url, data=data)
     except Exception:
@@ -1137,11 +1202,13 @@ def update_static_metadata(project_pk, path=None):
     if not path:
         path = project.static_metadata_path()
 
-    log.info(LOG_TEMPLATE.format(
-        project=project.slug,
-        version='',
-        msg='Updating static metadata',
-    ))
+    log.info(
+        LOG_TEMPLATE.format(
+            project=project.slug,
+            version='',
+            msg='Updating static metadata',
+        )
+    )
     translations = [trans.language for trans in project.translations.all()]
     languages = set(translations)
     # Convert to JSON safe types
@@ -1158,11 +1225,13 @@ def update_static_metadata(project_pk, path=None):
         json.dump(metadata, fh)
         fh.close()
     except (AttributeError, IOError) as e:
-        log.debug(LOG_TEMPLATE.format(
-            project=project.slug,
-            version='',
-            msg='Cannot write to metadata.json: {0}'.format(e)
-        ))
+        log.debug(
+            LOG_TEMPLATE.format(
+                project=project.slug,
+                version='',
+                msg='Cannot write to metadata.json: {0}'.format(e),
+            )
+        )
 
 
 # Random Tasks
@@ -1174,7 +1243,7 @@ def remove_dir(path):
     This is mainly a wrapper around shutil.rmtree so that app servers can kill
     things on the build server.
     """
-    log.info("Removing %s", path)
+    log.info('Removing %s', path)
     shutil.rmtree(path, ignore_errors=True)
 
 
@@ -1224,7 +1293,8 @@ def finish_inactive_builds():
 
         if build.project.container_time_limit:
             custom_delta = datetime.timedelta(
-                seconds=int(build.project.container_time_limit))
+                seconds=int(build.project.container_time_limit),
+            )
             if build.date + custom_delta > datetime.datetime.now():
                 # Do not mark as FINISHED builds with a custom time limit that wasn't
                 # expired yet (they are still building the project version)
@@ -1235,7 +1305,7 @@ def finish_inactive_builds():
         build.error = _(
             'This build was terminated due to inactivity. If you '
             'continue to encounter this error, file a support '
-            'request with and reference this build id ({0}).'.format(build.pk)
+            'request with and reference this build id ({0}).'.format(build.pk),
         )
         build.save()
         builds_finished += 1


### PR DESCRIPTION
There are some exceptions risen while building documentation that are considered an ERROR from the Build perspective, but for our application are just a WARNING and shouldn't be logged as ERROR (sent to Sentry).

It's not an ERROR in our application but a WARNING that the user's documentation couldn't be built.

This will help us to find Sentry more useful than it's right now as we are getting close to have logged only things that need human/dev attention.

> NOTE: this is the most important commit https://github.com/rtfd/readthedocs.org/pull/4495/commits/1dd850a4e276b4849f45ebe3eabdc17e61be0cc9, the first one is a minimum refactor and the last one introduces some style changes

Closes: #4109 