### PR TITLE
Allow modifying version slugs

### DIFF
--- a/readthedocs/builds/forms.py
+++ b/readthedocs/builds/forms.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 from builtins import object
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, ugettext
 
 from .constants import STABLE, LATEST
 from .models import VersionAlias, Version
@@ -46,7 +46,7 @@ class VersionForm(forms.ModelForm):
         super(VersionForm, self).__init__(*args, **kwargs)
         if self.instance and self.instance.slug in (LATEST, STABLE):
             self.fields['slug'].disabled = True
-            self.fields['slug'].help_text += _(' - read only for special versions')
+            self.fields['slug'].help_text += ugettext(' - read only for special versions')
 
     def clean_slug(self):
         slug = self.cleaned_data['slug']
@@ -54,7 +54,7 @@ class VersionForm(forms.ModelForm):
         version = self.instance
         if version:
             if Version.objects.filter(project=version.project, slug=slug).exclude(
-                    pk=version.pk).count() > 0:
+                    pk=version.pk).exists():
                 raise forms.ValidationError(
                     _('There is already a version for this project with that slug'),
                 )

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -394,7 +394,9 @@ def build_versions_form(project):
                 version.identifier[:8],
             )
         else:
-            label = version.verbose_name
+            label = version.slug
+            if version.slug not in version.identifier:
+                label += ' ({})'.format(version.identifier)
         attrs[field_name] = forms.BooleanField(
             label=label,
             widget=DualCheckboxWidget(version),

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -156,12 +156,9 @@ def project_version_detail(request, project_slug, version_slug):
     if request.method == 'POST' and form.is_valid():
         version = form.save()
         if form.has_changed():
-            if 'slug' in form.changed_data and version.slug not in (STABLE, LATEST):
-                # Rebuild symlinks to the new slug, remove the old slug's symlink
-                # Latest and Stable would appear here because they are disabled on the form
-                log.info('Rebuilding symlinks for %s. A version slug changed', version.project)
-                broadcast(type='app', task=tasks.symlink_project, args=[version.project.pk])
-
+            if (version.active and 'slug' in form.changed_data and
+                    version.slug not in (STABLE, LATEST)):
+                # Latest and Stable appear "changed" because they are disabled on the form
                 log.info('Triggering a build of the moved version')
                 trigger_build(version.project, version)
 

--- a/readthedocs/templates/projects/project_version_detail.html
+++ b/readthedocs/templates/projects/project_version_detail.html
@@ -14,9 +14,16 @@
 {% block content-header %}<h1>{% blocktrans with version.name as version_name %}{{ version_name }}{% endblocktrans %}</h1>{% endblock %}
 
 {% block content %}
-    <h2> Editing {{ version.slug }} </h2>
+    <h2>{% blocktrans with version_name=version.verbose_name %}Editing version {{ version_name }}{% endblocktrans %}</h2>
+
     <form method="post" action=".">
       {% csrf_token %}
+
+      <p>
+      <label>Version control identifier:</label>
+      <strong style="color: black">{{ version.identifier }}</strong>
+    </p>
+
       {{ form.as_p }}
       <p>
         <input style="display: inline;" type="submit" value="{% trans "Save" %}">

--- a/readthedocs/templates/projects/project_version_detail.html
+++ b/readthedocs/templates/projects/project_version_detail.html
@@ -20,9 +20,9 @@
       {% csrf_token %}
 
       <p>
-      <label>Version control identifier:</label>
-      <strong style="color: black">{{ version.identifier }}</strong>
-    </p>
+      <label>{% trans 'Version control identifier' %}:</label>
+        <strong style="color: black">{{ version.identifier }}</strong>
+      </p>
 
       {{ form.as_p }}
       <p>


### PR DESCRIPTION
This change allows version slugs to be modified.

- This very explicitly breaks out the `Version.slug` (the thing in the URL, mutable) from `Version.identifier` (version control identifier, immutable). The [explanations on the `Version` model](https://github.com/rtfd/readthedocs.org/blob/8282885/readthedocs/builds/models.py#L61-L79) are helpful.
- When a version slug is changed, symlinks are rebuilt and a build is triggered. I suppose we could move the version on the filesystem but triggering a build is probably cleaner and works across the multiple filesystems we have.
- The version slugs "latest" and "stable" are not editable

Fixes #4167

## Screenshot

<img width="601" alt="screen shot 2018-08-10 at 3 56 25 pm" src="https://user-images.githubusercontent.com/185043/43984530-f87b667a-9cb5-11e8-9b8d-3a7a551086b9.png">

## Alternatives
Another approach to this problem is to have an alias (eg. the `readthedocs` branch's docs could be accessed at `/en/readthedocs/` or `/en/rtd/`). However, after considering this option, I decided that having one location is probably best. If there were multiple paths, in my opinion, one should redirect to the other (eg. `/en/rtd/` -> `/en/readthedocs/`). Furthermore, the point of #4167 is to use the alias **in favor** of the actual version control branch name. I guess we could make the alias the canonical path or make that an option, but it seemed a bit like overengineering.