### PR TITLE
Fix nested syntax in docs

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -190,7 +190,7 @@ Can I document a python package that is not at the root of my repository?
 
 Yes. The most convenient way to access a python package for example via
 `Sphinx's autoapi`_ in your documentation is to use the *Install your project
-inside a virtualenv using ``setup.py install``* option in the admin panel of
+inside a virtualenv using setup.py install* option in the admin panel of
 your project. However this assumes that your ``setup.py`` is in the root of
 your repository.
 


### PR DESCRIPTION
rst doesn't support nested elements, it renders in a weird way

![screenshot_2018-08-24 frequently asked questions read the docs 1 0 documentation](https://user-images.githubusercontent.com/4975310/44602471-573f2a80-a7a5-11e8-8b8d-f8e08922dd20.png)
