### PR TITLE
Lint requirement file for py2

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,8 +1,15 @@
 -r pip.txt
+# We need these special cases of Python < 3 for Read the Docs
+# corporate site.
 astroid==2.0.4; python_version > '3'
 astroid==1.6.4; python_version < '3'
-pylint==2.1.1
-pylint-django==2.0.2
+
+pylint==2.1.1; python_version > '3'
+pylint<2; python_version < '3'
+
+pylint-django==2.0.2; python_version > '3'
+pylint-django==0.11.1; python_version < '3'
+
 pylint-celery==0.3
 prospector==1.1.2
 pyflakes==2.0.0


### PR DESCRIPTION
Read the Docs corporate site still uses Python 2.

Reference: https://github.com/rtfd/readthedocs-corporate/pull/395