### PR TITLE
Custom domain clarifications

### DIFF
--- a/docs/alternate_domains.rst
+++ b/docs/alternate_domains.rst
@@ -46,7 +46,11 @@ By default, when you setup a custom domain to host documentation at Read the Doc
 we will attempt to provision a domain validated SSL certificate for the domain.
 This service is generously provided by Cloudflare.
 
-If your domain has configred CAA records, please do not forget to include
+After configuring your custom domain on Read the Docs,
+you can see the status of the certificate on the domain edit screen
+(**Project Admin > Domains > Edit Domain**).
+
+If your domain has configured CAA records, please do not forget to include
 Cloudflare CAA entries, see their `Certification Authority Authorization (CAA)
 FAQ <https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ>`_.
 
@@ -55,7 +59,8 @@ FAQ <https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification
     Some older setups configured a CNAME record pointing to ``readthedocs.org``
     or another variation. While these continue to resolve,
     they do not yet allow us to acquire SSL certificates for those domains.
-    Simply point the CNAME to ``readthedocs.io``.
+    Point the CNAME to ``readthedocs.io`` and re-request a certificate
+    by saving the domain (**Project Admin > Domains > Edit Domain**).
 
     If you change the CNAME, the SSL certificate issuance can take about one hour.
 

--- a/readthedocs/templates/projects/domain_list.html
+++ b/readthedocs/templates/projects/domain_list.html
@@ -12,6 +12,9 @@
 {% block project_edit_content_header %}{% trans "Domains" %}{% endblock %}
 
 {% block project_edit_content %}
+  {# Remove anytime after 2018-10-01 #}
+  <p class="empty">{% blocktrans %}Recently we added HTTPS support for custom domains. Depending on your setup, you may need to take action for your domain to support HTTPS. <a href="https://docs.readthedocs.io/en/latest/alternate_domains.html#cname-ssl">See our docs</a> for details.{% endblocktrans %}</p>
+
   <p class="help_text">
     {% trans "This allows you to add domains to your project. This allows them to live in the same namespace in the URLConf for a subdomain or CNAME." %}
   </p>


### PR DESCRIPTION
For some users with older custom domain setups (eg. CNAME to `readthedocs.org`), we were not able to issue a certificate for them. While the request to issue certificates retries for a long time, it has been a couple weeks now and they have timed out.

My goal with this PR is to notify those users that they need to re-request a certificate -- by saving the domain object -- in order to get one. Likewise, after #4483 we show the status of the domain on the domain edit screen and I want users to see that which might help uncover issues (eg. CAA, incorrect setup, time out).

Lastly, since things have changed I added a link to the docs from the domain edit screen. This should be removed in the near future (October-ish).

<img width="874" alt="screen shot 2018-08-13 at 1 24 33 pm" src="https://user-images.githubusercontent.com/185043/44056448-1fcb872a-9efd-11e8-9549-f164b98d6afd.png">
