### PR TITLE
Cache the footer_api template based on version for one minute

### DIFF
--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -1,7 +1,6 @@
 {% load cache %}
 
 {# Vary the cache on the version #}
-{% cache 60 footer-html version.pk %}
 
 <!-- Inserted RTD Footer -->
 <div class="injected">
@@ -16,6 +15,7 @@
     <div class="rst-other-versions">
       {% endif %}
 
+      {% cache 60 footer_html_versions project.pk %}
       {% block versions %}
       {% if translations %}
       <dl>
@@ -62,6 +62,7 @@
       </dl>
       {% endif %}
       {% endblock %}
+      {% endcache %}
 
       {% block readthedocs %}
       <dl>
@@ -142,4 +143,3 @@
 
 </div>
 
-{% endcache %}

--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -1,3 +1,8 @@
+{% load cache %}
+
+{# Vary the cache on the version #}
+{% cache 60 footer-html version %}
+
 <!-- Inserted RTD Footer -->
 <div class="injected">
 
@@ -136,3 +141,5 @@
   {% endif %}
 
 </div>
+
+{% endcache %}

--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -1,7 +1,7 @@
 {% load cache %}
 
 {# Vary the cache on the version #}
-{% cache 60 footer-html version %}
+{% cache 60 footer-html version.pk %}
 
 <!-- Inserted RTD Footer -->
 <div class="injected">


### PR DESCRIPTION
This is something that should increase the speed of our responses on the most popular versions.
It will make it so that users who update their versions might not see the footer change in under a minute,
but I think we can probably put up with that for the hopeful performance benefits.

I think that increasing this also makes a lot of sense, if we build a way to bust the cache. I think generating this fresh on every pageview for the most part doesn't make much sense. 