### PR TITLE
Update information on mkdocs build process

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -46,7 +46,12 @@ we will first look for a ``mkdocs.yml`` file in the root of your repository.
 If we don't find one,
 we will generate one for you.
 
-Then MkDocs will build any files with a ``.md`` extension within a single directory called ``docs``, ``doc``, ``Doc``, or ``book`` (this is the order in which directories are searched).
+Then MkDocs will build any files with a ``.md`` extension within the directory specifed as ``docs_dir`` in the ``mkdocs.yml``. 
+
+If no ``mkdocs.yml`` was found in the root of your repository and we generated one for you, 
+MkDocs will attempt to set ``docs_dir`` by sequentially searching for a  ``docs``, ``doc``, ``Doc``, or ``book`` directory. 
+The first of these directories that exists and contains files with a ``.md`` extension will be set to ``docs_dir`` within ``mkdocs.yml``,
+and MkDocs will build the ``.md`` files in that directory. 
 As MkDocs doesn't support automatic PDF generation, 
 Read the Docs cannot create a PDF version of your documentation with the *Mkdocs* option.
 

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -42,7 +42,7 @@ MkDocs
 ~~~~~~
 
 When you choose *Mkdocs* as your *Documentation Type*,
-we will first look for a ``mkdocs.yml`` file in the root of your repository.
+we will first look for a ``mkdocs.yml`` file in the ```doc``` or ```docs``` directory.
 If we don't find one,
 we will generate one for you.
 

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -49,7 +49,7 @@ we will generate one for you.
 Then MkDocs will build any files with a ``.md`` extension within the directory specifed as ``docs_dir`` in the ``mkdocs.yml``. 
 
 If no ``mkdocs.yml`` was found in the root of your repository and we generated one for you, 
-MkDocs will attempt to set ``docs_dir`` by sequentially searching for a  ``docs``, ``doc``, ``Doc``, or ``book`` directory. 
+Read the Docs will attempt to set ``docs_dir`` by sequentially searching for a  ``docs``, ``doc``, ``Doc``, or ``book`` directory. 
 The first of these directories that exists and contains files with a ``.md`` extension will be set to ``docs_dir`` within ``mkdocs.yml``,
 and MkDocs will build the ``.md`` files in that directory. 
 As MkDocs doesn't support automatic PDF generation, 

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -42,11 +42,11 @@ MkDocs
 ~~~~~~
 
 When you choose *Mkdocs* as your *Documentation Type*,
-we will first look for a ``mkdocs.yml`` file in the ```doc``` or ```docs``` directory.
+we will first look for a ``mkdocs.yml`` file in the root of your repository, and if not found, within a ``doc`` or ``docs`` directory.
 If we don't find one,
 we will generate one for you.
 
-Then MkDocs will build any files with a ``.md`` extension.
+Then MkDocs will build any files with a ``.md`` extension within the ``doc`` or ``docs`` directory.
 As MkDocs doesn't support automatic PDF generation, 
 Read the Docs cannot create a PDF version of your documentation with the *Mkdocs* option.
 

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -42,11 +42,11 @@ MkDocs
 ~~~~~~
 
 When you choose *Mkdocs* as your *Documentation Type*,
-we will first look for a ``mkdocs.yml`` file in the root of your repository, and if not found, within a ``doc`` or ``docs`` directory.
+we will first look for a ``mkdocs.yml`` file in the root of your repository.
 If we don't find one,
 we will generate one for you.
 
-Then MkDocs will build any files with a ``.md`` extension within the ``doc`` or ``docs`` directory.
+Then MkDocs will build any files with a ``.md`` extension within a single directory called ``docs``, ``doc``, ``Doc``, or ``book`` (this is the order in which directories are searched).
 As MkDocs doesn't support automatic PDF generation, 
 Read the Docs cannot create a PDF version of your documentation with the *Mkdocs* option.
 


### PR DESCRIPTION
This PR should resolve #4507. As per #4231, builds fail with mkdocs when markdown files are not in a `doc` or `docs` directory. The `mkdocs.yml` could either be in the root or in the `docs` directory, as per https://www.mkdocs.org/about/release-notes/#stricter-directory-validation and my own testing within my own project. 

I was able to solve this issue by moving my `mkdocs.yml` and relevant markdown files to a `docs` directory. I also tested this with a `doc` directory, see this closed [PR](https://github.com/AumitLeon/module_starter_cli/pull/32) in my project. I think it makes sense to have the docs reflect this so future users know to have their files in the correct directory.  

Of course, this doesn't solve the issue of builds failing when files are at the root, but users should be aware of the current caveat. 

This is my first PR, so I am definitely open to feedback, comments, and questions :) 