### PR TITLE
Make ads more obvious that they are ads

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -46,30 +46,66 @@ framework html structure.
 
 */
 
-div.ethical-sidebar, div.ethical-footer {
+div.ethical-sidebar,
+div.ethical-footer {
     display: block !important;
 }
-.ethical-sidebar, .ethical-footer {
-    padding: .5em;
+.ethical-sidebar,
+.ethical-footer {
+    padding: 1em;
     margin: 1em 0;
 }
-.ethical-sidebar img, .ethical-footer img {
+.ethical-sidebar img,
+.ethical-footer img {
     width: 120px;
     height: 90px;
     display: inline-block;
 }
-.ethical-sidebar .ethical-callout, .ethical-footer .ethical-callout {
+.ethical-sidebar .ethical-callout,
+.ethical-footer .ethical-callout {
     padding-top: 1em;
     clear: both;
 }
-.ethical-sidebar .ethical-pixel, .ethical-footer .ethical-pixel, .ethical-fixedfooter .ethical-pixel {
+.ethical-sidebar .ethical-pixel,
+.ethical-footer .ethical-pixel,
+.ethical-fixedfooter .ethical-pixel {
     display: none !important;
 }
-.ethical-sidebar .ethical-text, .ethical-footer .ethical-text {
+.ethical-sidebar .ethical-text,
+.ethical-footer .ethical-text {
     margin-top: 1em;
 }
-.ethical-sidebar .ethical-image-link, .ethical-footer .ethical-image-link {
+.ethical-sidebar .ethical-image-link,
+.ethical-footer .ethical-image-link {
     border: 0;
+}
+
+.ethical-sidebar,
+.ethical-footer {
+    background-color: #eee;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    color: #0a0a0a;
+    font-size: 14px;
+    line-height: 20px;
+}
+
+.ethical-sidebar a,
+.ethical-sidebar a:visited,
+.ethical-sidebar a:hover,
+.ethical-sidebar a:active,
+.ethical-footer a,
+.ethical-footer a:visited,
+.ethical-footer a:hover,
+.ethical-footer a:active {
+    color: #0a0a0a;
+    text-decoration: underline !important;
+    border-bottom: 0 !important;
+}
+
+.ethical-callout a {
+    color: #707070 !important;
+    text-decoration: none !important;
 }
 
 /* Sidebar promotions */
@@ -80,14 +116,19 @@ div.ethical-sidebar, div.ethical-footer {
 /* Footer promotions */
 .ethical-footer {
     text-align: left;
-    font-size: 90%;
+
+    font-size: 12px;
+    line-height: 18px;
 }
 .ethical-footer img {
     float: right;
     margin-left: 25px;
 }
 .ethical-footer .ethical-callout {
-    text-align: right;
+    text-align: center;
+}
+.ethical-footer small {
+    font-size: 10px;
 }
 
 /* Fixed footer promotions */
@@ -127,22 +168,17 @@ div.ethical-sidebar, div.ethical-footer {
 }
 
 /* RTD Theme specific customizations */
+.wy-nav-side .ethical-rtd {
+    /* RTD theme doesn't correctly set the sidebar width */
+    width: 300px;
+    padding: 1em;
+}
 .ethical-rtd .ethical-sidebar {
     /* RTD theme doesn't set sidebar text color */
     color: #b3b3b3;
 
-    /* RTD theme doesn't correctly set the sidebar width */
-    width: 300px;
-
     font-size: 14px;
     line-height: 20px;
-}
-.ethical-rtd .ethical-sidebar a,
-.ethical-rtd .ethical-sidebar a:visited,
-.ethical-rtd .ethical-sidebar a:hover,
-.ethical-rtd .ethical-sidebar a:active {
-    /* RTD theme doesn't set sidebar link color */
-    color: #efefef;
 }
 
 /* Alabaster specific customizations */
@@ -161,6 +197,22 @@ div.ethical-sidebar, div.ethical-footer {
     display: table;
     margin-top: 3em;
 }
+
+/* Dark theme */
+.ethical-dark-theme .ethical-sidebar {
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 1px solid #a0a0a0;
+    color: #c2c2c2 !important;
+}
+.ethical-dark-theme a,
+.ethical-dark-theme a:visited {
+    color: #e6e6e6 !important;
+    border-bottom: 0 !important;
+}
+.ethical-dark-theme .ethical-callout a {
+    color: #b3b3b3 !important;
+}
+
 
 /* Ad block nag */
 .keep-us-sustainable {

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -20,10 +20,10 @@ function create_sidebar_placement() {
 
     if (rtd.is_mkdocs_builder() && rtd.is_rtd_like_theme()) {
         selector = 'nav.wy-nav-side';
-        class_name = 'ethical-rtd';
+        class_name = 'ethical-rtd ethical-dark-theme';
     } else if (rtd.is_rtd_like_theme()) {
         selector = 'nav.wy-nav-side > div.wy-side-scroll';
-        class_name = 'ethical-rtd';
+        class_name = 'ethical-rtd ethical-dark-theme';
     } else if (rtd.is_alabaster_like_theme()) {
         selector = 'div.sphinxsidebar > div.sphinxsidebarwrapper';
         class_name = 'ethical-alabaster';


### PR DESCRIPTION
* A few visual tweaks
  * Adds a box with a background color around the ad so as to separate it from other content.
  * Links are always underlined.
  * Text in footer ads is a bit smaller
  * Slightly increases the padding around the ad container
  * The "sponsored" and "ads served ethically" text is blended a bit with the background so it emphasizes the actual ad. It is also always centered even on footer ads (previously it was right aligned).
* Adds a dark theme for ads that looks good on the RTD theme but could be used elsewhere if needed.

Note: this doesn't change any of the CSS classes for of our ads. Ad blockers will continue to work as normal. This means we shouldn't need to contact our partners at Eyeo/AdblockPlus with respect to "acceptable ads".

## Screenshots

### Sidebar on RTD
<img width="465" alt="screen shot 2018-09-10 at 12 25 38 pm" src="https://user-images.githubusercontent.com/185043/45320002-41946980-b4f6-11e8-8464-8ef628d4d1cb.png">

### Footer on RTD
<img width="1099" alt="screen shot 2018-09-10 at 12 25 23 pm" src="https://user-images.githubusercontent.com/185043/45319977-30e3f380-b4f6-11e8-8c10-c086a47bf951.png">

### Sidebar on Alabaster
<img width="412" alt="screen shot 2018-09-10 at 12 24 49 pm" src="https://user-images.githubusercontent.com/185043/45319962-29bce580-b4f6-11e8-949a-a3313718c84a.png">

### Footer on Alabaster
<img width="990" alt="screen shot 2018-09-10 at 12 24 36 pm" src="https://user-images.githubusercontent.com/185043/45319945-20cc1400-b4f6-11e8-8584-e61c9dbd575e.png">

