### PR TITLE
Sanitize command output when running under DockerBuildEnvironment

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -258,11 +258,8 @@ class DockerBuildCommand(BuildCommand):
                 stderr=True,
             )
 
-            output = client.exec_start(exec_id=exec_cmd['Id'], stream=False)
-            try:
-                self.output = output.decode('utf-8', 'replace')
-            except (TypeError, AttributeError):
-                self.output = ''
+            cmd_output = client.exec_start(exec_id=exec_cmd['Id'], stream=False)
+            self.output = self.sanitize_output(cmd_output)
             cmd_ret = client.exec_inspect(exec_id=exec_cmd['Id'])
             self.exit_code = cmd_ret['ExitCode']
 


### PR DESCRIPTION
In #4552 I fixed this for LocalBuildEnvironment but I forget to do exactly the same for Docker. This is what this commit does.

Closes #3900