### PR TITLE
Pin missing dependency for the MkDocs guide compatibility

### DIFF
--- a/docs/guides/mkdocs-old-versions.rst
+++ b/docs/guides/mkdocs-old-versions.rst
@@ -25,6 +25,7 @@ To make your project continue using this version you will need to create a ``req
      mkdocs==0.15.0
      mkdocs-bootstrap==0.1.1
      mkdocs-bootswatch==0.1.0
+     markdown>=2.3.1,<2.5
 
 .. note::
 


### PR DESCRIPTION
Today I realize that it's better to PIN this "just in case" that leave it there.

If we pin the `markdown` we can still use the old way to define extensions. Yay!