### PR TITLE
Performance improvement: cache version listing on the homepage

### DIFF
--- a/readthedocs/templates/core/project_list_featured.html
+++ b/readthedocs/templates/core/project_list_featured.html
@@ -14,13 +14,10 @@
         <a href="#">&#x25BC;</a>
       </span>
       <ul>
-          {% with project.get_stable_version as version %}
-          {% if version %}
-            <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
-          {% else %}
-            <li>No stable version</li>
-          {% endif %}
-          {% endwith %}
+          <li><input type="search" placeholder="{% trans "Search" %}&hellip;" /></li>
+          {% for version in project.ordered_active_versions reversed %}
+              <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
+          {% endfor %}
       </ul>
     </span>
     {% else %}

--- a/readthedocs/templates/core/project_list_featured.html
+++ b/readthedocs/templates/core/project_list_featured.html
@@ -15,7 +15,9 @@
       </span>
       <ul>
           {% with project.get_stable_version as version %}
+          {% if version %}
             <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
+          {% endif %}
           {% endwith %}
       </ul>
     </span>

--- a/readthedocs/templates/core/project_list_featured.html
+++ b/readthedocs/templates/core/project_list_featured.html
@@ -14,10 +14,9 @@
         <a href="#">&#x25BC;</a>
       </span>
       <ul>
-          <li><input type="search" placeholder="{% trans "Search" %}&hellip;" /></li>
-          {% for version in project.ordered_active_versions reversed %}
-              <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
-          {% endfor %}
+          {% with project.get_stable_version as version %}
+            <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
+          {% endwith %}
       </ul>
     </span>
     {% else %}

--- a/readthedocs/templates/core/project_list_featured.html
+++ b/readthedocs/templates/core/project_list_featured.html
@@ -17,6 +17,8 @@
           {% with project.get_stable_version as version %}
           {% if version %}
             <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
+          {% else %}
+            <li>No stable version</li>
           {% endif %}
           {% endwith %}
       </ul>

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load humanize %}
 {% load pagination_tags %}
+{% load cache %}
 
 {% block extra_metas %}
   <meta name="description" content="{% trans "Read the Docs simplifies technical documentation by automating building, versioning, and hosting for you. Build up-to-date documentation for the web, print, and offline use on every version control push automatically." %}">

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -116,6 +116,7 @@
   </section>
 
   {% if featured_list %}
+  {% cache 600 homepage featured_list %}
     <!-- BEGIN projects list -->
     <section>
       <h3>{% trans "Featured Projects" %}</h3>
@@ -128,6 +129,7 @@
       </div>
     </section>
     <!-- END projects list -->
+  {% endcache %}
   {% endif %}
 
   <!-- Funding and Contributing -->

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -116,7 +116,7 @@
   </section>
 
   {% if featured_list %}
-  {% cache 600 homepage featured_list %}
+  {% cache 600 homepage %}
     <!-- BEGIN projects list -->
     <section>
       <h3>{% trans "Featured Projects" %}</h3>

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -117,7 +117,7 @@
   </section>
 
   {% if featured_list %}
-  {% cache 600 homepage %}
+  {% cache 600 homepage_featured_list %}
     <!-- BEGIN projects list -->
     <section>
       <h3>{% trans "Featured Projects" %}</h3>


### PR DESCRIPTION
This is similar to #4524,
where resolving a ton of URL's for versions is time consuming.
This caches the features projects list on the homepage. 