### PR TITLE
Remove mailgun from our dependencies

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -3,7 +3,6 @@ psycopg2==2.7.3.2
 gunicorn==19.1.0
 pysolr==2.0.13
 django-redis-cache==1.6.3
-django-mailgun==0.2.2
 
 hiredis==0.1.2
 


### PR DESCRIPTION
This is prod only, and is out of date. This dependency is handled by our
provisioning.