### PR TITLE
Pin sphinx to a compatible version

### DIFF
--- a/requirements/docs-lint.txt
+++ b/requirements/docs-lint.txt
@@ -1,2 +1,4 @@
-Sphinx
+# Sphinx 1.8 is incompatible with
+# the latest version of rstcheck
+Sphinx<1.8
 rstcheck

--- a/requirements/docs-lint.txt
+++ b/requirements/docs-lint.txt
@@ -1,4 +1,4 @@
 # Sphinx 1.8 is incompatible with
 # the latest version of rstcheck
 Sphinx<1.8
-rstcheck
+rstcheck==3.3


### PR DESCRIPTION
Sphinx 1.8 was released today, somehow is incompatible with rstcheck see https://travis-ci.org/rtfd/readthedocs.org/builds/427828516?utm_source=github_status&utm_medium=notification