### PR TITLE
Return 404 for inactive versions and allow redirects on them

### DIFF
--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -155,8 +155,9 @@ def serve_docs(
     try:
         version = project.versions.public(request.user).get(slug=version_slug)
     except Version.DoesNotExist:
-        # Properly raise a 404 if the version doesn't exist & a 401 if it does
-        if project.versions.filter(slug=version_slug).exists():
+        # Properly raise a 404 if the version doesn't exist (or is inactive) and
+        # a 401 if it does
+        if project.versions.filter(slug=version_slug, active=True).exists():
             return _serve_401(request, project)
         raise Http404('Version does not exist.')
     filename = resolve_path(


### PR DESCRIPTION
When a version exists and is inactive, we return 404 instead of 401 so our redirect system can be used for these versions.

We only return 401 when the reader has no permission to read the version (active and private).

Closes #4598