### PR TITLE
Handle 401, 403 and 404 status codes when hitting GitHub for webhook

### DIFF
--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -207,6 +207,13 @@ class GitHubService(Service):
                 log.info('GitHub webhook creation successful for project: %s',
                          project)
                 return (True, resp)
+            elif resp.status_code in [401, 403, 404]:
+                log.info(
+                    'GitHub project does not exist or user does not have '
+                    'permissions: project=%s',
+                    project,
+                )
+                return (False, resp)
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             log.exception(

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -207,7 +207,8 @@ class GitHubService(Service):
                 log.info('GitHub webhook creation successful for project: %s',
                          project)
                 return (True, resp)
-            elif resp.status_code in [401, 403, 404]:
+
+            if resp.status_code in [401, 403, 404]:
                 log.info(
                     'GitHub project does not exist or user does not have '
                     'permissions: project=%s',


### PR DESCRIPTION
This is a work in progress PR.

All of our integrations are not handling these error codes: 401, 403 and 404. All of them are being logged as errors in our application. This PR handle them to log as info instead of an error (via the else: clause).

Also, this code may need to be repeated across all the integrations and twice on each. So, maybe it's possible to refactor this all together: https://github.com/rtfd/readthedocs-corporate/issues/372