### PR TITLE
Use STATIC_URL for badges

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -15,7 +15,6 @@ import requests
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -121,18 +120,18 @@ def project_badge(request, project_slug):
         version = Version.objects.public(request.user).get(
             project__slug=project_slug, slug=version_slug)
     except Version.DoesNotExist:
-        url = static(badge_path % 'unknown')
+        url = settings.STATIC_URL + (badge_path % 'unknown')
         return HttpResponseRedirect(url)
     version_builds = version.builds.filter(type='html',
                                            state='finished').order_by('-date')
     if not version_builds.exists():
-        url = static(badge_path % 'unknown')
+        url = settings.STATIC_URL + (badge_path % 'unknown')
         return HttpResponseRedirect(url)
     last_build = version_builds[0]
     if last_build.success:
-        url = static(badge_path % 'passing')
+        url = settings.STATIC_URL + (badge_path % 'passing')
     else:
-        url = static(badge_path % 'failing')
+        url = settings.STATIC_URL + (badge_path % 'failing')
     return HttpResponseRedirect(url)
 
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta
 
 from mock import patch
 from django.test import TestCase
+from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.contrib.messages import constants as message_const
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
@@ -426,7 +426,7 @@ class TestBadges(TestCase):
 
     # To set `flat` as default style as done in code.
     def get_badge_path(self, version, style='flat'):
-        return static(self.BADGE_PATH % (version, style))
+        return settings.STATIC_URL + (self.BADGE_PATH % (version, style))
 
     def setUp(self):
         self.BADGE_PATH = 'projects/badges/%s-%s.svg'


### PR DESCRIPTION
Now that we are going to start using Django's [ManifestFilesMixin](https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/#manifeststaticfilesstorage) for static files, we should not use this (undocumented?) method for generating paths to the docs badges.

Related to: https://github.com/rtfd/readthedocs.org/issues/4557