### PR TITLE
Use collectstatic on `media/`, without collecting user files

### DIFF
--- a/media/css/badge_only.css
+++ b/media/css/badge_only.css
@@ -1,1 +1,1 @@
-../static/core/css/badge_only.css
+../../readthedocs/core/static/core/css/badge_only.css

--- a/media/css/sphinx_rtd_theme.css
+++ b/media/css/sphinx_rtd_theme.css
@@ -1,1 +1,1 @@
-../static/core/css/theme.css
+../../readthedocs/core/static/core/css/theme.css

--- a/media/font/fontawesome_webfont.eot
+++ b/media/font/fontawesome_webfont.eot
@@ -1,1 +1,1 @@
-../static/core/font/fontawesome-webfont.eot
+../../readthedocs/core/static/core/font/fontawesome-webfont.eot

--- a/media/font/fontawesome_webfont.svg
+++ b/media/font/fontawesome_webfont.svg
@@ -1,1 +1,1 @@
-../static/core/font/fontawesome-webfont.svg
+../../readthedocs/core/static/core/font/fontawesome-webfont.svg

--- a/media/font/fontawesome_webfont.ttf
+++ b/media/font/fontawesome_webfont.ttf
@@ -1,1 +1,1 @@
-../static/core/font/fontawesome-webfont.ttf
+../../readthedocs/core/static/core/font/fontawesome-webfont.ttf

--- a/media/font/fontawesome_webfont.woff
+++ b/media/font/fontawesome_webfont.woff
@@ -1,1 +1,1 @@
-../static/core/font/fontawesome-webfont.woff
+../../readthedocs/core/static/core/font/fontawesome-webfont.woff

--- a/media/fonts
+++ b/media/fonts
@@ -1,1 +1,1 @@
-static/core/font/
+../readthedocs/core/static/core/font/

--- a/media/javascript/jquery/jquery-2.0.3.min.js
+++ b/media/javascript/jquery/jquery-2.0.3.min.js
@@ -1,1 +1,1 @@
-../../static/vendor/jquery-standalone.js
+../../../readthedocs/static/vendor/jquery-standalone.js

--- a/media/javascript/jquery/jquery-migrate-1.2.1.min.js
+++ b/media/javascript/jquery/jquery-migrate-1.2.1.min.js
@@ -1,1 +1,1 @@
-../../static/vendor/jquery-migrate-standalone.js
+../../../readthedocs/static/vendor/jquery-migrate-standalone.js

--- a/media/javascript/jquery/jquery-ui-1.8.24.custom.min.js
+++ b/media/javascript/jquery/jquery-ui-1.8.24.custom.min.js
@@ -1,1 +1,1 @@
-../../static/vendor/jquery-ui-standalone.js
+../../../readthedocs/static/vendor/jquery-ui-standalone.js

--- a/media/javascript/readthedocs-doc-embed.js
+++ b/media/javascript/readthedocs-doc-embed.js
@@ -1,1 +1,1 @@
-../static/core/js/readthedocs-doc-embed.js
+../../readthedocs/core/static/core/js/readthedocs-doc-embed.js

--- a/media/javascript/underscore.js
+++ b/media/javascript/underscore.js
@@ -1,1 +1,1 @@
-../static/vendor/underscore-standalone.js
+../../readthedocs/static/vendor/underscore-standalone.js

--- a/readthedocs/core/static.py
+++ b/readthedocs/core/static.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, print_function, unicode_literals
+
+from django.contrib.staticfiles.finders import FileSystemFinder
+
+
+class SelectiveFileSystemFinder(FileSystemFinder):
+
+    """
+    Add user media paths in ``media/`` to ignore patterns.
+
+    This allows collectstatic inside ``media/`` without collecting all of the
+    paths that include user files
+    """
+
+    def list(self, ignore_patterns):
+        ignore_patterns.extend(['epub', 'pdf', 'htmlzip', 'json', 'man'])
+        return super(SelectiveFileSystemFinder, self).list(ignore_patterns)

--- a/readthedocs/core/static.py
+++ b/readthedocs/core/static.py
@@ -14,5 +14,5 @@ class SelectiveFileSystemFinder(FileSystemFinder):
     """
 
     def list(self, ignore_patterns):
-        ignore_patterns.extend(['epub', 'pdf', 'htmlzip', 'json', 'man'])
+        ignore_patterns.extend(['epub', 'pdf', 'htmlzip', 'json', 'man', 'static'])
         return super(SelectiveFileSystemFinder, self).list(ignore_patterns)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -172,7 +172,14 @@ class CommunityBaseSettings(Settings):
     MEDIA_ROOT = os.path.join(SITE_ROOT, 'media/')
     MEDIA_URL = '/media/'
     ADMIN_MEDIA_PREFIX = '/media/admin/'
-    STATICFILES_DIRS = [os.path.join(SITE_ROOT, 'readthedocs', 'static')]
+    STATICFILES_DIRS = [
+        os.path.join(SITE_ROOT, 'readthedocs', 'static'),
+        os.path.join(SITE_ROOT, 'media'),
+    ]
+    STATICFILES_FINDERS = [
+        'readthedocs.core.static.SelectiveFileSystemFinder',
+        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    ]
 
     TEMPLATES = [
         {


### PR DESCRIPTION
This doesn't change the STATICFILES_ROOT yet, in an attempt to avoid making any
breaking changes. This is a port of #4489 that we'll merge before azure
migration