### PR TITLE
Support ads on pallets themes

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/constants.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/constants.js
@@ -5,15 +5,34 @@ var exports = {
     THEME_ALABASTER: 'alabaster',
     THEME_MKDOCS_RTD: 'readthedocs',
 
+    // Alabaster-like
+    THEME_CELERY: 'sphinx_celery',
+    THEME_BABEL: 'babel',
+    THEME_CLICK: 'click',
+    THEME_FLASK_SQLALCHEMY: 'flask-sqlalchemy',
+    THEME_FLASK: 'flask',
+    THEME_JINJA: 'jinja',
+    THEME_PLATTER: 'platter',
+    THEME_POCOO: 'pocoo',
+    THEME_WERKZEUG: 'werkzeug',
+
     DEFAULT_PROMO_PRIORITY: 5,
     MINIMUM_PROMO_PRIORITY: 10,
     MAXIMUM_PROMO_PRIORITY: 1,
     LOW_PROMO_PRIORITY: 10,
 };
 
-exports.PROMO_SUPPORTED_THEMES = [
-    exports.THEME_RTD,
+exports.ALABASTER_LIKE_THEMES = [
     exports.THEME_ALABASTER,
+    exports.THEME_CELERY,
+    exports.THEME_BABEL,
+    exports.THEME_CLICK,
+    exports.THEME_FLASK_SQLALCHEMY,
+    exports.THEME_FLASK,
+    exports.THEME_JINJA,
+    exports.THEME_PLATTER,
+    exports.THEME_POCOO,
+    exports.THEME_WERKZEUG,
 ];
 
 exports.PROMO_TYPES = {

--- a/readthedocs/core/static-src/core/js/doc-embed/constants.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/constants.js
@@ -3,7 +3,6 @@
 var exports = {
     THEME_RTD: 'sphinx_rtd_theme',
     THEME_ALABASTER: 'alabaster',
-    THEME_CELERY: 'sphinx_celery',
     THEME_MKDOCS_RTD: 'readthedocs',
 
     DEFAULT_PROMO_PRIORITY: 5,
@@ -15,7 +14,6 @@ var exports = {
 exports.PROMO_SUPPORTED_THEMES = [
     exports.THEME_RTD,
     exports.THEME_ALABASTER,
-    exports.THEME_CELERY
 ];
 
 exports.PROMO_TYPES = {

--- a/readthedocs/core/static-src/core/js/doc-embed/footer.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/footer.js
@@ -7,7 +7,7 @@ function injectFooter(data) {
 
     // If the theme looks like ours, update the existing badge
     // otherwise throw a a full one into the page.
-    if (config.is_rtd_theme()) {
+    if (config.is_rtd_like_theme()) {
         $("div.rst-other-versions").html(data['html']);
     } else {
         $("body").append(data['html']);

--- a/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
@@ -7,17 +7,22 @@
 var constants = require('./constants');
 
 var configMethods = {
-    is_rtd_theme: function () {
-        return this.get_theme_name() === constants.THEME_RTD;
+    is_rtd_like_theme: function () {
+        if ($('div.rst-other-versions').length === 1) {
+            // Crappy heuristic, but people change the theme name
+            // So we have to do some duck typing.
+            return true;
+        }
+        return this.theme === constants.THEME_RTD || this.theme === constants.THEME_MKDOCS_RTD;
     },
 
-    is_alabaster_theme: function () {
+    is_alabaster_like_theme: function () {
         // Returns true for Alabaster-like themes (eg. flask, celery)
-        return this.get_theme_name() === constants.THEME_ALABASTER;
+        return constants.ALABASTER_LIKE_THEMES.indexOf(this.get_theme_name()) > -1;
     },
 
     theme_supports_promo: function () {
-        return constants.PROMO_SUPPORTED_THEMES.indexOf(this.get_theme_name()) > -1;
+        return this.is_rtd_like_theme() || this.is_alabaster_like_theme();
     },
 
     is_sphinx_builder: function () {
@@ -29,17 +34,6 @@ var configMethods = {
     },
 
     get_theme_name: function () {
-        // Crappy heuristic, but people change the theme name on us.
-        // So we have to do some duck typing.
-        if (this.theme !== constants.THEME_RTD && this.theme !== constants.THEME_ALABASTER) {
-            if (this.theme === constants.THEME_MKDOCS_RTD) {
-                return constants.THEME_RTD;
-            } else if ($('div.rst-other-versions').length === 1) {
-                return constants.THEME_RTD;
-            } else if ($('div.sphinxsidebar > div.sphinxsidebarwrapper').length === 1) {
-                return constants.THEME_ALABASTER;
-            }
-        }
         return this.theme;
     },
 

--- a/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
@@ -11,6 +11,11 @@ var configMethods = {
         return this.get_theme_name() === constants.THEME_RTD;
     },
 
+    is_alabaster_theme: function () {
+        // Returns true for Alabaster-like themes (eg. flask, celery)
+        return this.get_theme_name() === constants.THEME_ALABASTER;
+    },
+
     theme_supports_promo: function () {
         return constants.PROMO_SUPPORTED_THEMES.indexOf(this.get_theme_name()) > -1;
     },
@@ -24,14 +29,15 @@ var configMethods = {
     },
 
     get_theme_name: function () {
-        // Crappy heuristic, but people change the theme name on us.  So we have to
-        // do some duck typing.
-        if (this.theme !== constants.THEME_RTD) {
+        // Crappy heuristic, but people change the theme name on us.
+        // So we have to do some duck typing.
+        if (this.theme !== constants.THEME_RTD && this.theme !== constants.THEME_ALABASTER) {
             if (this.theme === constants.THEME_MKDOCS_RTD) {
                 return constants.THEME_RTD;
-            }
-            if ($('div.rst-other-versions').length === 1) {
+            } else if ($('div.rst-other-versions').length === 1) {
                 return constants.THEME_RTD;
+            } else if ($('div.sphinxsidebar > div.sphinxsidebarwrapper').length === 1) {
+                return constants.THEME_ALABASTER;
             }
         }
         return this.theme;

--- a/readthedocs/core/static-src/core/js/doc-embed/sphinx.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sphinx.js
@@ -44,7 +44,7 @@ function init() {
             }, 1000);
         });
 
-        if (rtd.is_rtd_theme()) {
+        if (rtd.is_rtd_like_theme()) {
             // Add a scrollable element to the sidebar on the RTD sphinx theme
             // This fix is for sphinx_rtd_theme<=0.1.8
             var navBar = jquery('div.wy-side-scroll:first');

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -18,13 +18,13 @@ function create_sidebar_placement() {
     var class_name;         // Used for theme specific CSS customizations
     var offset;
 
-    if (rtd.is_mkdocs_builder() && rtd.is_rtd_theme()) {
+    if (rtd.is_mkdocs_builder() && rtd.is_rtd_like_theme()) {
         selector = 'nav.wy-nav-side';
         class_name = 'ethical-rtd';
-    } else if (rtd.is_rtd_theme()) {
+    } else if (rtd.is_rtd_like_theme()) {
         selector = 'nav.wy-nav-side > div.wy-side-scroll';
         class_name = 'ethical-rtd';
-    } else if (rtd.is_alabaster_theme()) {
+    } else if (rtd.is_alabaster_like_theme()) {
         selector = 'div.sphinxsidebar > div.sphinxsidebarwrapper';
         class_name = 'ethical-alabaster';
     }
@@ -62,10 +62,10 @@ function create_footer_placement() {
     var class_name;
     var offset;
 
-    if (rtd.is_rtd_theme()) {
+    if (rtd.is_rtd_like_theme()) {
         selector = $('<div />').insertAfter('footer hr');
         class_name = 'ethical-rtd';
-    } else if (rtd.is_alabaster_theme()) {
+    } else if (rtd.is_alabaster_like_theme()) {
         selector = 'div.bodywrapper .body';
         class_name = 'ethical-alabaster';
     }

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -24,8 +24,7 @@ function create_sidebar_placement() {
     } else if (rtd.is_rtd_theme()) {
         selector = 'nav.wy-nav-side > div.wy-side-scroll';
         class_name = 'ethical-rtd';
-    } else if (rtd.get_theme_name() === constants.THEME_ALABASTER ||
-               rtd.get_theme_name() === constants.THEME_CELERY) {
+    } else if (rtd.is_alabaster_theme()) {
         selector = 'div.sphinxsidebar > div.sphinxsidebarwrapper';
         class_name = 'ethical-alabaster';
     }
@@ -66,8 +65,7 @@ function create_footer_placement() {
     if (rtd.is_rtd_theme()) {
         selector = $('<div />').insertAfter('footer hr');
         class_name = 'ethical-rtd';
-    } else if (rtd.get_theme_name() === constants.THEME_ALABASTER ||
-               rtd.get_theme_name() === constants.THEME_CELERY) {
+    } else if (rtd.is_alabaster_theme()) {
         selector = 'div.bodywrapper .body';
         class_name = 'ethical-alabaster';
     }


### PR DESCRIPTION
This will allow showing ads on "alabaster-like" themes which includes the pallets themes. It also no longer handles celery as a special case but as another "alabaster-like" theme.

## Testing

To test on pallets themes you can:

- Create a local project from the repo https://github.com/pallets/flask/tree/rtd (use `rtd` branch and Python3)
- Build the docs
- Load the docs and verify that ads are present (assuming you have the ad code)

## Screenshots

### A sidebar ad
<img width="870" alt="screen shot 2018-08-08 at 4 29 10 pm" src="https://user-images.githubusercontent.com/185043/43869613-48e8d140-9b28-11e8-8ce9-425503ff4ee9.png">

### A footer ad
<img width="1070" alt="screen shot 2018-08-08 at 4 29 35 pm" src="https://user-images.githubusercontent.com/185043/43869614-4901bebc-9b28-11e8-93da-56eda27cc2ca.png">
