### PR TITLE
Add cwd to subprocess calls

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -310,7 +310,13 @@ class EpubBuilder(BaseSphinx):
                 self.target,
                 '{}.epub'.format(self.project.slug),
             )
-            self.run('mv', '-f', from_file, to_file)
+            self.run(
+                'mv',
+                '-f',
+                from_file,
+                to_file,
+                cwd=self.project.checkout_path(self.version.slug),
+            )
 
 
 class LatexBuildCommand(BuildCommand):
@@ -429,4 +435,10 @@ class PdfBuilder(BaseSphinx):
         if from_file:
             to_file = os.path.join(
                 self.target, '{}.pdf'.format(self.project.slug))
-            self.run('mv', '-f', from_file, to_file)
+            self.run(
+                'mv',
+                '-f',
+                from_file,
+                to_file,
+                cwd=self.project.checkout_path(self.version.slug),
+            )

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -78,7 +78,7 @@ class PythonEnvironment(object):
                 self.project.pip_cache_path,
                 '.{0}'.format(extra_req_param),
                 cwd=self.checkout_path,
-                bin_path=self.venv_bin()
+                bin_path=self.venv_bin(),
             )
         elif self.config.python.install_with_setup:
             self.build_env.run(
@@ -87,7 +87,7 @@ class PythonEnvironment(object):
                 'install',
                 '--force',
                 cwd=self.checkout_path,
-                bin_path=self.venv_bin()
+                bin_path=self.venv_bin(),
             )
 
     def venv_bin(self, filename=None):
@@ -269,7 +269,7 @@ class Virtualenv(PythonEnvironment):
         self.build_env.run(
             *cmd,
             bin_path=self.venv_bin(),
-            cwd=self.checkout_path,
+            cwd=self.checkout_path  # noqa - no comma here in py27 :/
         )
 
     def install_user_requirements(self):
@@ -304,7 +304,7 @@ class Virtualenv(PythonEnvironment):
             self.build_env.run(
                 *args,
                 cwd=self.checkout_path,
-                bin_path=self.venv_bin()
+                bin_path=self.venv_bin()  # noqa - no comma here in py27 :/
             )
 
 
@@ -368,7 +368,7 @@ class Conda(PythonEnvironment):
         cmd.extend(requirements)
         self.build_env.run(
             *cmd,
-            cwd=self.checkout_path,
+            cwd=self.checkout_path  # noqa - no comma here in py27 :/
         )
 
         pip_cmd = [
@@ -383,7 +383,7 @@ class Conda(PythonEnvironment):
         self.build_env.run(
             *pip_cmd,
             bin_path=self.venv_bin(),
-            cwd=self.checkout_path,
+            cwd=self.checkout_path  # noqa - no comma here in py27 :/
         )
 
     def install_user_requirements(self):

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -214,6 +214,7 @@ class Virtualenv(PythonEnvironment):
             '--no-download',
             env_path,
             bin_path=None,  # Don't use virtualenv bin that doesn't exist yet
+            cwd=self.checkout_path,
         )
 
     def install_core_requirements(self):
@@ -267,7 +268,8 @@ class Virtualenv(PythonEnvironment):
         cmd.extend(requirements)
         self.build_env.run(
             *cmd,
-            bin_path=self.venv_bin()
+            bin_path=self.venv_bin(),
+            cwd=self.checkout_path,
         )
 
     def install_user_requirements(self):
@@ -334,6 +336,7 @@ class Conda(PythonEnvironment):
             '--file',
             self.config.conda.environment,
             bin_path=None,  # Don't use conda bin that doesn't exist yet
+            cwd=self.checkout_path,
         )
 
     def install_core_requirements(self):
@@ -364,7 +367,8 @@ class Conda(PythonEnvironment):
         ]
         cmd.extend(requirements)
         self.build_env.run(
-            *cmd
+            *cmd,
+            cwd=self.checkout_path,
         )
 
         pip_cmd = [
@@ -378,7 +382,8 @@ class Conda(PythonEnvironment):
         pip_cmd.extend(pip_requirements)
         self.build_env.run(
             *pip_cmd,
-            bin_path=self.venv_bin()
+            bin_path=self.venv_bin(),
+            cwd=self.checkout_path,
         )
 
     def install_user_requirements(self):

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1335,8 +1335,8 @@ class TestPythonEnvironment(TestCase):
         args_conda.extend(conda_requirements)
 
         self.build_env_mock.run.assert_has_calls([
-            mock.call(*args_conda),
-            mock.call(*args_pip, bin_path=mock.ANY)
+            mock.call(*args_conda, cwd=mock.ANY),
+            mock.call(*args_pip, bin_path=mock.ANY, cwd=mock.ANY)
         ])
 
     @patch('readthedocs.projects.models.Project.checkout_path')
@@ -1374,8 +1374,8 @@ class TestPythonEnvironment(TestCase):
         args_conda.extend(conda_requirements)
 
         self.build_env_mock.run.assert_has_calls([
-            mock.call(*args_conda),
-            mock.call(*args_pip, bin_path=mock.ANY)
+            mock.call(*args_conda, cwd=mock.ANY),
+            mock.call(*args_pip, bin_path=mock.ANY, cwd=mock.ANY)
         ])
 
     @patch('readthedocs.projects.models.Project.checkout_path')


### PR DESCRIPTION
We were assuming this path before, which defaulted to the path you
executed django from on the host machine. The cwd was used in commands
run on inside Docker however. On Linux dev environments, this path is
most likely missing.

By specifying paths, we will get paths that have been created inside the
container.