### PR TITLE
Use the STATIC_URL for static files to avoid redirection

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -20,19 +20,19 @@ from readthedocs.doc_builder.exceptions import BuildEnvironmentError
 log = logging.getLogger(__name__)
 
 
-def get_absolute_media_url():
+def get_absolute_static_url():
     """
-    Get the fully qualified media URL from settings.
+    Get the fully qualified static URL from settings.
 
-    Mkdocs needs a full domain because it tries to link to local media files.
+    Mkdocs needs a full domain because it tries to link to local files.
     """
-    media_url = settings.MEDIA_URL
+    static_url = settings.STATIC_URL
 
-    if not media_url.startswith('http'):
+    if not static_url.startswith('http'):
         domain = getattr(settings, 'PRODUCTION_DOMAIN')
-        media_url = 'http://{}{}'.format(domain, media_url)
+        static_url = 'http://{}{}'.format(domain, static_url)
 
-    return media_url
+    return static_url
 
 
 class BaseMkdocs(BaseBuilder):
@@ -108,15 +108,15 @@ class BaseMkdocs(BaseBuilder):
         user_config['docs_dir'] = docs_dir
 
         # Set mkdocs config values
-        media_url = get_absolute_media_url()
+        static_url = get_absolute_static_url()
         user_config.setdefault('extra_javascript', []).extend([
             'readthedocs-data.js',
-            '%sstatic/core/js/readthedocs-doc-embed.js' % media_url,
-            '%sjavascript/readthedocs-analytics.js' % media_url,
+            '%score/js/readthedocs-doc-embed.js' % static_url,
+            '%sjavascript/readthedocs-analytics.js' % static_url,
         ])
         user_config.setdefault('extra_css', []).extend([
-            '%scss/badge_only.css' % media_url,
-            '%scss/readthedocs-doc-embed.css' % media_url,
+            '%scss/badge_only.css' % static_url,
+            '%scss/readthedocs-doc-embed.css' % static_url,
         ])
 
         docs_path = os.path.join(self.root_path, docs_dir)

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -76,6 +76,7 @@ context = {
     'html_theme': html_theme,
     'current_version': "{{ version.verbose_name }}",
     'version_slug': "{{ version.slug }}",
+    'MEDIA_URL': "{{ settings.MEDIA_URL }}",
     'STATIC_URL': "{{ settings.STATIC_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
     'versions': [{% for version in versions %}

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -67,10 +67,7 @@ else:
 
 if globals().get('websupport2_base_url', False):
     websupport2_base_url = '{{ api_host }}/websupport'
-    if 'http' not in settings.MEDIA_URL:
-        websupport2_static_url = '{{ settings.STATIC_URL }}'
-    else:
-        websupport2_static_url = '{{ settings.MEDIA_URL }}/static'
+    websupport2_static_url = '{{ settings.STATIC_URL }}'
 
 
 #Add project information to the template context.
@@ -79,7 +76,7 @@ context = {
     'html_theme': html_theme,
     'current_version': "{{ version.verbose_name }}",
     'version_slug': "{{ version.slug }}",
-    'MEDIA_URL': "{{ settings.MEDIA_URL }}",
+    'STATIC_URL': "{{ settings.STATIC_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
     'versions': [{% for version in versions %}
     ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -153,16 +153,16 @@ class MkdocsBuilderTest(TestCase):
         self.assertEqual(
             config['extra_css'],
             [
-                'http://readthedocs.org/media/css/badge_only.css',
-                'http://readthedocs.org/media/css/readthedocs-doc-embed.css'
+                'http://readthedocs.org/static/css/badge_only.css',
+                'http://readthedocs.org/static/css/readthedocs-doc-embed.css'
             ]
         )
         self.assertEqual(
             config['extra_javascript'],
             [
                 'readthedocs-data.js',
-                'http://readthedocs.org/media/static/core/js/readthedocs-doc-embed.js',
-                'http://readthedocs.org/media/javascript/readthedocs-analytics.js',
+                'http://readthedocs.org/static/core/js/readthedocs-doc-embed.js',
+                'http://readthedocs.org/static/javascript/readthedocs-analytics.js',
             ]
         )
         self.assertIsNone(
@@ -205,16 +205,16 @@ class MkdocsBuilderTest(TestCase):
         self.assertEqual(
             config['extra_css'],
             [
-                'http://readthedocs.org/media/css/badge_only.css',
-                'http://readthedocs.org/media/css/readthedocs-doc-embed.css'
+                'http://readthedocs.org/static/css/badge_only.css',
+                'http://readthedocs.org/static/css/readthedocs-doc-embed.css'
             ]
         )
         self.assertEqual(
             config['extra_javascript'],
             [
                 'readthedocs-data.js',
-                'http://readthedocs.org/media/static/core/js/readthedocs-doc-embed.js',
-                'http://readthedocs.org/media/javascript/readthedocs-analytics.js',
+                'http://readthedocs.org/static/core/js/readthedocs-doc-embed.js',
+                'http://readthedocs.org/static/javascript/readthedocs-analytics.js',
             ]
         )
         self.assertIsNone(

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -345,7 +345,7 @@ class CommunityBaseSettings(Settings):
     # Misc application settings
     GLOBAL_ANALYTICS_CODE = None
     DASHBOARD_ANALYTICS_CODE = None  # For the dashboard, not docs
-    GRAVATAR_DEFAULT_IMAGE = 'https://media.readthedocs.org/images/silhouette.png'  # NOQA
+    GRAVATAR_DEFAULT_IMAGE = 'https://assets.readthedocs.org/static/images/silhouette.png'  # NOQA
     OAUTH_AVATAR_USER_DEFAULT_URL = GRAVATAR_DEFAULT_IMAGE
     OAUTH_AVATAR_ORG_DEFAULT_URL = GRAVATAR_DEFAULT_IMAGE
     RESTRICTEDSESSIONS_AUTHED_ONLY = True

--- a/readthedocs/templates/core/email/base.html
+++ b/readthedocs/templates/core/email/base.html
@@ -63,7 +63,7 @@ p {
           <tr>
             <td class="header">
               {% block header %}
-              <img src='https://media.readthedocs.org/images/email-header.png' width="100%" height="150"style="" />
+              <img src="https://assets.readthedocs.org/static/images/email-header.png" width="100%" height="150" />
               {% endblock %}
             </td>
           </tr>


### PR DESCRIPTION
This PR cleans up a few areas that were using `MEDIA_URL` but really should be using `STATIC_URL` after #4489. The old URL will work but will result in a redirect which slows things down and results in an extra hit.