### PR TITLE
Update tests failing on master

### DIFF
--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -736,7 +736,7 @@ def test_requirements_file_is_null(tmpdir):
         source_file=str(tmpdir.join('readthedocs.yml')),
     )
     build.validate()
-    assert build.requirements_file is None
+    assert build.python.requirements is None
 
 
 def test_requirements_file_is_blank(tmpdir):
@@ -746,7 +746,7 @@ def test_requirements_file_is_blank(tmpdir):
         source_file=str(tmpdir.join('readthedocs.yml')),
     )
     build.validate()
-    assert build.requirements_file is None
+    assert build.python.requirements is None
 
 
 def test_build_validate_calls_all_subvalidators(tmpdir):


### PR DESCRIPTION
Ref to https://github.com/rtfd/readthedocs.org/pull/4461#discussion_r213152317

So, this was caused because the PR was outdated, makes me think if we could do better to prevent this. What about requiring the PRs to be updated before merging to master? Now GitHub supports a button to update the PR from the web, so the process isn't slow, but we will need to wait to the tests to pass again with the new merge, for simple PRs this can be a little overkill, but in general, I think this is a sane check