### PR TITLE
Fix the queryset used in chunking

### DIFF
--- a/readthedocs/search/parse_json.py
+++ b/readthedocs/search/parse_json.py
@@ -94,9 +94,9 @@ def process_file(filename):
     try:
         with codecs.open(filename, encoding='utf-8', mode='r') as f:
             file_contents = f.read()
-    except IOError as e:
-        log.info('Unable to index file: %s', filename, exc_info=True)
-        return
+    except IOError:
+        log.info('Unable to read file: %s', filename)
+        return None
     data = json.loads(file_contents)
     sections = []
     title = ''

--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -77,7 +77,10 @@ def index_objects_to_es(app_label, model_name, document_class, index_name,
     document = _get_document(model=model, document_class=document_class)
     doc_obj = document()
 
-    # Use queryset from model as the ids are specific
+    # WARNING: This must use the exact same queryset as from where we get the ID's
+    # There is a chance there is a race condition here as the ID's may change as the task runs,
+    # so we need to think through this a bit more and probably pass explicit ID's,
+    # but there are performance issues with that on large model sets
     queryset = doc_obj.get_queryset()
     if chunk:
         # Chunk is a tuple with start and end index of queryset

--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -75,9 +75,10 @@ def index_objects_to_es(app_label, model_name, document_class, index_name,
 
     model = apps.get_model(app_label, model_name)
     document = _get_document(model=model, document_class=document_class)
+    doc_obj = document()
 
     # Use queryset from model as the ids are specific
-    queryset = model.objects.all()
+    queryset = doc_obj.get_queryset()
     if chunk:
         # Chunk is a tuple with start and end index of queryset
         start = chunk[0]
@@ -87,7 +88,7 @@ def index_objects_to_es(app_label, model_name, document_class, index_name,
         queryset = queryset.filter(id__in=objects_id)
 
     log.info("Indexing model: {}, '{}' objects".format(model.__name__, queryset.count()))
-    document().update(queryset.iterator(), index_name=index_name)
+    doc_obj.update(queryset.iterator(), index_name=index_name)
 
 
 @app.task(queue='web')


### PR DESCRIPTION
This makes sure we’re using ID’s from the same queryset,
otherwise we end up indexing the wrong objects.