### PR TITLE
Do not log as error a webhook with an invalid branch name

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -310,7 +310,7 @@ def bitbucket_build(request):
             return _build_url(search_url, projects, branches)
 
         if not branches:
-            log.error(
+            log.info(
                 'Commit/branch not found url=%s branches=%s',
                 search_url,
                 branches,


### PR DESCRIPTION
Although this endpoint is deprecated, we still receive request on it and many of them are invalid and do not contains the branch name or similar. This is logging a lot under Sentry and kill our quota.