### PR TITLE
Only use HostHeaderSSLAdapter for SSL/HTTPS connections

### DIFF
--- a/readthedocs/api/client.py
+++ b/readthedocs/api/client.py
@@ -7,7 +7,7 @@ from __future__ import (
 import logging
 
 from django.conf import settings
-from requests import Session
+import requests
 from requests_toolbelt.adapters import host_header_ssl
 from slumber import API
 
@@ -20,13 +20,17 @@ API_HOST = getattr(settings, 'SLUMBER_API_HOST', 'https://readthedocs.org')
 
 
 def setup_api():
-    session = Session()
+    session = requests.Session()
     if API_HOST.startswith('https'):
         # Only use the HostHeaderSSLAdapter for HTTPS connections
-        session.mount(
-            API_HOST,
-            host_header_ssl.HostHeaderSSLAdapter(),
-        )
+        adapter_class = host_header_ssl.HostHeaderSSLAdapter
+    else:
+        adapter_class = requests.adapters.HTTPAdapter
+
+    session.mount(
+        API_HOST,
+        adapter_class(max_retries=3),
+    )
     session.headers.update({'Host': PRODUCTION_DOMAIN})
     api_config = {
         'base_url': '%s/api/v1/' % API_HOST,

--- a/readthedocs/api/client.py
+++ b/readthedocs/api/client.py
@@ -21,7 +21,12 @@ API_HOST = getattr(settings, 'SLUMBER_API_HOST', 'https://readthedocs.org')
 
 def setup_api():
     session = Session()
-    session.mount(API_HOST, host_header_ssl.HostHeaderSSLAdapter())
+    if API_HOST.startswith('https'):
+        # Only use the HostHeaderSSLAdapter for HTTPS connections
+        session.mount(
+            API_HOST,
+            host_header_ssl.HostHeaderSSLAdapter(),
+        )
     session.headers.update({'Host': PRODUCTION_DOMAIN})
     api_config = {
         'base_url': '%s/api/v1/' % API_HOST,

--- a/readthedocs/restapi/client.py
+++ b/readthedocs/restapi/client.py
@@ -37,12 +37,14 @@ class DrfJsonSerializer(serialize.JsonSerializer):
 
 def setup_api():
     session = requests.Session()
-    session.mount(
-        API_HOST,
-        host_header_ssl.HostHeaderSSLAdapter(
-            max_retries=3,
-        ),
-    )
+    if API_HOST.startswith('https'):
+        # Only use the HostHeaderSSLAdapter for HTTPS connections
+        session.mount(
+            API_HOST,
+            host_header_ssl.HostHeaderSSLAdapter(
+                max_retries=3,
+            ),
+        )
     session.headers.update({'Host': PRODUCTION_DOMAIN})
     api_config = {
         'base_url': '%s/api/v2/' % API_HOST,

--- a/readthedocs/restapi/client.py
+++ b/readthedocs/restapi/client.py
@@ -39,12 +39,14 @@ def setup_api():
     session = requests.Session()
     if API_HOST.startswith('https'):
         # Only use the HostHeaderSSLAdapter for HTTPS connections
-        session.mount(
-            API_HOST,
-            host_header_ssl.HostHeaderSSLAdapter(
-                max_retries=3,
-            ),
-        )
+        adapter_class = host_header_ssl.HostHeaderSSLAdapter
+    else:
+        adapter_class = requests.adapters.HTTPAdapter
+
+    session.mount(
+        API_HOST,
+        adapter_class(max_retries=3),
+    )
     session.headers.update({'Host': PRODUCTION_DOMAIN})
     api_config = {
         'base_url': '%s/api/v2/' % API_HOST,


### PR DESCRIPTION
We made a mistake using `HostHeaderSSLAdapter` even when the connection wasn't HTTPS (in dev, that is). This causes problems connecting to the API.

Fixes #4494