### PR TITLE
Add a contrib Dockerfile for local build image on Linux

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,17 +1,15 @@
-FROM readthedocs/build:4.0rc1
+FROM readthedocs/build:latest
 
 ARG username
-ARG uid=1000
+ARG uid=$uid
 ARG gid=$uid
-ARG label=latest
 
-ENV USERNAME ${username}
 ENV UID ${uid}
 ENV GID ${gid}
 
 USER root
-RUN groupadd --gid $GID $USERNAME
-RUN useradd -m --uid $UID --gid $GID $USERNAME
-USER $username
+RUN groupadd --gid ${GID} docscustom
+RUN usermod --uid ${UID} --gid ${GID} docs
+USER docs
 
 CMD ["/bin/bash"]

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,17 @@
+FROM readthedocs/build:4.0rc1
+
+ARG username
+ARG uid=1000
+ARG gid=$uid
+ARG label=latest
+
+ENV USERNAME ${username}
+ENV UID ${uid}
+ENV GID ${gid}
+
+USER root
+RUN groupadd --gid $GID $USERNAME
+RUN useradd -m --uid $UID --gid $GID $USERNAME
+USER $username
+
+CMD ["/bin/bash"]

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,14 +1,15 @@
-FROM readthedocs/build:latest
+ARG label
 
-ARG username
-ARG uid=$uid
-ARG gid=$uid
+FROM readthedocs/build:${label}
+
+ARG uid
+ARG gid
 
 ENV UID ${uid}
 ENV GID ${gid}
 
 USER root
-RUN groupadd --gid ${GID} docscustom
+RUN groupmod --gid ${GID} docs
 RUN usermod --uid ${UID} --gid ${GID} docs
 USER docs
 

--- a/contrib/docker_build.sh
+++ b/contrib/docker_build.sh
@@ -2,6 +2,8 @@
 
 uid=`id -u`
 gid=`id -g`
+basedir=`dirname "$0"`
+dockerfile=${basedir}/Dockerfile
 
 version=$1
 [ -n "${version}" ] || version="latest"
@@ -12,4 +14,4 @@ docker build \
     --build-arg uid=${uid} \
     --build-arg gid=${gid} \
     --build-arg label=${version} \
-    .
+    - <${dockerfile}

--- a/contrib/docker_build.sh
+++ b/contrib/docker_build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+username=`id -nu`
+uid=`id -u`
+gid=`id -g`
+
+version=$1
+[ -n "${version}" ] || version="latest"
+
+docker build \
+    -t readthedocs/build:dev \
+    --build-arg username=${username} \
+    --build-arg uid=${uid} \
+    --build-arg gid=${gid} \
+    --build-arg label=${version} \
+    .

--- a/contrib/docker_build.sh
+++ b/contrib/docker_build.sh
@@ -4,13 +4,8 @@ username=`id -nu`
 uid=`id -u`
 gid=`id -g`
 
-version=$1
-[ -n "${version}" ] || version="latest"
-
 docker build \
-    -t readthedocs/build:dev \
-    --build-arg username=${username} \
+    -t readthedocs/build:latest-dev \
     --build-arg uid=${uid} \
     --build-arg gid=${gid} \
-    --build-arg label=${version} \
     .

--- a/contrib/docker_build.sh
+++ b/contrib/docker_build.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 
-username=`id -nu`
 uid=`id -u`
 gid=`id -g`
 
+version=$1
+[ -n "${version}" ] || version="latest"
+
 docker build \
-    -t readthedocs/build:latest-dev \
+    --no-cache \
+    -t readthedocs/build-dev:${version} \
     --build-arg uid=${uid} \
     --build-arg gid=${gid} \
+    --build-arg label=${version} \
     .

--- a/contrib/readme.rst
+++ b/contrib/readme.rst
@@ -1,5 +1,17 @@
+Contrib
+=======
+
+Building development Docker image
+---------------------------------
+
+If you run Linux, you likely need to build a local Docker image that extends our
+default image::
+
+    cd contrib/
+    ./docker_build.sh
+
 Running Read the Docs via Supervisord
-=====================================
+-------------------------------------
 
 This is the easiest way to start all of the commands you'll need for development
 in an environment relatively close to the production evironment. All you need is

--- a/contrib/readme.rst
+++ b/contrib/readme.rst
@@ -7,8 +7,7 @@ Building development Docker image
 If you run Linux, you likely need to build a local Docker image that extends our
 default image::
 
-    cd contrib/
-    ./docker_build.sh
+    contrib/docker_build.sh latest
 
 Running Read the Docs via Supervisord
 -------------------------------------

--- a/docs/development/buildenvironments.rst
+++ b/docs/development/buildenvironments.rst
@@ -89,7 +89,8 @@ Local development
 
 On Linux development environments, it's likely that your UID and GID do not
 match the ``docs`` user that is set up as the default user for builds. In this
-case, it's necessary to make a new image that overrides this user::
+case, it's necessary to make a new image that overrides the UID and GID for the
+normal container user::
 
     contrib/docker_build.sh latest
 
@@ -99,3 +100,11 @@ different image, you can instead specify a version to build::
     contrib/docker_build.sh 5.0
 
 This will create a new image, ``readthedocs/build-dev:5.0``.
+
+You can set a ``local_settings.py`` option to automatically patch the image
+names to the development image names that are built here:
+
+DOCKER_USE_DEV_IMAGES
+    If set to ``True``, replace the normal Docker image name used in building
+    ``readthedocs/build`` with the image name output for these commands,
+    ``readthedocs/build-dev``.

--- a/docs/development/buildenvironments.rst
+++ b/docs/development/buildenvironments.rst
@@ -91,13 +91,11 @@ On Linux development environments, it's likely that your UID and GID do not
 match the ``docs`` user that is set up as the default user for builds. In this
 case, it's necessary to make a new image that overrides this user::
 
-    cd contrib/
-    ./docker_build.sh latest
+    contrib/docker_build.sh latest
 
 This will create a new image, ``readthedocs/build-dev:latest``. To build a
 different image, you can instead specify a version to build::
 
-    cd contrib/
-    ./docker_build.sh 5.0
+    contrib/docker_build.sh 5.0
 
 This will create a new image, ``readthedocs/build-dev:5.0``.

--- a/docs/development/buildenvironments.rst
+++ b/docs/development/buildenvironments.rst
@@ -92,9 +92,12 @@ match the ``docs`` user that is set up as the default user for builds. In this
 case, it's necessary to make a new image that overrides this user::
 
     cd contrib/
-    ./docker_build.sh
+    ./docker_build.sh latest
 
-This will create a new image, ``readthedocs/build:latest-dev``,
-which you can re-tag as ``latest`` to make Read the Docs use this image instead::
+This will create a new image, ``readthedocs/build-dev:latest``. To build a
+different image, you can instead specify a version to build::
 
-  docker tag readthedocs/build:latest-dev readthedocs/build:latest
+    cd contrib/
+    ./docker_build.sh 5.0
+
+This will create a new image, ``readthedocs/build-dev:5.0``.

--- a/docs/development/buildenvironments.rst
+++ b/docs/development/buildenvironments.rst
@@ -83,6 +83,7 @@ DOCKER_VERSION
 
     Default: :djangosetting:`DOCKER_VERSION`
 
+
 Local development
 -----------------
 
@@ -93,12 +94,7 @@ case, it's necessary to make a new image that overrides this user::
     cd contrib/
     ./docker_build.sh
 
-You can also specify a specific image version to use::
+This will create a new image, ``readthedocs/build:latest-dev``,
+which you can re-tag as ``latest`` to make Read the Docs use this image instead::
 
-    cd contrib/
-    ./docker_build.sh 4.0rc1
-
-This will create a new image, ``readthedocs/build:dev``, which you can specify
-as the default image in local settings overrides::
-
-    DOCKER_IMAGE = 'readthedocs/build:dev'
+  docker tag readthedocs/build:latest-dev readthedocs/build:latest

--- a/docs/development/buildenvironments.rst
+++ b/docs/development/buildenvironments.rst
@@ -82,3 +82,23 @@ DOCKER_VERSION
     Version of the API to use for the Docker API client.
 
     Default: :djangosetting:`DOCKER_VERSION`
+
+Local development
+-----------------
+
+On Linux development environments, it's likely that your UID and GID do not
+match the ``docs`` user that is set up as the default user for builds. In this
+case, it's necessary to make a new image that overrides this user::
+
+    cd contrib/
+    ./docker_build.sh
+
+You can also specify a specific image version to use::
+
+    cd contrib/
+    ./docker_build.sh 4.0rc1
+
+This will create a new image, ``readthedocs/build:dev``, which you can specify
+as the default image in local settings overrides::
+
+    DOCKER_IMAGE = 'readthedocs/build:dev'

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -83,3 +83,14 @@ if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
         from .local_settings import *  # noqa
     except ImportError:
         pass
+
+# Allow for local settings override to trigger images name change
+try:
+    if DOCKER_USE_DEV_IMAGES:
+        DOCKER_IMAGE_SETTINGS = {
+            key.replace('readthedocs/build:', 'readthedocs/build-dev:'): settings
+            for (key, settings)
+            in DOCKER_IMAGE_SETTINGS.items()
+        }
+except NameError:
+    pass


### PR DESCRIPTION
This is necessary as permissions are all incorrect on the paths that are
shared between the host system and the Docker build container.

Closes #2692