### PR TITLE
Ability to use supervisor from python 2.7 and still run Python 3

### DIFF
--- a/contrib/supervisord.conf
+++ b/contrib/supervisord.conf
@@ -26,7 +26,7 @@ stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
 [program:main]
-command = python manage.py runserver 8000
+command = python3 manage.py runserver 8000
 directory = ../
 priority = 100
 stopasgroup = True
@@ -34,7 +34,7 @@ stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
 [program:celery]
-command = celery worker -A readthedocs -Q default,celery,web,builder -l DEBUG -c 2
+command = python3 -m celery worker -A readthedocs -Q default,celery,web,builder -l DEBUG -c 2
 directory = ../
 priority = 100
 stopasgroup = True


### PR DESCRIPTION
This has been sitting around on my local dev instance for a while, I
figure we're fine to start switching all of our development pieces to
py3 before we announce deprecation of python 2.x