### PR TITLE
Define the doc_search reverse URL from inside the __init__ on test

### DIFF
--- a/readthedocs/search/tests/test_api.py
+++ b/readthedocs/search/tests/test_api.py
@@ -11,7 +11,12 @@ from readthedocs.search.tests.utils import get_search_query_from_project_file
 @pytest.mark.django_db
 @pytest.mark.search
 class TestDocumentSearch(object):
-    url = reverse('doc_search')
+
+    def __init__(self):
+        # This reverse needs to be inside the ``__init__`` method because from
+        # the Corporate site we don't define this URL if ``-ext`` module is not
+        # installed
+        self.url = reverse('doc_search')
 
     @pytest.mark.parametrize('data_type', ['content', 'headers', 'title'])
     @pytest.mark.parametrize('page_num', [0, 1])

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,5 +1,6 @@
 -r pip.txt
-astroid==2.0.4
+astroid==2.0.4; python_version > '3'
+astroid==1.6.4; python_version < '3'
 pylint==2.1.1
 pylint-django==2.0.2
 pylint-celery==0.3


### PR DESCRIPTION
Since we import this file from Corporate site without defining this URL name, this blow up. By defining it inside the __init__ method we workaround this.