### PR TITLE
Feature to exclude VCS links from versions menu and breadcrumbs

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -97,6 +97,10 @@ class BaseSphinx(BaseBuilder):
             versions = self.project.api_versions()
             downloads = api.version(self.version.pk).get()['downloads']
 
+        # TODO: check for a Project Feature to decide if display VCS links or note
+        # if not self.project.has_feature(Feature.DONT_SHOW_VCS_LINKS):
+        #     display_github = display_gitlab = display_bitbucket = False
+
         data = {
             'current_version': self.version.verbose_name,
             'project': self.project,

--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -74,6 +74,7 @@
       </dl>
       {% endblock %}
 
+      {# TODO: check for a Project Feature here to decide if we show the VCS links or not #}
       {% block vcs %}
 
       {% if github_edit_url %}


### PR DESCRIPTION
Use a Project Feature to decide if we want to avoid showing VCS links.

Currently the user can only remove breadcrumbs links but not from the version menu: https://docs.readthedocs.io/en/latest/guides/remove-edit-buttons.html