### PR TITLE
Fix Exact Redirect to work properly when using $rest keyword

### DIFF
--- a/docs/user-defined-redirects.rst
+++ b/docs/user-defined-redirects.rst
@@ -73,7 +73,8 @@ but just the user-controlled section of the URL.
 
 .. tip::
 
-   *Page Redirects* can redirect URLs **outside** Read the Docs platform.
+   *Page Redirects* can redirect URLs **outside** Read the Docs platform
+   just by defining the "To URL" as the absolute URL you want to redirect to.
 
 
 Exact Redirects
@@ -119,7 +120,8 @@ The readers of your documentation will now be redirected as::
 
 .. tip::
 
-   *Exact Redirects* can redirect URLs **outside** Read the Docs platform.
+   *Exact Redirects* can redirect URLs **outside** Read the Docs platform
+   just by defining the "To URL" as the absolute URL you want to redirect to.
 
 
 Sphinx Redirects

--- a/docs/user-defined-redirects.rst
+++ b/docs/user-defined-redirects.rst
@@ -71,6 +71,10 @@ You would set the following configuration::
 Note that the ``/`` at the start doesn't count the ``/en/latest``, 
 but just the user-controlled section of the URL.
 
+.. tip::
+
+   *Page Redirects* can redirect URLs **outside** Read the Docs platform.
+
 
 Exact Redirects
 ~~~~~~~~~~~~~~~
@@ -111,6 +115,11 @@ The readers of your documentation will now be redirected as::
 
   docs.example.com/en/2.0/dev/install.html ->
   docs.example.com/en/3.0/dev/install.html
+
+
+.. tip::
+
+   *Exact Redirects* can redirect URLs **outside** Read the Docs platform.
 
 
 Sphinx Redirects

--- a/docs/user-defined-redirects.rst
+++ b/docs/user-defined-redirects.rst
@@ -1,7 +1,7 @@
 User-defined Redirects
 ======================
 
-You can set up redirects for a project in your project dashboard's Redirects page. 
+You can set up redirects for a project in your project dashboard's Redirects page.
 
 Quick Summary
 -------------
@@ -9,7 +9,7 @@ Quick Summary
 * Log into your readthedocs.org account.
 * From your dashboard, select the project on which you wish to add redirects.
 * From the project's top navigation bar, select the Admin tab.
-* From the left navigation menu, select Redirects. 
+* From the left navigation menu, select Redirects.
 * In the form box "Redirect Type" select the type of redirect you want. See below for detail.
 * Depending on the redirect type you select, enter FROM and/or TO URL as needed.
 * When finished, click the SUBMIT Button.
@@ -40,8 +40,8 @@ The example configuration would be::
 
 Your users query would now redirect in the following manner::
 
-	docs.example.com/dev/install.html ->
-	docs.example.com/en/latest/install.html
+        docs.example.com/dev/install.html ->
+        docs.example.com/en/latest/install.html
 
 Where ``en`` and ``latest`` are the default language and version values for your project.
 
@@ -68,7 +68,7 @@ You would set the following configuration::
     From URL: /example.html
     To URL: /examples/intro.html
 
-Note that the ``/`` at the start doesn't count the ``/en/latest``, 
+Note that the ``/`` at the start doesn't count the ``/en/latest``,
 but just the user-controlled section of the URL.
 
 .. tip::
@@ -95,8 +95,8 @@ The example configuration would be::
 
 Your users query would now redirect in the following manner::
 
-	docs.example.com/dev/install.html ->
-	docs.example.com/en/latest/installing-your-site.html
+        docs.example.com/dev/install.html ->
+        docs.example.com/en/latest/installing-your-site.html
 
 Note that you should insert the desired language for "en" and version for "latest" to
 achieve the desired redirect.
@@ -129,7 +129,7 @@ We also support redirects for changing the type of documentation Sphinx is build
 If you switch between *HTMLDir* and *HTML*, your URL's will change.
 A page at ``/en/latest/install.html`` will be served at ``/en/latest/install/``,
 or vice versa.
-The built in redirects for this will handle redirecting users appropriately. 
+The built in redirects for this will handle redirecting users appropriately.
 
 Implementation
 --------------
@@ -140,4 +140,3 @@ This means that redirects will only happen in the case of a *404 File Not Found*
 
 In the future we might implement redirect logic in Javascript,
 but this first version is only implemented in the 404 handlers.
-

--- a/docs/user-defined-redirects.rst
+++ b/docs/user-defined-redirects.rst
@@ -6,7 +6,7 @@ You can set up redirects for a project in your project dashboard's Redirects pag
 Quick Summary
 -------------
 
-* Log into your Readthedocs.com Admin account.
+* Log into your readthedocs.org account.
 * From your dashboard, select the project on which you wish to add redirects.
 * From the project's top navigation bar, select the Admin tab.
 * From the left navigation menu, select Redirects. 
@@ -18,6 +18,7 @@ Your redirects will be effective immediately.
 
 Redirect Types
 --------------
+
 Prefix Redirects
 ~~~~~~~~~~~~~~~~
 
@@ -44,6 +45,14 @@ Your users query would now redirect in the following manner::
 
 Where ``en`` and ``latest`` are the default language and version values for your project.
 
+
+.. note::
+
+   In other words, a *Prefix Redirect* removes a prefix from the original URL.
+   This prefix is removed from the rest of the URL's ``path`` after ``/$lang/$version``.
+   For example, if the URL is ``/es/1.0/guides/tutorial/install.html`` the "From URL's prefix" will be removed from ``/guides/tutorial/install.html`` part.
+
+
 Page Redirects
 ~~~~~~~~~~~~~~
 
@@ -61,6 +70,7 @@ You would set the following configuration::
 
 Note that the ``/`` at the start doesn't count the ``/en/latest``, 
 but just the user-controlled section of the URL.
+
 
 Exact Redirects
 ~~~~~~~~~~~~~~~
@@ -86,6 +96,22 @@ Your users query would now redirect in the following manner::
 
 Note that you should insert the desired language for "en" and version for "latest" to
 achieve the desired redirect.
+
+*Exact Redirects* could be also useful to redirect a whole sub-path to a different one by using a special ``$rest`` keyword in the "From URL".
+Let's say that you want to redirect your readers of your version ``2.0`` of your documentation under ``/en/2.0/`` because it's deprecated,
+to the newest ``3.0`` version of it at ``/en/3.0/``.
+
+This example would be::
+
+  Type: Exact Redirect
+  From URL: /en/2.0/$rest
+  To URL: /en/3.0/
+
+The readers of your documentation will now be redirected as::
+
+  docs.example.com/en/2.0/dev/install.html ->
+  docs.example.com/en/3.0/dev/install.html
+
 
 Sphinx Redirects
 ~~~~~~~~~~~~~~~~

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -613,29 +613,6 @@ class RedirectForm(forms.ModelForm):
         self.project = kwargs.pop('project', None)
         super(RedirectForm, self).__init__(*args, **kwargs)
 
-    def clean(self):
-        redirect_type = self.cleaned_data['redirect_type']
-        from_url = self.cleaned_data['from_url']
-        to_url = self.cleaned_data['to_url']
-        if redirect_type == 'exact':
-            if '$rest' in from_url:
-                # Leading slash
-                if not from_url.startswith('/') or not to_url.startswith('/'):
-                    raise forms.ValidationError(
-                        _('Exact Redirects require the leading slash (/) in both URLs when using $rest keyword'),  # noqa
-                    )
-                # Trailing slash
-                if from_url.endswith('/'):
-                    raise forms.ValidationError(
-                        _("Exact Redirects doesn't allow trailing slash (/) in From URL when using $rest keyword"),  # noqa
-                    )
-                if not to_url.endswith('/'):
-                    raise forms.ValidationError(
-                        _('Exact Redirects require a trailing slash (/) in To URL when using $rest keyword'),  # noqa
-                    )
-
-        return self.cleaned_data
-
     def save(self, **_):  # pylint: disable=arguments-differ
         # TODO this should respect the unused argument `commit`. It's not clear
         # why this needs to be a call to `create`, instead of relying on the

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -613,6 +613,29 @@ class RedirectForm(forms.ModelForm):
         self.project = kwargs.pop('project', None)
         super(RedirectForm, self).__init__(*args, **kwargs)
 
+    def clean(self):
+        redirect_type = self.cleaned_data['redirect_type']
+        from_url = self.cleaned_data['from_url']
+        to_url = self.cleaned_data['to_url']
+        if redirect_type == 'exact':
+            if '$rest' in from_url:
+                # Leading slash
+                if not from_url.startswith('/') or not to_url.startswith('/'):
+                    raise forms.ValidationError(
+                        _('Exact Redirects require the leading slash (/) in both URLs when using $rest keyword'),  # noqa
+                    )
+                # Trailing slash
+                if from_url.endswith('/'):
+                    raise forms.ValidationError(
+                        _("Exact Redirects doesn't allow trailing slash (/) in From URL when using $rest keyword"),  # noqa
+                    )
+                if not to_url.endswith('/'):
+                    raise forms.ValidationError(
+                        _('Exact Redirects require a trailing slash (/) in To URL when using $rest keyword'),  # noqa
+                    )
+
+        return self.cleaned_data
+
     def save(self, **_):  # pylint: disable=arguments-differ
         # TODO this should respect the unused argument `commit`. It's not clear
         # why this needs to be a call to `create`, instead of relying on the

--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -36,10 +36,14 @@ TYPE_CHOICES = (
     # ('advanced', _('Advanced')),
 )
 
+# FIXME: this help_text message should be dynamic since "Absolute path" doesn't
+# make sense for "Prefix Redirects" since the from URL is considered after the
+# ``/$lang/$version/`` part. Also, there is a feature for the "Exact
+# Redirects" that should be mentioned here: the usage of ``$rest``
 from_url_helptext = _('Absolute path, excluding the domain. '
                       'Example: <b>/docs/</b>  or <b>/install.html</b>'
                       )
-to_url_helptext = _('Absolute or relative URL. Examples: '
+to_url_helptext = _('Absolute or relative URL. Example: '
                     '<b>/tutorial/install.html</b>'
                     )
 redirect_type_helptext = _('The type of redirect you wish to use.')

--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -154,8 +154,8 @@ class Redirect(models.Model):
         # Handle full sub-level redirects
         if '$rest' in self.from_url:
             match = self.from_url.split('$rest')[0]
-            if path.startswith(match):
-                cut_path = re.sub('^%s' % match, self.to_url, path)
+            if full_path.startswith(match):
+                cut_path = re.sub('^%s' % match, self.to_url, full_path)
                 return cut_path
 
     def redirect_sphinx_html(self, path, language=None, version_slug=None):

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -159,6 +159,33 @@ class RedirectAppTests(TestCase):
             r['Location'], 'http://pip.readthedocs.org/en/latest/tutorial/install.html')
 
     @override_settings(USE_SUBDOMAIN=True)
+    def test_redirect_exact_with_rest(self):
+        """
+        Exact redirects can have a ``$rest`` in the ``from_url``.
+
+        Use case: we want to deprecate version ``2.0`` and replace it by
+        ``3.0``. We write an exact redirect from ``/en/2.0/$rest`` to
+        ``/en/3.0/``.
+        """
+        Redirect.objects.create(
+            project=self.pip, redirect_type='exact',
+            from_url='/en/latest/$rest', to_url='/en/version/', # change version
+        )
+        r = self.client.get('/en/latest/guides/install.html', HTTP_HOST='pip.readthedocs.org')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'http://pip.readthedocs.org/en/version/guides/install.html')
+
+        Redirect.objects.create(
+            project=self.pip, redirect_type='exact',
+            from_url='/es/version/$rest', to_url='/en/master/', # change language and version
+        )
+        r = self.client.get('/es/version/guides/install.html', HTTP_HOST='pip.readthedocs.org')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'http://pip.readthedocs.org/en/master/guides/install.html')
+
+    @override_settings(USE_SUBDOMAIN=True)
     def test_redirect_keeps_version_number(self):
         Redirect.objects.create(
             project=self.pip, redirect_type='page',

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
-
+from __future__ import absolute_import
+from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -9,7 +9,6 @@ from django_dynamic_fixture import fixture
 from mock import patch
 
 from readthedocs.builds.constants import LATEST
-from readthedocs.projects.forms import RedirectForm
 from readthedocs.projects.models import Project
 from readthedocs.redirects.models import Redirect
 
@@ -353,82 +352,3 @@ class GetFullPathTests(TestCase):
             self.redirect.get_full_path('faq.html'),
             '/docs/read-the-docs/faq.html'
         )
-
-
-class RedirectFormTests(TestCase):
-
-    def test_sphinx_html_redirect(self):
-        data = {
-            'redirect_type': 'sphinx_html',
-        }
-        form = RedirectForm(data=data)
-        self.assertTrue(form.is_valid())
-
-    def test_sphinx_htmldir_redirect(self):
-        data = {
-            'redirect_type': 'sphinx_htmldir',
-        }
-        form = RedirectForm(data=data)
-        self.assertTrue(form.is_valid())
-
-    def test_prefix_redirect(self):
-        data = {
-            'from_url': '/oldurl/',
-            'redirect_type': 'prefix',
-        }
-        form = RedirectForm(data=data)
-        self.assertTrue(form.is_valid())
-
-    def test_page_redirect(self):
-        data = {
-            'from_url': '/install.html',
-            'to_url': '/tutorial/install.html',
-            'redirect_type': 'page',
-        }
-        form = RedirectForm(data=data)
-        self.assertTrue(form.is_valid())
-
-    def test_exact_redirect(self):
-        data = {
-            'from_url': '/en/2.0/$rest',
-            'to_url': '/en/3.0/',
-            'redirect_type': 'exact',
-        }
-        form = RedirectForm(data=data)
-        self.assertTrue(form.is_valid())
-
-    def test_exact_redirect_leading_slash_from_url(self):
-        data = {
-            'from_url': 'no/leading/slash/$rest',
-            'to_url': '/en/latest/',
-            'redirect_type': 'exact',
-        }
-        form = RedirectForm(data=data)
-        self.assertFalse(form.is_valid())
-
-    def test_exact_redirect_leading_slash_to_url(self):
-        data = {
-            'from_url': '/jp/latest/$rest',
-            'to_url': 'no/leading/slash/',
-            'redirect_type': 'exact',
-        }
-        form = RedirectForm(data=data)
-        self.assertFalse(form.is_valid())
-
-    def test_exact_redirect_trailing_slash_from_url(self):
-        data = {
-            'from_url': '/trailing/slash/$rest/',
-            'to_url': '/en/latest/',
-            'redirect_type': 'exact',
-        }
-        form = RedirectForm(data=data)
-        self.assertFalse(form.is_valid())
-
-    def test_exact_redirect_trailing_slash_to_url(self):
-        data = {
-            'from_url': '/jp/latest/$rest',
-            'to_url': '/no/trailing/slash',
-            'redirect_type': 'exact',
-        }
-        form = RedirectForm(data=data)
-        self.assertFalse(form.is_valid())

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from django.core.urlresolvers import reverse
+# -*- coding: utf-8 -*-
+
 from django.http import Http404
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -9,6 +9,7 @@ from django_dynamic_fixture import fixture
 from mock import patch
 
 from readthedocs.builds.constants import LATEST
+from readthedocs.projects.forms import RedirectForm
 from readthedocs.projects.models import Project
 from readthedocs.redirects.models import Redirect
 
@@ -352,3 +353,82 @@ class GetFullPathTests(TestCase):
             self.redirect.get_full_path('faq.html'),
             '/docs/read-the-docs/faq.html'
         )
+
+
+class RedirectFormTests(TestCase):
+
+    def test_sphinx_html_redirect(self):
+        data = {
+            'redirect_type': 'sphinx_html',
+        }
+        form = RedirectForm(data=data)
+        self.assertTrue(form.is_valid())
+
+    def test_sphinx_htmldir_redirect(self):
+        data = {
+            'redirect_type': 'sphinx_htmldir',
+        }
+        form = RedirectForm(data=data)
+        self.assertTrue(form.is_valid())
+
+    def test_prefix_redirect(self):
+        data = {
+            'from_url': '/oldurl/',
+            'redirect_type': 'prefix',
+        }
+        form = RedirectForm(data=data)
+        self.assertTrue(form.is_valid())
+
+    def test_page_redirect(self):
+        data = {
+            'from_url': '/install.html',
+            'to_url': '/tutorial/install.html',
+            'redirect_type': 'page',
+        }
+        form = RedirectForm(data=data)
+        self.assertTrue(form.is_valid())
+
+    def test_exact_redirect(self):
+        data = {
+            'from_url': '/en/2.0/$rest',
+            'to_url': '/en/3.0/',
+            'redirect_type': 'exact',
+        }
+        form = RedirectForm(data=data)
+        self.assertTrue(form.is_valid())
+
+    def test_exact_redirect_leading_slash_from_url(self):
+        data = {
+            'from_url': 'no/leading/slash/$rest',
+            'to_url': '/en/latest/',
+            'redirect_type': 'exact',
+        }
+        form = RedirectForm(data=data)
+        self.assertFalse(form.is_valid())
+
+    def test_exact_redirect_leading_slash_to_url(self):
+        data = {
+            'from_url': '/jp/latest/$rest',
+            'to_url': 'no/leading/slash/',
+            'redirect_type': 'exact',
+        }
+        form = RedirectForm(data=data)
+        self.assertFalse(form.is_valid())
+
+    def test_exact_redirect_trailing_slash_from_url(self):
+        data = {
+            'from_url': '/trailing/slash/$rest/',
+            'to_url': '/en/latest/',
+            'redirect_type': 'exact',
+        }
+        form = RedirectForm(data=data)
+        self.assertFalse(form.is_valid())
+
+    def test_exact_redirect_trailing_slash_to_url(self):
+        data = {
+            'from_url': '/jp/latest/$rest',
+            'to_url': '/no/trailing/slash',
+            'redirect_type': 'exact',
+        }
+        form = RedirectForm(data=data)
+        self.assertFalse(form.is_valid())

--- a/readthedocs/templates/projects/project_redirects.html
+++ b/readthedocs/templates/projects/project_redirects.html
@@ -14,8 +14,8 @@
             var field_from_url = $('#id_from_url');
                 field_to_url =  $('#id_to_url');
                 option = $('#id_redirect_type').val();
-                redirect_from = ""; 
-                redirect_target = ""; 
+                redirect_from = "";
+                redirect_target = "";
 
             if (option === "prefix") {
                 redirect_from = field_from_url.val() + "faq.html";
@@ -33,7 +33,7 @@
             if (redirect_from && redirect_target) {
                 var result = "Outcome: " + redirect_from + " -> " + redirect_target;
                 $('#dynamic-redirect').text(result).show();
-            } else { 
+            } else {
                 $('#dynamic-redirect').text("").hide();
             }
         };


### PR DESCRIPTION
In #3965 we added the ability to use the `full_path` but it was added only to the first case and it wasn't considered in the case when `$rest` keyword was used.

With these changes we can "deprecate a whole sub-path" by writing a Exact Redirect like this:

``` text
/en/obsolete-version/$rest ->
/en/newest-version/
```

and all links pointing to the `obsolete-version` at any sub-path will be redirected to the newest docs.

Closes #4029
Closes #2444
Closes #3794