### PR TITLE
[Fix #4576] Do not delete projects which have multiple users

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -81,6 +81,7 @@ def delete_projects_and_organizations(sender, instance, *args, **kwargs):
     # Here we count the owner list from the projects that the user own
     # Then exclude the projects where there are more than one owner
     # Add annotate before filter
+    # https://github.com/rtfd/readthedocs.org/pull/4577
     # https://docs.djangoproject.com/en/2.1/topics/db/aggregation/#order-of-annotate-and-filter-clauses # noqa
     projects = (Project.objects.annotate(num_users=Count('users')).filter(users=instance.id)
                                                                   .exclude(num_users__gt=1))

--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -81,7 +81,7 @@ def delete_projects_and_organizations(sender, instance, *args, **kwargs):
     # Here we count the owner list from the projects that the user own
     # Then exclude the projects where there are more than one owner
     # Add annotate before filter
-    # https://bit.ly/2Nne6ZJ
+    # https://docs.djangoproject.com/en/2.1/topics/db/aggregation/#order-of-annotate-and-filter-clauses # noqa
     projects = (Project.objects.annotate(num_users=Count('users')).filter(users=instance.id)
                                                                   .exclude(num_users__gt=1))
 

--- a/readthedocs/core/tests/test_signals.py
+++ b/readthedocs/core/tests/test_signals.py
@@ -1,7 +1,7 @@
 import pytest
+import django_dynamic_fixture
 
 from django.contrib.auth.models import User
-from django_dynamic_fixture import G
 
 from readthedocs.oauth.models import RemoteOrganization
 from readthedocs.projects.models import Project
@@ -18,8 +18,8 @@ class TestProjectOrganizationSignal(object):
         deleted.
         """
 
-        obj = G(model_class)
-        user1 = G(User)
+        obj = django_dynamic_fixture.get(model_class)
+        user1 = django_dynamic_fixture.get(User)
         obj.users.add(user1)
 
         obj.refresh_from_db()
@@ -38,9 +38,9 @@ class TestProjectOrganizationSignal(object):
         when any of the user delete his account.
         """
 
-        obj = G(model_class)
-        user1 = G(User)
-        user2 = G(User)
+        obj = django_dynamic_fixture.get(model_class)
+        user1 = django_dynamic_fixture.get(User)
+        user2 = django_dynamic_fixture.get(User)
         obj.users.add(user1, user2)
 
         obj.refresh_from_db()

--- a/readthedocs/core/tests/test_signals.py
+++ b/readthedocs/core/tests/test_signals.py
@@ -1,0 +1,35 @@
+import pytest
+
+from django.contrib.auth.models import User
+from django_dynamic_fixture import G
+
+from readthedocs.oauth.models import RemoteOrganization
+from readthedocs.projects.models import Project
+
+
+@pytest.mark.django_db
+class TestProjectOrganizationSignal(object):
+
+    @pytest.mark.parametrize('model', [Project, RemoteOrganization])
+    def test_multiple_users_project_organization_not_delete(self, model):
+        """
+        Check Project or RemoteOrganization which have multiple users do not get deleted
+        when any of the user delete his account.
+        """
+
+        obj = G(model)
+        user1 = G(User)
+        user2 = G(User)
+        obj.users.add(user1, user2)
+
+        obj.refresh_from_db()
+        assert obj.users.all().count() > 1
+        # Delete 1 user of the project
+        user1.delete()
+
+        # The project should still exist and it should have 1 user
+        obj.refresh_from_db()
+        assert obj.id
+        obj_users = obj.users.all()
+        assert len(obj_users) == 1
+        assert user2 in obj_users


### PR DESCRIPTION
Fixes #4576 
The query was limiting the users before annotation because of django's backward relation query. the Documentation of django does not provide much information about it, but I have gone through the differentiate of the sql query and found the root cause.
I have also added tests for this so it should not happen again. I should have written the tests when I implemented the feature in #3214.
@agjohnson @humitos r?
