### PR TITLE
Respect user language when caching homepage

### DIFF
--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -117,7 +117,8 @@
   </section>
 
   {% if featured_list %}
-  {% cache 600 homepage_featured_list %}
+  {% get_current_language as language %}
+  {% cache 600 homepage_featured_list language %}
     <!-- BEGIN projects list -->
     <section>
       <h3>{% trans "Featured Projects" %}</h3>


### PR DESCRIPTION
Previously it was using the first language that hit the page to cache.

Fixes #4582 