### PR TITLE
Force resolver to use PUBLIC_DOMAIN over HTTPS if not Domain.https

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -147,13 +147,7 @@ class ResolverBase(object):
         canonical_project = self._get_canonical_project(project)
         custom_domain = self._get_project_custom_domain(canonical_project)
 
-        # This duplication from resolve_domain is for performance purposes
-        # in order to check whether a custom domain should be HTTPS
-        use_custom_domain = any([
-            (custom_domain and not require_https),
-            (custom_domain and require_https and custom_domain.https),
-        ])
-        if use_custom_domain:
+        if self._use_custom_domain(custom_domain):
             domain = custom_domain.domain
         elif self._use_subdomain():
             domain = self._get_project_subdomain(canonical_project)
@@ -256,6 +250,17 @@ class ResolverBase(object):
         else:
             path = ""
         return path
+
+    def _use_custom_domain(self, custom_domain):
+        """
+        Make decision about whether to use a custom domain to serve docs.
+
+        Always use the custom domain if it exists.
+
+        :param custom_domain: Domain instance or ``None``
+        :type custom_domain: readthedocs.projects.models.Domain
+        """
+        return True if custom_domain is not None else False
 
     def _use_subdomain(self):
         """Make decision about whether to use a subdomain to serve docs."""

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -136,7 +136,7 @@ class ResolverBase(object):
             return self._get_project_subdomain(canonical_project)
         return getattr(settings, 'PRODUCTION_DOMAIN')
 
-    def resolve(self, project, require_https_domain=False, filename='', private=None,
+    def resolve(self, project, require_https=False, filename='', private=None,
                 **kwargs):
         if private is None:
             version_slug = kwargs.get('version_slug')
@@ -150,8 +150,8 @@ class ResolverBase(object):
         # This duplication from resolve_domain is for performance purposes
         # in order to check whether a custom domain should be HTTPS
         use_custom_domain = any([
-            (custom_domain and not require_https_domain),
-            (custom_domain and require_https_domain and custom_domain.https),
+            (custom_domain and not require_https),
+            (custom_domain and require_https and custom_domain.https),
         ])
         if use_custom_domain:
             domain = custom_domain.domain
@@ -167,7 +167,7 @@ class ResolverBase(object):
             # Rely on the ``Domain.https`` field
             custom_domain and custom_domain.https,
             # or force it if specified
-            require_https_domain,
+            require_https,
             # or fallback to settings
             use_https and public_domain and public_domain in domain,
         ])

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -146,8 +146,9 @@ class ResolverBase(object):
 
         canonical_project = self._get_canonical_project(project)
         custom_domain = self._get_project_custom_domain(canonical_project)
+        use_custom_domain = self._use_custom_domain(custom_domain)
 
-        if self._use_custom_domain(custom_domain):
+        if use_custom_domain:
             domain = custom_domain.domain
         elif self._use_subdomain():
             domain = self._get_project_subdomain(canonical_project)
@@ -159,7 +160,7 @@ class ResolverBase(object):
 
         use_https_protocol = any([
             # Rely on the ``Domain.https`` field
-            custom_domain and custom_domain.https,
+            use_custom_domain and custom_domain.https,
             # or force it if specified
             require_https,
             # or fallback to settings

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -160,17 +160,18 @@ class ResolverBase(object):
         else:
             domain = getattr(settings, 'PRODUCTION_DOMAIN')
 
-        protocol = 'http'
-        if custom_domain:
-            # Rely on the ``Domain.https`` field or force it if specified
-            if custom_domain.https or require_https_domain:
-                protocol = 'https'
-        else:
-            # Use HTTPS if settings specify
-            public_domain = getattr(settings, 'PUBLIC_DOMAIN', None)
-            use_https = getattr(settings, 'PUBLIC_DOMAIN_USES_HTTPS', False)
-            if use_https and public_domain and public_domain in domain:
-                protocol = 'https'
+        public_domain = getattr(settings, 'PUBLIC_DOMAIN', None)
+        use_https = getattr(settings, 'PUBLIC_DOMAIN_USES_HTTPS', False)
+
+        use_https_protocol = any([
+            # Rely on the ``Domain.https`` field
+            custom_domain and custom_domain.https,
+            # or force it if specified
+            require_https_domain,
+            # or fallback to settings
+            use_https and public_domain and public_domain in domain,
+        ])
+        protocol = 'https' if use_https_protocol else 'http'
 
         return '{protocol}://{domain}{path}'.format(
             protocol=protocol,

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -51,23 +51,26 @@ def get_filesystem(path, top_level_path=None):
     return fs
 
 
-class TempSiterootCase(object):
+TEMP_SITE_ROOT = tempfile.mkdtemp(suffix='siteroot')
+TEMP_DOCROOT = os.path.join(TEMP_SITE_ROOT, 'user_builds')
 
-    """Override SITE_ROOT and patch necessary pieces to inspect symlink structure
+
+@override_settings(
+    SITE_ROOT=TEMP_SITE_ROOT,
+    DOCROOT=TEMP_DOCROOT,
+)
+class TempSiteRootTestCase(TestCase):
+
+    """
+    Override SITE_ROOT and patch necessary pieces to inspect symlink structure.
 
     This uses some patches and overidden settings to build out symlinking in a
     temporary path.  Each test is therefore isolated, and cleanup will remove
     these paths after the test case wraps up.
-
-    And subclasses that implement :py:class:`TestCase` should also make use of
-    :py:func:`override_settings`.
     """
 
     def setUp(self):
         self.maxDiff = None
-        self.site_root = os.path.realpath(tempfile.mkdtemp(suffix='siteroot'))
-        settings.SITE_ROOT = self.site_root
-        settings.DOCROOT = os.path.join(settings.SITE_ROOT, 'user_builds')
         self.mocks = {
             'PublicSymlinkBase.CNAME_ROOT': mock.patch(
                 'readthedocs.core.symlink.PublicSymlinkBase.CNAME_ROOT',
@@ -115,16 +118,16 @@ class TempSiterootCase(object):
         )
 
     def tearDown(self):
-        shutil.rmtree(self.site_root)
+        shutil.rmtree(settings.SITE_ROOT)
 
     def assertFilesystem(self, filesystem):
         """
         Creates a nested dictionary that represents the folder structure of rootdir
         """
-        self.assertEqual(filesystem, get_filesystem(self.site_root))
+        self.assertEqual(filesystem, get_filesystem(settings.SITE_ROOT))
 
 
-class BaseSymlinkCnames(TempSiterootCase):
+class BaseSymlinkCnames(object):
 
     def setUp(self):
         super(BaseSymlinkCnames, self).setUp()
@@ -290,19 +293,17 @@ class BaseSymlinkCnames(TempSiterootCase):
         self.assertFilesystem(filesystem)
 
 
-@override_settings()
-class TestPublicSymlinkCnames(BaseSymlinkCnames, TestCase):
+class TestPublicSymlinkCnames(BaseSymlinkCnames, TempSiteRootTestCase):
     privacy = 'public'
     symlink_class = PublicSymlink
 
 
-@override_settings()
-class TestPrivateSymlinkCnames(BaseSymlinkCnames, TestCase):
+class TestPrivateSymlinkCnames(BaseSymlinkCnames, TempSiteRootTestCase):
     privacy = 'private'
     symlink_class = PrivateSymlink
 
 
-class BaseSubprojects(TempSiterootCase):
+class BaseSubprojects(object):
 
     def setUp(self):
         super(BaseSubprojects, self).setUp()
@@ -503,19 +504,17 @@ class BaseSubprojects(TempSiterootCase):
         self.assertFilesystem(filesystem)
 
 
-@override_settings()
-class TestPublicSubprojects(BaseSubprojects, TestCase):
+class TestPublicSubprojects(BaseSubprojects, TempSiteRootTestCase):
     privacy = 'public'
     symlink_class = PublicSymlink
 
 
-@override_settings()
-class TestPrivateSubprojects(BaseSubprojects, TestCase):
+class TestPrivateSubprojects(BaseSubprojects, TempSiteRootTestCase):
     privacy = 'private'
     symlink_class = PrivateSymlink
 
 
-class BaseSymlinkTranslations(TempSiterootCase):
+class BaseSymlinkTranslations(object):
 
     def setUp(self):
         super(BaseSymlinkTranslations, self).setUp()
@@ -757,19 +756,17 @@ class BaseSymlinkTranslations(TempSiterootCase):
         self.assertFilesystem(filesystem)
 
 
-@override_settings()
-class TestPublicSymlinkTranslations(BaseSymlinkTranslations, TestCase):
+class TestPublicSymlinkTranslations(BaseSymlinkTranslations, TempSiteRootTestCase):
     privacy = 'public'
     symlink_class = PublicSymlink
 
 
-@override_settings()
-class TestPrivateSymlinkTranslations(BaseSymlinkTranslations, TestCase):
+class TestPrivateSymlinkTranslations(BaseSymlinkTranslations, TempSiteRootTestCase):
     privacy = 'private'
     symlink_class = PrivateSymlink
 
 
-class BaseSymlinkSingleVersion(TempSiterootCase):
+class BaseSymlinkSingleVersion(object):
 
     def setUp(self):
         super(BaseSymlinkSingleVersion, self).setUp()
@@ -834,19 +831,17 @@ class BaseSymlinkSingleVersion(TempSiterootCase):
         self.assertFilesystem(filesystem)
 
 
-@override_settings()
-class TestPublicSymlinkSingleVersion(BaseSymlinkSingleVersion, TestCase):
+class TestPublicSymlinkSingleVersion(BaseSymlinkSingleVersion, TempSiteRootTestCase):
     privacy = 'public'
     symlink_class = PublicSymlink
 
 
-@override_settings()
-class TestPublicSymlinkSingleVersion(BaseSymlinkSingleVersion, TestCase):
+class TestPublicSymlinkSingleVersion(BaseSymlinkSingleVersion, TempSiteRootTestCase):
     privacy = 'private'
     symlink_class = PrivateSymlink
 
 
-class BaseSymlinkVersions(TempSiterootCase):
+class BaseSymlinkVersions(object):
 
     def setUp(self):
         super(BaseSymlinkVersions, self).setUp()
@@ -962,20 +957,17 @@ class BaseSymlinkVersions(TempSiterootCase):
         self.assertFilesystem(filesystem)
 
 
-@override_settings()
-class TestPublicSymlinkVersions(BaseSymlinkVersions, TestCase):
+class TestPublicSymlinkVersions(BaseSymlinkVersions, TempSiteRootTestCase):
     privacy = 'public'
     symlink_class = PublicSymlink
 
 
-@override_settings()
-class TestPrivateSymlinkVersions(BaseSymlinkVersions, TestCase):
+class TestPrivateSymlinkVersions(BaseSymlinkVersions, TempSiteRootTestCase):
     privacy = 'private'
     symlink_class = PrivateSymlink
 
 
-@override_settings()
-class TestPublicSymlinkUnicode(TempSiterootCase, TestCase):
+class TestPublicSymlinkUnicode(TempSiteRootTestCase):
 
     def setUp(self):
         super(TestPublicSymlinkUnicode, self).setUp()
@@ -1040,8 +1032,7 @@ class TestPublicSymlinkUnicode(TempSiterootCase, TestCase):
             )
 
 
-@override_settings()
-class TestPublicPrivateSymlink(TempSiterootCase, TestCase):
+class TestPublicPrivateSymlink(TempSiteRootTestCase):
 
     def setUp(self):
         super(TestPublicPrivateSymlink, self).setUp()

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -471,6 +471,10 @@ class ResolverTests(ResolverBase):
             url = resolve(project=self.pip)
             self.assertEqual(url, 'http://docs.foobar.com/en/latest/')
 
+            # Do not use the ``Domain.domain`` when ``require_https_domain=True``
+            url = resolve(project=self.pip, require_https_domain=True)
+            self.assertEqual(url, 'https://pip.readthedocs.org/en/latest/')
+
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
     def test_resolver_domain_https(self):
         self.domain = fixture.get(
@@ -485,6 +489,10 @@ class ResolverTests(ResolverBase):
             self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
         with override_settings(USE_SUBDOMAIN=True):
             url = resolve(project=self.pip)
+            self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
+
+            # Use the ``Domain.domain`` when ``require_https_domain=True``
+            url = resolve(project=self.pip, require_https_domain=True)
             self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -471,8 +471,8 @@ class ResolverTests(ResolverBase):
             url = resolve(project=self.pip)
             self.assertEqual(url, 'http://docs.foobar.com/en/latest/')
 
-            # Do not use the ``Domain.domain`` when ``require_https_domain=True``
-            url = resolve(project=self.pip, require_https_domain=True)
+            # Do not use the ``Domain.domain`` when ``require_https=True``
+            url = resolve(project=self.pip, require_https=True)
             self.assertEqual(url, 'https://pip.readthedocs.org/en/latest/')
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
@@ -491,8 +491,8 @@ class ResolverTests(ResolverBase):
             url = resolve(project=self.pip)
             self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
 
-            # Use the ``Domain.domain`` when ``require_https_domain=True``
-            url = resolve(project=self.pip, require_https_domain=True)
+            # Use the ``Domain.domain`` when ``require_https=True``
+            url = resolve(project=self.pip, require_https=True)
             self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -471,10 +471,6 @@ class ResolverTests(ResolverBase):
             url = resolve(project=self.pip)
             self.assertEqual(url, 'http://docs.foobar.com/en/latest/')
 
-            # Do not use the ``Domain.domain`` when ``require_https=True``
-            url = resolve(project=self.pip, require_https=True)
-            self.assertEqual(url, 'https://pip.readthedocs.org/en/latest/')
-
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
     def test_resolver_domain_https(self):
         self.domain = fixture.get(
@@ -489,10 +485,6 @@ class ResolverTests(ResolverBase):
             self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
         with override_settings(USE_SUBDOMAIN=True):
             url = resolve(project=self.pip)
-            self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
-
-            # Use the ``Domain.domain`` when ``require_https=True``
-            url = resolve(project=self.pip, require_https=True)
             self.assertEqual(url, 'https://docs.foobar.com/en/latest/')
 
     @override_settings(PRODUCTION_DOMAIN='readthedocs.org')


### PR DESCRIPTION
Argument ``require_https_domain`` added to force the resolver to use https URLs with PUBLIC_DOMAIN when the Domain is not https.

I found this while running tests on Corporate site since we don't serve documentation over plain HTTP there. So, we need a way to force the https protocol even when the project has a Domain object (but https=False). In this case, we force to use our PUBLIC_DOMAIN URL over HTTPS.