### PR TITLE
Validate the slug generated is valid before importing a project

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -118,6 +118,12 @@ class ProjectBasicsForm(ProjectForm):
             if Project.objects.filter(slug=potential_slug).exists():
                 raise forms.ValidationError(
                     _('Invalid project name, a project already exists with that name'))  # yapf: disable # noqa
+            if not potential_slug:
+                # Check the generated slug won't be empty
+                raise forms.ValidationError(
+                    _('Invalid project name'),
+                )
+
         return name
 
     def clean_remote_repository(self):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -316,7 +316,7 @@ class Project(models.Model):
         if not self.slug:
             # Subdomains can't have underscores in them.
             self.slug = slugify(self.name)
-            if self.slug == '':
+            if not self.slug:
                 raise Exception(_('Model must have slug'))
         if self.documentation_type == 'auto':
             # This used to determine the type and automatically set the

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -93,6 +93,13 @@ class TestProjectForms(TestCase):
                 form = ProjectBasicsForm(initial)
                 self.assertEqual(form.is_valid(), valid, msg=url)
 
+    def test_empty_slug(self):
+        initial = {
+            'name': "''",
+        }
+        form = ProjectBasicsForm(initial)
+        self.assertFalse(form.is_valid())
+
 
 class TestTranslationForms(TestCase):
 

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -96,9 +96,12 @@ class TestProjectForms(TestCase):
     def test_empty_slug(self):
         initial = {
             'name': "''",
+            'repo_type': 'git',
+            'repo': 'https://github.com/user/repository',
         }
         form = ProjectBasicsForm(initial)
         self.assertFalse(form.is_valid())
+        self.assertIn('name', form.errors)
 
 
 class TestTranslationForms(TestCase):


### PR DESCRIPTION
Very small PR that to avoid importing invalid project names.