### PR TITLE
Make restapi URL additions conditional

### DIFF
--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -1,24 +1,39 @@
+# -*- coding: utf-8 -*-
+
 """Define routes between URL paths and views/endpoints."""
 
-from __future__ import absolute_import
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 from django.conf import settings
-from django.conf.urls import url, include
-
+from django.conf.urls import include, url
 from rest_framework import routers
 
 from readthedocs.constants import pattern_opts
 from readthedocs.restapi import views
 from readthedocs.restapi.views import (
-    core_views, footer_views, search_views, task_views, integrations
+    core_views,
+    footer_views,
+    integrations,
+    search_views,
+    task_views,
 )
 
-from .views.model_views import (BuildViewSet, BuildCommandViewSet,
-                                ProjectViewSet, NotificationViewSet,
-                                VersionViewSet, DomainViewSet,
-                                RemoteOrganizationViewSet,
-                                RemoteRepositoryViewSet,
-                                SocialAccountViewSet)
+from .views.model_views import (
+    BuildCommandViewSet,
+    BuildViewSet,
+    DomainViewSet,
+    NotificationViewSet,
+    ProjectViewSet,
+    RemoteOrganizationViewSet,
+    RemoteRepositoryViewSet,
+    SocialAccountViewSet,
+    VersionViewSet,
+)
 
 router = routers.DefaultRouter()
 router.register(r'build', BuildViewSet, base_name='build')
@@ -28,11 +43,20 @@ router.register(r'project', ProjectViewSet, base_name='project')
 router.register(r'notification', NotificationViewSet, base_name='emailhook')
 router.register(r'domain', DomainViewSet, base_name='domain')
 router.register(
-    r'remote/org', RemoteOrganizationViewSet, base_name='remoteorganization')
+    r'remote/org',
+    RemoteOrganizationViewSet,
+    base_name='remoteorganization',
+)
 router.register(
-    r'remote/repo', RemoteRepositoryViewSet, base_name='remoterepository')
+    r'remote/repo',
+    RemoteRepositoryViewSet,
+    base_name='remoterepository',
+)
 router.register(
-    r'remote/account', SocialAccountViewSet, base_name='remoteaccount')
+    r'remote/account',
+    SocialAccountViewSet,
+    base_name='remoteaccount',
+)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
@@ -46,44 +70,74 @@ function_urls = [
 ]
 
 search_urls = [
-    url(r'index_search/',
+    url(
+        r'index_search/',
         search_views.index_search,
-        name='index_search'),
+        name='index_search',
+    ),
     url(r'search/$', views.search_views.search, name='api_search'),
-    url(r'search/project/$',
+    url(
+        r'search/project/$',
         search_views.project_search,
-        name='api_project_search'),
-    url(r'search/section/$',
+        name='api_project_search',
+    ),
+    url(
+        r'search/section/$',
         search_views.section_search,
-        name='api_section_search'),
+        name='api_section_search',
+    ),
 ]
 
 task_urls = [
-    url(r'jobs/status/(?P<task_id>[^/]+)/',
+    url(
+        r'jobs/status/(?P<task_id>[^/]+)/',
         task_views.job_status,
-        name='api_job_status'),
-    url(r'jobs/sync-remote-repositories/',
+        name='api_job_status',
+    ),
+    url(
+        r'jobs/sync-remote-repositories/',
         task_views.sync_remote_repositories,
-        name='api_sync_remote_repositories'),
+        name='api_sync_remote_repositories',
+    ),
 ]
 
 integration_urls = [
-    url(r'webhook/github/(?P<project_slug>{project_slug})/$'.format(**pattern_opts),
+    url(
+        r'webhook/github/(?P<project_slug>{project_slug})/$'.format(
+            **pattern_opts,
+        ),
         integrations.GitHubWebhookView.as_view(),
-        name='api_webhook_github'),
-    url(r'webhook/gitlab/(?P<project_slug>{project_slug})/$'.format(**pattern_opts),
+        name='api_webhook_github',
+    ),
+    url(
+        r'webhook/gitlab/(?P<project_slug>{project_slug})/$'.format(
+            **pattern_opts,
+        ),
         integrations.GitLabWebhookView.as_view(),
-        name='api_webhook_gitlab'),
-    url(r'webhook/bitbucket/(?P<project_slug>{project_slug})/$'.format(**pattern_opts),
+        name='api_webhook_gitlab',
+    ),
+    url(
+        r'webhook/bitbucket/(?P<project_slug>{project_slug})/$'.format(
+            **pattern_opts,
+        ),
         integrations.BitbucketWebhookView.as_view(),
-        name='api_webhook_bitbucket'),
-    url(r'webhook/generic/(?P<project_slug>{project_slug})/$'.format(**pattern_opts),
+        name='api_webhook_bitbucket',
+    ),
+    url(
+        r'webhook/generic/(?P<project_slug>{project_slug})/$'.format(
+            **pattern_opts,
+        ),
         integrations.APIWebhookView.as_view(),
-        name='api_webhook_generic'),
-    url((r'webhook/(?P<project_slug>{project_slug})/'
-         r'(?P<integration_pk>{integer_pk})/$'.format(**pattern_opts)),
+        name='api_webhook_generic',
+    ),
+    url(
+        (
+            r'webhook/(?P<project_slug>{project_slug})/'
+            r'(?P<integration_pk>{integer_pk})/$'.format(**pattern_opts)
+        ),
         integrations.WebhookView.as_view(),
-        name='api_webhook'),
+        name='api_webhook',
+    ),
 ]
 
 urlpatterns += function_urls
@@ -92,6 +146,7 @@ urlpatterns += task_urls
 urlpatterns += integration_urls
 
 if 'readthedocsext.search' in settings.INSTALLED_APPS:
+    # pylint: disable=import-error
     from readthedocsext.search.docsearch import DocSearch
     api_search_urls = [
         url(r'^docsearch/$', DocSearch.as_view(), name='doc_search'),
@@ -99,7 +154,9 @@ if 'readthedocsext.search' in settings.INSTALLED_APPS:
     urlpatterns += api_search_urls
 
 if 'readthedocsext.donate' in settings.INSTALLED_APPS:
-    from readthedocsext.donate.restapi.urls import urlpatterns as sustainability_urls
+    # pylint: disable=import-error
+    from readthedocsext.donate.restapi.urls import urlpatterns \
+        as sustainability_urls
 
     urlpatterns += [
         url(r'^sustainability/', include(sustainability_urls)),

--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+from django.conf import settings
 from django.conf.urls import url, include
 
 from rest_framework import routers
@@ -90,20 +91,16 @@ urlpatterns += search_urls
 urlpatterns += task_urls
 urlpatterns += integration_urls
 
-try:
+if 'readthedocsext.search' in settings.INSTALLED_APPS:
     from readthedocsext.search.docsearch import DocSearch
     api_search_urls = [
         url(r'^docsearch/$', DocSearch.as_view(), name='doc_search'),
     ]
     urlpatterns += api_search_urls
-except ImportError:
-    pass
 
-try:
+if 'readthedocsext.donate' in settings.INSTALLED_APPS:
     from readthedocsext.donate.restapi.urls import urlpatterns as sustainability_urls
 
     urlpatterns += [
         url(r'^sustainability/', include(sustainability_urls)),
     ]
-except ImportError:
-    pass

--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -103,30 +103,26 @@ task_urls = [
 
 integration_urls = [
     url(
-        r'webhook/github/(?P<project_slug>{project_slug})/$'.format(
-            **pattern_opts,
-        ),
+        r'webhook/github/(?P<project_slug>{project_slug})/$'
+        .format(**pattern_opts),
         integrations.GitHubWebhookView.as_view(),
         name='api_webhook_github',
     ),
     url(
-        r'webhook/gitlab/(?P<project_slug>{project_slug})/$'.format(
-            **pattern_opts,
-        ),
+        r'webhook/gitlab/(?P<project_slug>{project_slug})/$'
+        .format(**pattern_opts),
         integrations.GitLabWebhookView.as_view(),
         name='api_webhook_gitlab',
     ),
     url(
-        r'webhook/bitbucket/(?P<project_slug>{project_slug})/$'.format(
-            **pattern_opts,
-        ),
+        r'webhook/bitbucket/(?P<project_slug>{project_slug})/$'
+        .format(**pattern_opts),
         integrations.BitbucketWebhookView.as_view(),
         name='api_webhook_bitbucket',
     ),
     url(
-        r'webhook/generic/(?P<project_slug>{project_slug})/$'.format(
-            **pattern_opts,
-        ),
+        r'webhook/generic/(?P<project_slug>{project_slug})/$'
+        .format(**pattern_opts),
         integrations.APIWebhookView.as_view(),
         name='api_webhook_generic',
     ),


### PR DESCRIPTION
We already have logic that checks for readthedocsext import availability
when adding to INSTALLED_APPS, so checking here for import availability
isn't correct. For instance, on the readthedocsinc side, we remove
`readthedocsext.donate` from INSTALLED_APPS inherited from
settings.base, but urls.py would import the module, add the URLs (for
packages that aren't in INSTALLED_APPS anymore), and things broke.