### PR TITLE
Run coverage on travis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  layout: "diff, files"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
+branch = true
+source = .
 omit =
   */**/migrations/*
   */**/management/commands/*
@@ -8,3 +10,10 @@ omit =
   rtd_tests/*
   */**/tests/**
   wsgi.py
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,10 @@
 [run]
 omit =
   */**/migrations/*
+  */**/management/commands/*
+  */**/settings/*
+  */**/settings.py
+  analytics/vendor/*
+  rtd_tests/*
+  */**/tests/**
+  wsgi.py

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,7 +5,7 @@ pytest==3.7.4
 pytest-django==3.4.2
 pytest-describe==0.11.1
 pytest-xdist==1.23.0
-pytest-coverage
+pytest-cov
 apipkg==1.5
 execnet==1.5.0
 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,6 +5,7 @@ pytest==3.7.4
 pytest-django==3.4.2
 pytest-describe==0.11.1
 pytest-xdist==1.23.0
+pytest-coverage
 apipkg==1.5
 execnet==1.5.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,5 +57,5 @@ description = run test suite with code coverage for the application with {basepy
 deps = coverage
 whitelist_externals = echo
 commands =
-    coverage report --show-missing --fail-under=79
+    coverage report --show-missing --fail-under=76
     echo Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands =
     npm run lint
 
 [testenv:coverage]
-description = run test suite with code coverage for the application with {basepython}
+description = shows the coverage report
 deps = coverage
 whitelist_externals = echo
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 [travis]
 python =
     2.7: py27
-    3.6: py36, coverage
+    3.6: py36, codecov
 
 [testenv]
 description = run test suite for the application with {basepython}
@@ -16,6 +16,7 @@ setenv =
     LANG=C
     LC_CTYPE=C.UTF-8
     DJANGO_SETTINGS_SKIP_LOCAL=True
+passenv = CI TRAVIS TRAVIS_*
 deps = -r{toxinidir}/requirements/testing.txt
 changedir = {toxinidir}/readthedocs
 commands =
@@ -57,5 +58,11 @@ description = shows the coverage report
 deps = coverage
 whitelist_externals = echo
 commands =
-    coverage report --show-missing --fail-under=76
+    coverage report --show-missing
+    coverage html
     echo Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html
+
+[testenv:codecov]
+description = upload coverage report
+deps = codecov
+commands = codecov

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 [travis]
 python =
     2.7: py27
-    3.6: py36
+    3.6: py36, coverage
 
 [testenv]
 description = run test suite for the application with {basepython}
@@ -19,7 +19,7 @@ setenv =
 deps = -r{toxinidir}/requirements/testing.txt
 changedir = {toxinidir}/readthedocs
 commands =
-    py.test {posargs}
+    py.test --cov-report= --cov-config {toxinidir}/.coveragerc --cov=. {posargs}
 
 [testenv:docs]
 description = build readthedocs documentation
@@ -54,11 +54,8 @@ commands =
 
 [testenv:coverage]
 description = run test suite with code coverage for the application with {basepython}
-deps =
-    -r{toxinidir}/requirements/testing.txt
-    pytest-cov
+deps = coverage
 whitelist_externals = echo
 commands =
-    py.test --disable-pytest-warnings \
-        --cov-report=term --cov-report=html --cov-config {toxinidir}/.coveragerc --cov=.  {posargs}
+    coverage report --show-missing --fail-under=79
     echo Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html


### PR DESCRIPTION
Our coverage is good, and I would love to maintain it like that. The coverage report is 0% on management commands (not sure if we care to have tests for that)

What change? Almost nothing, devs can still run normal tests, as usual. The only thing is that Travis will fail if the coverage goes down 79% (our current coverage).

We can increase the coverage later, but keeping it >=79% is a good first step.

If you want to check the coverage locally, you'll need to run tox like this `tox -e py36,coverage`