### PR TITLE
Do not send notification on VersionLockedError

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -419,10 +419,11 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 msg=msg,
             ))
 
-            # Send notification to users only if the build didn't fail because of
-            # LockTimeout: this exception occurs when a build is triggered before the previous
-            # one has finished (e.g. two webhooks, one after the other)
-            if not isinstance(self.setup_env.failure, vcs_support_utils.LockTimeout):
+            # Send notification to users only if the build didn't fail because
+            # of VerisionLockedTimeout: this exception occurs when a build is
+            # triggered before the previous one has finished (e.g. two webhooks,
+            # one after the other)
+            if not isinstance(self.setup_env.failure, VersionLockedError):
                 self.send_notifications()
 
             return False


### PR DESCRIPTION
Instead of LockTimeout exception we are raising VersionLockedError instead. This change introduced a bug that notification started being sent again when a Version was locked and this was really annoying.