### PR TITLE
Tuning elasticsearch shard and replica

### DIFF
--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -21,6 +21,7 @@ class ProjectDocument(RTDDocTypeMixin, DocType):
     class Meta(object):
         model = Project
         fields = ('name', 'slug', 'description')
+        auto_refresh = False
 
     url = fields.TextField(attr='get_absolute_url')
     users = fields.NestedField(properties={
@@ -52,6 +53,7 @@ class PageDocument(RTDDocTypeMixin, DocType):
         model = HTMLFile
         fields = ('commit',)
         ignore_signals = settings.ES_PAGE_IGNORE_SIGNALS
+        auto_refresh = False
 
     project = fields.KeywordField(attr='project.slug')
     version = fields.KeywordField(attr='version.slug')

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -349,14 +349,14 @@ class CommunityBaseSettings(Settings):
         'project': {
             'name': 'project_index',
             'settings': {'number_of_shards': 5,
-                         'number_of_replicas': 0
+                         'number_of_replicas': 1
                          }
         },
         'page': {
             'name': 'page_index',
             'settings': {
-                'number_of_shards': 5,
-                'number_of_replicas': 0,
+                'number_of_shards': 10,
+                'number_of_replicas': 1,
             }
         },
     }

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -355,7 +355,7 @@ class CommunityBaseSettings(Settings):
         'page': {
             'name': 'page_index',
             'settings': {
-                'number_of_shards': 10,
+                'number_of_shards': 5,
                 'number_of_replicas': 1,
             }
         },


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/_basic_concepts.html#getting-started-shards-and-replicas

https://www.elastic.co/guide/en/elasticsearch/guide/current/replica-shards.html#img-three-nodes

We need to change the `replica` dynamically
you can run following command in django shell to change the replica
```python
from readthedocs.search.documents import page_conf, page_index
page_index.put_settings(page_conf['settings'])
```