### PR TITLE
Fix the sponsor image paths

### DIFF
--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -240,32 +240,32 @@
 
           <div class="sponsors">
             <a class="sponsor" href="https://azure.microsoft.com" rel="noopener" target="_blank">
-              <img src="{% static '/media/images/sponsors/azure.png' %}" alt="Microsoft Azure" class="sponsor-image">
+              <img src="{% static 'images/sponsors/azure.png' %}" alt="Microsoft Azure" class="sponsor-image">
               <div class="sponsor-name">Microsoft Azure</div>
               <div class="sponsor-description">Cloud Computing</div>
             </a>
             <a class="sponsor" href="https://cloudflare.com" rel="noopener" target="_blank">
-              <img src="{% static '/media/images/sponsors/cloudflare.png' %}" alt="CloudFlare" class="sponsor-image">
+              <img src="{% static 'images/sponsors/cloudflare.png' %}" alt="CloudFlare" class="sponsor-image">
               <div class="sponsor-name">Cloudflare</div>
               <div class="sponsor-description">DNS &amp; SSL</div>
             </a>
             <a class="sponsor" href="https://sentry.io/" rel="noopener" target="_blank">
-              <img src="{% static '/media/images/sponsors/sentry.png' %}" alt="Sentry" class="sponsor-image">
+              <img src="{% static 'images/sponsors/sentry.png' %}" alt="Sentry" class="sponsor-image">
               <div class="sponsor-name">Sentry</div>
               <div class="sponsor-description">Monitoring</div>
             </a>
             <a class="sponsor" href="https://www.elastic.co/" rel="noopener" target="_blank">
-              <img src="{% static '/media/images/sponsors/elastic.png' %}" alt="Elastic" class="sponsor-image">
+              <img src="{% static 'images/sponsors/elastic.png' %}" alt="Elastic" class="sponsor-image">
               <div class="sponsor-name">Elastic</div>
               <div class="sponsor-description">Search</div>
             </a>
             <a class="sponsor" href="https://newrelic.com/" rel="noopener" target="_blank">
-              <img src="{% static '/media/images/sponsors/newrelic.png' %}" alt="New Relic" class="sponsor-image">
+              <img src="{% static 'images/sponsors/newrelic.png' %}" alt="New Relic" class="sponsor-image">
               <div class="sponsor-name">New Relic</div>
               <div class="sponsor-description">Performance</div>
             </a>
             <a class="sponsor" href="https://www.elastic.co/" rel="noopener" target="_blank">
-              <img src="{% static '/media/images/sponsors/pagerduty.png' %}" alt="PagerDuty" class="sponsor-image">
+              <img src="{% static 'images/sponsors/pagerduty.png' %}" alt="PagerDuty" class="sponsor-image">
               <div class="sponsor-name">PagerDuty</div>
               <div class="sponsor-description">Monitoring</div>
             </a>


### PR DESCRIPTION
Due to changes in our `collectstatic` since the original sponsor images PR #4424, the paths were not correct. Also, don't start `{% static %}` with a `/` character.
Related to #4489, #4502.