### PR TITLE
Remove logging verbosity on syncer failure

### DIFF
--- a/readthedocs/builds/syncers.py
+++ b/readthedocs/builds/syncers.py
@@ -58,7 +58,7 @@ class RemoteSyncer(object):
                 mkdir_cmd = ("ssh %s@%s mkdir -p %s" % (sync_user, server, target))
                 ret = os.system(mkdir_cmd)
                 if ret != 0:
-                    log.error("Copy error to app servers: cmd=%s", mkdir_cmd)
+                    log.debug("Copy error to app servers: cmd=%s", mkdir_cmd)
                 if is_file:
                     slash = ""
                 else:
@@ -74,7 +74,7 @@ class RemoteSyncer(object):
                         target=target))
                 ret = os.system(sync_cmd)
                 if ret != 0:
-                    log.error("Copy error to app servers: cmd=%s", sync_cmd)
+                    log.debug("Copy error to app servers: cmd=%s", sync_cmd)
 
 
 class DoubleRemotePuller(object):
@@ -98,7 +98,7 @@ class DoubleRemotePuller(object):
                 )
                 ret = os.system(mkdir_cmd)
                 if ret != 0:
-                    log.error("MkDir error to app servers: cmd=%s", mkdir_cmd)
+                    log.debug("MkDir error to app servers: cmd=%s", mkdir_cmd)
             # Add a slash when copying directories
             sync_cmd = (
                 "ssh {user}@{server} 'rsync -av "
@@ -111,7 +111,7 @@ class DoubleRemotePuller(object):
                     target=target))
             ret = os.system(sync_cmd)
             if ret != 0:
-                log.error("Copy error to app servers: cmd=%s", sync_cmd)
+                log.debug("Copy error to app servers: cmd=%s", sync_cmd)
 
 
 class RemotePuller(object):
@@ -138,7 +138,7 @@ class RemotePuller(object):
         )
         ret = os.system(sync_cmd)
         if ret != 0:
-            log.error(
+            log.debug(
                 "Copy error to app servers. Command: [%s] Return: [%s]",
                 sync_cmd,
                 ret,


### PR DESCRIPTION
We get a ton of these,
but never look at them.
I don't really know if we can fix this,
but lets stop spamming Sentry