### PR TITLE
Serve badges directly from local filesystem

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -15,7 +15,6 @@ import requests
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -136,11 +135,11 @@ def project_badge(request, project_slug):
         version_builds = version.builds.filter(type='html',
                                                state='finished').order_by('-date')
         if version_builds.exists():
-            last_build = version_builds[0]
+            last_build = version_builds.first()
             if last_build.success:
-                file_path = static(badge_path % 'passing')
+                file_path = badge_path % 'passing'
             else:
-                file_path = static(badge_path % 'failing')
+                file_path = badge_path % 'failing'
 
     with open(file_path) as fd:
         return HttpResponse(

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -139,11 +139,15 @@ def project_badge(request, project_slug):
             else:
                 file_path = badge_path % 'failing'
 
-    with open(file_path) as fd:
-        return HttpResponse(
-            fd.read(),
-            content_type='image/svg+xml',
-        )
+    try:
+        with open(file_path) as fd:
+            return HttpResponse(
+                fd.read(),
+                content_type='image/svg+xml',
+            )
+    except (IOError, OSError):
+        log.exception('Failed to read local filesystem while serving a docs badge')
+        return HttpResponse(status=503)
 
 
 def project_downloads(request, project_slug):

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -132,10 +132,8 @@ def project_badge(request, project_slug):
         project__slug=project_slug, slug=version_slug).first()
 
     if version:
-        version_builds = version.builds.filter(type='html',
-                                               state='finished').order_by('-date')
-        if version_builds.exists():
-            last_build = version_builds.first()
+        last_build = version.builds.filter(type='html', state='finished').order_by('-date').first()
+        if last_build:
             if last_build.success:
                 file_path = badge_path % 'passing'
             else:

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -177,7 +177,7 @@ class PublicProjectMixin(ProjectMixin):
     response_data = {
         # Public
         '/projects/pip/downloads/pdf/latest/': {'status_code': 302},
-        '/projects/pip/badge/': {'status_code': 302},
+        '/projects/pip/badge/': {'status_code': 200},
     }
 
     def test_public_urls(self):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -4,13 +4,11 @@ from datetime import datetime, timedelta
 from mock import patch
 from django.test import TestCase
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.contrib.messages import constants as message_const
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
 from django.views.generic.base import ContextMixin
-from django_dynamic_fixture import get
-from django_dynamic_fixture import new
+from django_dynamic_fixture import get, new
 
 import six
 
@@ -424,10 +422,6 @@ class TestPrivateMixins(MockBuildTestCase):
 class TestBadges(TestCase):
     """Test a static badge asset is served for each build."""
 
-    # To set `flat` as default style as done in code.
-    def get_badge_path(self, version, style='flat'):
-        return static(self.BADGE_PATH % (version, style))
-
     def setUp(self):
         self.BADGE_PATH = 'projects/badges/%s-%s.svg'
         self.project = get(Project, slug='badgey')
@@ -436,32 +430,38 @@ class TestBadges(TestCase):
 
     def test_unknown_badge(self):
         res = self.client.get(self.badge_url, {'version': self.version.slug})
-        static_badge = self.get_badge_path('unknown')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'unknown')
+
+        # Unknown project
+        unknown_project_url = reverse('project_badge', args=['fake-project'])
+        res = self.client.get(unknown_project_url, {'version': 'latest'})
+        self.assertContains(res, 'unknown')
 
     def test_passing_badge(self):
         get(Build, project=self.project, version=self.version, success=True)
         res = self.client.get(self.badge_url, {'version': self.version.slug})
-        static_badge = self.get_badge_path('passing')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'passing')
 
     def test_failing_badge(self):
         get(Build, project=self.project, version=self.version, success=False)
         res = self.client.get(self.badge_url, {'version': self.version.slug})
-        static_badge = self.get_badge_path('failing')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'failing')
 
     def test_plastic_failing_badge(self):
         get(Build, project=self.project, version=self.version, success=False)
         res = self.client.get(self.badge_url, {'version': self.version.slug, 'style': 'plastic'})
-        static_badge = self.get_badge_path('failing', 'plastic')
-        self.assertEquals(res.url, static_badge)
+        self.assertContains(res, 'failing')
+
+        # The plastic badge has slightly more rounding
+        self.assertContains(res, 'rx="4"')
 
     def test_social_passing_badge(self):
         get(Build, project=self.project, version=self.version, success=True)
-        res = self.client.get(self.badge_url, {'version': self.version.slug , 'style': 'social'})
-        static_badge = self.get_badge_path('passing', 'social')
-        self.assertEquals(res.url, static_badge)
+        res = self.client.get(self.badge_url, {'version': self.version.slug, 'style': 'social'})
+        self.assertContains(res, 'passing')
+
+        # The social badge (but not the other badges) has this element
+        self.assertContains(res, 'rlink')
 
 
 class TestTags(TestCase):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -441,6 +441,7 @@ class TestBadges(TestCase):
         get(Build, project=self.project, version=self.version, success=True)
         res = self.client.get(self.badge_url, {'version': self.version.slug})
         self.assertContains(res, 'passing')
+        self.assertEqual(res['Content-Type'], 'image/svg+xml')
 
     def test_failing_badge(self):
         get(Build, project=self.project, version=self.version, success=False)


### PR DESCRIPTION
- Serves badges directly without a redirect
- Attaches the cache control header directly to the response as GitHub doesn't respect the cache-control headers on a redirect. GitHub only respects the cache-control header on the 2xx response.
- A bit of code simplification

This solves an issue that arose because the badges need to be explicitly not cached or have a very short cache TTL. When no cache-control headers are present (as on [this badge](https://assets.readthedocs.org/static/projects/badges/passing-flat.svg) for example), sometimes other intermediaries -- github in this case -- cache it too long. This PR keeps the cache rules and the response together in the code so this problem doesn't arise again like it did previously in https://github.com/rtfd/readthedocs.org/issues/3323.

Similar to #4559 but reads from a local file instead of possibly remote one.

Fixes #4557