### PR TITLE
Don't activate version on build

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -605,7 +605,6 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             if html:
                 version = api_v2.version(self.version.pk)
                 version.patch({
-                    'active': True,
                     'built': True,
                 })
         except HttpClientError:


### PR DESCRIPTION
Close #4793

I was trying to write a test for this, but is so complicated or I don't know how
to do it, as it requires to hit the api from the `SLUMBER` setting.

I was trying using live server, but it didn't work as expected... If codecov fails,
at least I could test that we are calling to the path with `built=True`