### PR TITLE
Do not re-raise the exception if the one that we are checking

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -222,9 +222,8 @@ def safe_makedirs(directory_name):
     try:
         os.makedirs(directory_name)
     except OSError as e:
-        if e.errno == errno.EEXIST:
-            pass
-        raise
+        if e.errno != errno.EEXIST:  # 17, FileExistsError
+            raise
 
 
 def safe_unlink(path):


### PR DESCRIPTION
I think that this commit introduced the problem: https://github.com/rtfd/readthedocs.org/pull/2765/commits/0432ee8f0c897a9f60a7d8813275924f9e12487c (this is the PR: https://github.com/rtfd/readthedocs.org/pull/2765)

The problem is that it's always re-raising the exception, even if the problem is the one that we checking in the `if`. I think this has generated 4.2k Sentry logs: https://sentry.io/read-the-docs/readthedocs-org/issues/628363742/?query=is:unresolved