### PR TITLE
Create an explicit ad placement

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -174,7 +174,7 @@ div.ethical-footer {
 .wy-nav-side .ethical-rtd {
     /* RTD theme doesn't correctly set the sidebar width */
     width: 300px;
-    padding: 1em;
+    padding: 0 1em;
 }
 .ethical-rtd .ethical-sidebar {
     /* RTD theme doesn't set sidebar text color */

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -7,6 +7,35 @@ var bowser = require('bowser');
 
 var rtd;
 
+var EXPLICIT_PLACEMENT_SELECTOR = '#ethical-ad-placement';
+
+
+/*
+ * Create an explicit placement if the
+ */
+function create_explicit_placement() {
+    var element_id = 'rtd-' + (Math.random() + 1).toString(36).substring(4);
+    var display_type = constants.PROMO_TYPES.LEFTNAV;
+    var class_name;         // Used for theme specific CSS customizations
+
+    if(rtd.is_rtd_like_theme()) {
+        class_name = 'ethical-rtd ethical-dark-theme';
+    } else {
+        class_name = 'ethical-alabaster';
+    }
+
+    if ($(EXPLICIT_PLACEMENT_SELECTOR).length > 0) {
+        $('<div />').attr('id', element_id)
+            .addClass(class_name).appendTo(EXPLICIT_PLACEMENT_SELECTOR);
+
+        return {
+            'div_id': element_id,
+            'display_type': display_type,
+        };
+    }
+    return null;
+}
+
 /*
  *  Creates a sidebar div where an ad could go
  */
@@ -230,16 +259,26 @@ function init() {
 
     rtd = rtddata.get();
 
-    if (!rtd.show_promo()) {
-        return;
-    }
+    // Check if these docs have specified an explicit ad placement for us
+    placement = create_explicit_placement();
 
-    for (var i = 0; i < placement_funcs.length; i += 1) {
-        placement = placement_funcs[i]();
-        if (placement) {
-            div_ids.push(placement.div_id);
-            display_types.push(placement.display_type);
-            priorities.push(placement.priority || constants.DEFAULT_PROMO_PRIORITY);
+    if (placement) {
+        div_ids.push(placement.div_id);
+        display_types.push(placement.display_type);
+        priorities.push(placement.priority || constants.DEFAULT_PROMO_PRIORITY);
+    } else {
+        // Standard placements
+        if (!rtd.show_promo()) {
+            return;
+        }
+
+        for (var i = 0; i < placement_funcs.length; i += 1) {
+            placement = placement_funcs[i]();
+            if (placement) {
+                div_ids.push(placement.div_id);
+                display_types.push(placement.display_type);
+                priorities.push(placement.priority || constants.DEFAULT_PROMO_PRIORITY);
+            }
         }
     }
 

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -11,7 +11,7 @@ var EXPLICIT_PLACEMENT_SELECTOR = '#ethical-ad-placement';
 
 
 /*
- * Create an explicit placement if the
+ * Create an explicit placement if the project has specified one
  */
 function create_explicit_placement() {
     var element_id = 'rtd-' + (Math.random() + 1).toString(36).substring(4);


### PR DESCRIPTION
This adds the options for projects to opt-in to have an ad placement in a specific spot on their docs by adding a `<div id="ethical-ad-placement"></div>` in a specific place.

- For projects where we have a revenue share in place -- something I'm trying to grow -- this allows them to put the ads in a better spot and make more money.
- This puts projects in control of where ads go.

## Future things not in this PR

- Allow specifying different ad types (eg. text-only, footer ads, etc.). I envision doing this by adding `data-ad-type` attributes on the `<div>`. Currently this only does left-navigation ads.

## Screenshot

<img width="649" alt="screen shot 2018-09-18 at 4 54 03 pm" src="https://user-images.githubusercontent.com/185043/45723199-041e8480-bb65-11e8-83cb-352ceb651c63.png">
