### PR TITLE
Add an index page to our design docs.

### DIFF
--- a/docs/design/index.rst
+++ b/docs/design/index.rst
@@ -1,0 +1,12 @@
+Design Documents
+================
+
+This is where we outline the design of major parts of our project.
+Generally this is only available for features that have been build in the recent past,
+but we hope to write more of them over time.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   *


### PR DESCRIPTION
This still doesn't link them from anywhere,
but at least you can browse them at `/design/`.