### PR TITLE
Fix ad block nag project issue

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -280,7 +280,7 @@ function init() {
         error: function () {
             console.error('Error loading Read the Docs promo');
 
-            if (!rtddata.ad_free && rtd.api_host === 'https://readthedocs.org' && detect_adblock()) {
+            if (!rtd.ad_free && rtd.api_host === 'https://readthedocs.org' && detect_adblock()) {
                 adblock_admonition();
                 adblock_nag();
             }


### PR DESCRIPTION
This fixes an issue with the ad nag where a project is sponsored and the user runs an ad blocker. We know whether a project is ad-free when we build it and we should never show the nag on a sponsored project.

This partially resolves the nag issue in #4595 (I purposefully worded this to not auto-close that issue).

#4329 did not quite correctly fix this issue.