### PR TITLE
Fixes an OSX issue with the test suite

### DIFF
--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -51,7 +51,7 @@ def get_filesystem(path, top_level_path=None):
     return fs
 
 
-TEMP_SITE_ROOT = tempfile.mkdtemp(suffix='siteroot')
+TEMP_SITE_ROOT = os.path.realpath(tempfile.mkdtemp(suffix='siteroot'))
 TEMP_DOCROOT = os.path.join(TEMP_SITE_ROOT, 'user_builds')
 
 


### PR DESCRIPTION
There was a [change](https://github.com/rtfd/readthedocs.org/commit/ef6a05916c440916fba9755388b36ba95e98b0e4#diff-31a1317fe6aaf4de559c18d25fd89323L68) which causes the symlink test suite to fail on OSX.

The problem is caused by:
* `tempfile.mkdtemp` returns a path under `/var/folders`
* By default on OSX `/var` is a symlink to `/private/var`
* As a result, `os.path.realpath(TEMP_SITE_ROOT) != TEMP_SITE_ROOT` and the expected paths don't match [here](https://github.com/rtfd/readthedocs.org/blob/9d6aabb760d870288494d3ef665323a11912dbe4/readthedocs/rtd_tests/tests/test_project_symlinks.py#L42)

I'm running OSX 10.13.16.