### PR TITLE
 Respond directly with badges rather than redirecting

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -15,7 +15,6 @@ import requests
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -121,18 +120,18 @@ def project_badge(request, project_slug):
         version = Version.objects.public(request.user).get(
             project__slug=project_slug, slug=version_slug)
     except Version.DoesNotExist:
-        url = static(badge_path % 'unknown')
+        url = settings.STATIC_URL + (badge_path % 'unknown')
         return HttpResponseRedirect(url)
     version_builds = version.builds.filter(type='html',
                                            state='finished').order_by('-date')
     if not version_builds.exists():
-        url = static(badge_path % 'unknown')
+        url = settings.STATIC_URL + (badge_path % 'unknown')
         return HttpResponseRedirect(url)
     last_build = version_builds[0]
     if last_build.success:
-        url = static(badge_path % 'passing')
+        url = settings.STATIC_URL + (badge_path % 'passing')
     else:
-        url = static(badge_path % 'failing')
+        url = settings.STATIC_URL + (badge_path % 'failing')
     return HttpResponseRedirect(url)
 
 

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -18,6 +18,8 @@ from readthedocs.projects.models import Project, Domain
 from readthedocs.oauth.models import RemoteRepository, RemoteOrganization
 from readthedocs.rtd_tests.utils import create_user
 
+from ..utils import staticfiles_test_open
+
 
 class URLAccessMixin(object):
 
@@ -167,6 +169,7 @@ class ProjectMixin(URLAccessMixin):
         }
 
 
+@mock.patch('django.contrib.staticfiles.storage.staticfiles_storage.open', staticfiles_test_open)
 class PublicProjectMixin(ProjectMixin):
 
     request_data = {
@@ -177,7 +180,7 @@ class PublicProjectMixin(ProjectMixin):
     response_data = {
         # Public
         '/projects/pip/downloads/pdf/latest/': {'status_code': 302},
-        '/projects/pip/badge/': {'status_code': 302},
+        '/projects/pip/badge/': {'status_code': 200},
     }
 
     def test_public_urls(self):
@@ -185,6 +188,7 @@ class PublicProjectMixin(ProjectMixin):
         self._test_url(urlpatterns)
 
 
+@mock.patch('django.contrib.staticfiles.storage.staticfiles_storage.open', staticfiles_test_open)
 class PrivateProjectMixin(ProjectMixin):
 
     def test_private_urls(self):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -8,8 +8,8 @@ from django.contrib.messages import constants as message_const
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
 from django.views.generic.base import ContextMixin
-from django_dynamic_fixture import get
-from django_dynamic_fixture import new
+from django.contrib.staticfiles import finders
+from django_dynamic_fixture import get, new
 
 import six
 
@@ -420,6 +420,15 @@ class TestPrivateMixins(MockBuildTestCase):
         self.assertEqual(view.get_context_data()['project'], self.project)
 
 
+def staticfiles_test_open(fp):
+    local_path = finders.find(fp)
+    if local_path:
+        return open(local_path)
+    else:
+        raise RuntimeError(u'Could not open file {}'.format(fp))
+
+
+@patch('django.contrib.staticfiles.storage.staticfiles_storage.open', staticfiles_test_open)
 class TestBadges(TestCase):
     """Test a static badge asset is served for each build."""
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -8,7 +8,6 @@ from django.contrib.messages import constants as message_const
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
 from django.views.generic.base import ContextMixin
-from django.contrib.staticfiles import finders
 from django_dynamic_fixture import get, new
 
 import six
@@ -22,6 +21,8 @@ from readthedocs.projects.models import Project, Domain
 from readthedocs.projects.views.private import ImportWizardView
 from readthedocs.projects.views.mixins import ProjectRelationMixin
 from readthedocs.projects import tasks
+
+from ..utils import staticfiles_test_open
 
 
 @patch('readthedocs.projects.views.private.trigger_build', lambda x: None)
@@ -418,14 +419,6 @@ class TestPrivateMixins(MockBuildTestCase):
         self.assertEqual(view.get_project(), self.project)
         self.assertEqual(view.get_queryset().first(), self.domain)
         self.assertEqual(view.get_context_data()['project'], self.project)
-
-
-def staticfiles_test_open(fp):
-    local_path = finders.find(fp)
-    if local_path:
-        return open(local_path)
-    else:
-        raise RuntimeError(u'Could not open file {}'.format(fp))
 
 
 @patch('django.contrib.staticfiles.storage.staticfiles_storage.open', staticfiles_test_open)

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 
 from mock import patch
 from django.test import TestCase
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.messages import constants as message_const
 from django.core.urlresolvers import reverse
@@ -423,10 +422,6 @@ class TestPrivateMixins(MockBuildTestCase):
 
 class TestBadges(TestCase):
     """Test a static badge asset is served for each build."""
-
-    # To set `flat` as default style as done in code.
-    def get_badge_path(self, version, style='flat'):
-        return settings.STATIC_URL + (self.BADGE_PATH % (version, style))
 
     def setUp(self):
         self.BADGE_PATH = 'projects/badges/%s-%s.svg'

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta
 
 from mock import patch
 from django.test import TestCase
+from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.contrib.messages import constants as message_const
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
@@ -426,7 +426,7 @@ class TestBadges(TestCase):
 
     # To set `flat` as default style as done in code.
     def get_badge_path(self, version, style='flat'):
-        return static(self.BADGE_PATH % (version, style))
+        return settings.STATIC_URL + (self.BADGE_PATH % (version, style))
 
     def setUp(self):
         self.BADGE_PATH = 'projects/badges/%s-%s.svg'

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -436,32 +436,38 @@ class TestBadges(TestCase):
 
     def test_unknown_badge(self):
         res = self.client.get(self.badge_url, {'version': self.version.slug})
-        static_badge = self.get_badge_path('unknown')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'unknown')
+
+        # Unknown project
+        unknown_project_url = reverse('project_badge', args=['fake-project'])
+        res = self.client.get(unknown_project_url, {'version': 'latest'})
+        self.assertContains(res, 'unknown')
 
     def test_passing_badge(self):
         get(Build, project=self.project, version=self.version, success=True)
         res = self.client.get(self.badge_url, {'version': self.version.slug})
-        static_badge = self.get_badge_path('passing')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'passing')
 
     def test_failing_badge(self):
         get(Build, project=self.project, version=self.version, success=False)
         res = self.client.get(self.badge_url, {'version': self.version.slug})
-        static_badge = self.get_badge_path('failing')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'failing')
 
     def test_plastic_failing_badge(self):
         get(Build, project=self.project, version=self.version, success=False)
         res = self.client.get(self.badge_url, {'version': self.version.slug, 'style': 'plastic'})
-        static_badge = self.get_badge_path('failing', 'plastic')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'failing')
+
+        # The plastic badge has slightly more rounding
+        self.assertContains(res, 'rx="4"')
 
     def test_social_passing_badge(self):
         get(Build, project=self.project, version=self.version, success=True)
-        res = self.client.get(self.badge_url, {'version': self.version.slug , 'style': 'social'})
-        static_badge = self.get_badge_path('passing', 'social')
-        self.assertEquals(res.url, static_badge)
+        res = self.client.get(self.badge_url, {'version': self.version.slug, 'style': 'social'})
+        self.assertContains(res, 'passing')
+
+        # The social badge (but not the other badges) has this element
+        self.assertContains(res, 'rlink')
 
 
 class TestTags(TestCase):

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -13,6 +13,7 @@ from shutil import copytree
 from tempfile import mkdtemp
 
 from django.contrib.auth.models import User
+from django.contrib.staticfiles import finders
 from django_dynamic_fixture import new
 
 from readthedocs.doc_builder.base import restoring_chdir
@@ -173,3 +174,16 @@ def create_user(username, password, **kwargs):
     user.set_password(password)
     user.save()
     return user
+
+
+def staticfiles_test_open(fp):
+    """
+    Open a static file which may not be collected
+
+    Typically used with ``mock.patch``
+    """
+    local_path = finders.find(fp)
+    if local_path:
+        return open(local_path)
+    else:
+        raise RuntimeError(u'Could not open file {}'.format(fp))


### PR DESCRIPTION
This changes the docs badges to be served directly from Django. This is less efficient but gives us precise caching control and centralizes all the cache control in one place.

One possible optimization is to cache the part where we read from storage. The "passing" graphic doesn't change frequently. However, it is possible that reading from cache isn't really faster than reading from storage.

If merged, #4558 can be closed.
Fixes https://github.com/rtfd/readthedocs.org/issues/4557.