### PR TITLE
Do not import the Celery worker when running the Django app

### DIFF
--- a/readthedocs/__init__.py
+++ b/readthedocs/__init__.py
@@ -5,9 +5,6 @@ import os.path
 
 from future.moves.configparser import RawConfigParser
 
-# Import the Celery application before anything else happens
-from readthedocs.worker import app  # noqa
-
 
 def get_version(setupcfg_path):
     """Return package version from setup.cfg."""


### PR DESCRIPTION
Do not import all the Celery app (which import the Django settings) when it's not needed.

Required by https://github.com/rtfd/readthedocs-ops/pull/431