### PR TITLE
Revert "Remove SelectiveFileSystemFolder finder workaround"

### DIFF
--- a/readthedocs/core/static.py
+++ b/readthedocs/core/static.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, print_function, unicode_literals
+
+from django.contrib.staticfiles.finders import FileSystemFinder
+
+
+class SelectiveFileSystemFinder(FileSystemFinder):
+
+    """
+    Add user media paths in ``media/`` to ignore patterns.
+
+    This allows collectstatic inside ``media/`` without collecting all of the
+    paths that include user files
+    """
+
+    def list(self, ignore_patterns):
+        ignore_patterns.extend(['epub', 'pdf', 'htmlzip', 'json', 'man', 'static'])
+        return super(SelectiveFileSystemFinder, self).list(ignore_patterns)

--- a/readthedocs/core/static.py
+++ b/readthedocs/core/static.py
@@ -14,5 +14,5 @@ class SelectiveFileSystemFinder(FileSystemFinder):
     """
 
     def list(self, ignore_patterns):
-        ignore_patterns.extend(['epub', 'pdf', 'htmlzip', 'json', 'man', 'static'])
+        ignore_patterns.extend(['epub', 'pdf', 'htmlzip', 'json', 'man'])
         return super(SelectiveFileSystemFinder, self).list(ignore_patterns)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -176,6 +176,10 @@ class CommunityBaseSettings(Settings):
         os.path.join(SITE_ROOT, 'readthedocs', 'static'),
         os.path.join(SITE_ROOT, 'media'),
     ]
+    STATICFILES_FINDERS = [
+        'readthedocs.core.static.SelectiveFileSystemFinder',
+        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    ]
 
     TEMPLATES = [
         {


### PR DESCRIPTION
Reverts rtfd/readthedocs.org#4520

I believe this is in fact still required, as otherwise we get static collect of `media/{epub,pdf,json,htmlzip}`