### PR TITLE
Sanitize BuildCommand.output by removing NULL characters

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -159,20 +159,8 @@ class BuildCommand(BuildCommandResultMixin):
                 cmd_input_bytes = cmd_input
             cmd_output = proc.communicate(input=cmd_input_bytes)
             (cmd_stdout, cmd_stderr) = cmd_output
-            try:
-                self.output = cmd_stdout.decode('utf-8', 'replace')
-                # Replace NULL (\x00) character to avoid PostgreSQL db to fail
-                # https://code.djangoproject.com/ticket/28201
-                self.output = self.output.replace('\x00', '')
-            except (TypeError, AttributeError):
-                self.output = None
-            try:
-                self.error = cmd_stderr.decode('utf-8', 'replace')
-                # Replace NULL (\x00) character to avoid PostgreSQL db to fail
-                # https://code.djangoproject.com/ticket/28201
-                self.error = self.error.replace('\x00', '')
-            except (TypeError, AttributeError):
-                self.error = None
+            self.output = self.sanitize_output(cmd_stdout)
+            self.error = self.sanitize_output(cmd_stderr)
             self.exit_code = proc.returncode
         except OSError:
             self.error = traceback.format_exc()
@@ -180,6 +168,30 @@ class BuildCommand(BuildCommandResultMixin):
             self.exit_code = -1
         finally:
             self.end_time = datetime.utcnow()
+
+    def sanitize_output(self, output):
+        """
+        Sanitize ``output`` to be saved into the DB.
+
+            1. Decodes to UTF-8
+
+            2. Replaces NULL (\x00) characters with ``''`` (empty string) to
+               avoid PostgreSQL db to fail:
+               https://code.djangoproject.com/ticket/28201
+
+        :param output: stdout/stderr to be sanitized
+        :type output: bytes
+
+        :returns: sanitized output as string or ``None`` if it fails
+        """
+        try:
+            sanitized = output.decode('utf-8', 'replace')
+            # Replace NULL (\x00) character to avoid PostgreSQL db to fail
+            # https://code.djangoproject.com/ticket/28201
+            sanitized = sanitized.replace('\x00', '')
+        except (TypeError, AttributeError):
+            sanitized = None
+        return sanitized
 
     def get_command(self):
         """Flatten command."""

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -161,10 +161,16 @@ class BuildCommand(BuildCommandResultMixin):
             (cmd_stdout, cmd_stderr) = cmd_output
             try:
                 self.output = cmd_stdout.decode('utf-8', 'replace')
+                # Replace NULL (\x00) character to avoid PostgreSQL db to fail
+                # https://code.djangoproject.com/ticket/28201
+                self.output = self.output.replace('\x00', '')
             except (TypeError, AttributeError):
                 self.output = None
             try:
                 self.error = cmd_stderr.decode('utf-8', 'replace')
+                # Replace NULL (\x00) character to avoid PostgreSQL db to fail
+                # https://code.djangoproject.com/ticket/28201
+                self.error = self.error.replace('\x00', '')
             except (TypeError, AttributeError):
                 self.error = None
             self.exit_code = proc.returncode

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -170,7 +170,7 @@ class BuildCommand(BuildCommandResultMixin):
             self.end_time = datetime.utcnow()
 
     def sanitize_output(self, output):
-        """
+        r"""
         Sanitize ``output`` to be saved into the DB.
 
             1. Decodes to UTF-8


### PR DESCRIPTION
PostgreSQL doesn't support NULL (\x00) characters on TextFields.

Django 2.0 introduces a new validator that doesn't allow NULL characters to reach the database:

https://code.djangoproject.com/ticket/28201

This commit just replaces the NULL characters of the stdout and stder from the command ran by '' (empty string) to avoid conflicts when saving them into the database.

Closes #3900