### PR TITLE
Increase footer ad text size

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -120,8 +120,8 @@ div.ethical-footer {
 .ethical-footer {
     text-align: left;
 
-    font-size: 12px;
-    line-height: 18px;
+    font-size: 14px;
+    line-height: 20px;
 }
 .ethical-footer img {
     float: right;


### PR DESCRIPTION
#4628 shrank the size marginally of footer ads and now I think they are too small. I think the text can safely be the same size as the sidebar ads and most of the rest of the document (14px).

## Screenshots

### Previously 
<img width="792" alt="screen shot 2018-09-28 at 4 13 02 pm" src="https://user-images.githubusercontent.com/185043/46237468-6cc1ea00-c339-11e8-8c1e-1abd66a5717f.png">

### New
<img width="770" alt="screen shot 2018-09-28 at 4 13 59 pm" src="https://user-images.githubusercontent.com/185043/46237481-882cf500-c339-11e8-82fb-35f3ae59ee5c.png">
