### PR TITLE
Change the way of using login_required decorator.

### DIFF
--- a/readthedocs/profiles/views.py
+++ b/readthedocs/profiles/views.py
@@ -18,6 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 from readthedocs.core.forms import UserDeleteForm, UserAdvertisingForm
 
 
+@login_required
 def create_profile(
         request, form_class, success_url=None,
         template_name='profiles/private/create_profile.html',
@@ -109,9 +110,7 @@ def create_profile(
     return render(request, template_name, context=context)
 
 
-create_profile = login_required(create_profile)
-
-
+@login_required
 def edit_profile(
         request, form_class, success_url=None,
         template_name='profiles/private/edit_profile.html', extra_context=None):
@@ -190,9 +189,6 @@ def edit_profile(
         'user': profile_obj.user,
     })
     return render(request, template_name, context=context)
-
-
-edit_profile = login_required(edit_profile)
 
 
 @login_required()


### PR DESCRIPTION
Fixes #4692 

Some functions were using the login_required decorator like this, which is quite old.
```python3
def function():
    code 

function = login_required(function)
```

Now, this way of using it improves the readability of the code.
```python3
@decorator
def function():
    code
```