### PR TITLE
Allow to change project's VCS

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -323,11 +323,11 @@ class Project(models.Model):
         for owner in self.users.all():
             assign('view_project', owner, self)
         try:
-            if self.default_branch:
-                latest = self.versions.get(slug=LATEST)
-                if latest.identifier != self.default_branch:
-                    latest.identifier = self.default_branch
-                    latest.save()
+            latest = self.versions.get(slug=LATEST)
+            default_branch = self.get_default_branch()
+            if latest.identifier != default_branch:
+                latest.identifier = default_branch
+                latest.save()
         except Exception:
             log.exception('Failed to update latest identifier')
 

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -16,7 +16,13 @@ from textclassifier.validators import ClassifierValidator
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version
-from readthedocs.projects.constants import PRIVATE, PROTECTED, PUBLIC
+from readthedocs.projects.constants import (
+    PRIVATE,
+    PROTECTED,
+    PUBLIC,
+    REPO_TYPE_GIT,
+    REPO_TYPE_HG,
+)
 from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.forms import (
     ProjectAdvancedForm,
@@ -29,6 +35,7 @@ from readthedocs.projects.models import Project
 
 
 class TestProjectForms(TestCase):
+
     @mock.patch.object(ClassifierValidator, '__call__')
     def test_form_spam(self, mocked_validator):
         """Form description field fails spam validation."""
@@ -83,7 +90,7 @@ class TestProjectForms(TestCase):
             ('ssh+git://github.com/humitos/foo', True),
             ('strangeuser@bitbucket.org:strangeuser/readthedocs.git', True),
             ('user@one-ssh.domain.com:22/_ssh/docs', True),
-         ] + common_urls
+        ] + common_urls
 
         with override_settings(ALLOW_PRIVATE_REPOS=False):
             for url, valid in public_urls:
@@ -114,6 +121,47 @@ class TestProjectForms(TestCase):
         form = ProjectBasicsForm(initial)
         self.assertFalse(form.is_valid())
         self.assertIn('name', form.errors)
+
+    def test_changing_vcs_should_change_latest(self):
+        """When changing the project's VCS, latest should be changed too."""
+        project = get(Project, repo_type=REPO_TYPE_HG, default_branch=None)
+        latest = project.versions.get(slug=LATEST)
+        self.assertEqual(latest.identifier, 'default')
+
+        form = ProjectBasicsForm(
+            {
+                'repo': 'http://github.com/test/test',
+                'name': 'name',
+                'repo_type': REPO_TYPE_GIT,
+            },
+            instance=project,
+        )
+        self.assertTrue(form.is_valid())
+        form.save()
+        latest.refresh_from_db()
+        self.assertEqual(latest.identifier, 'master')
+
+    def test_changing_vcs_should_not_change_latest_is_not_none(self):
+        """
+        When changing the project's VCS,
+        we should respect the custom default branch.
+        """
+        project = get(Project, repo_type=REPO_TYPE_HG, default_branch='custom')
+        latest = project.versions.get(slug=LATEST)
+        self.assertEqual(latest.identifier, 'custom')
+
+        form = ProjectBasicsForm(
+            {
+                'repo': 'http://github.com/test/test',
+                'name': 'name',
+                'repo_type': REPO_TYPE_GIT,
+            },
+            instance=project,
+        )
+        self.assertTrue(form.is_valid())
+        form.save()
+        latest.refresh_from_db()
+        self.assertEqual(latest.identifier, 'custom')
 
 
 class TestProjectAdvancedForm(TestCase):


### PR DESCRIPTION
Fixes #4844 
More background on #1170

So, previously this wasn't so important, users could just change the `default_branch` to whatever they want (master in this case). But, with https://github.com/rtfd/readthedocs.org/pull/4710 they can't do that anymore and the only solution is to recreate the project.

I know this isn't a common case (changing VCS), but if the user chooses by mistake the wrong VCS when creating the project, then the user is in trouble.