### PR TITLE
Hide "edit on" when the version is a tag

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -2,36 +2,55 @@
 """Models for the builds app."""
 
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import logging
 import os.path
 import re
-from builtins import object
 from shutil import rmtree
 
+from builtins import object
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
+from django.utils.translation import ugettext_lazy as _
 from guardian.shortcuts import assign
 from taggit.managers import TaggableManager
 
 from readthedocs.core.utils import broadcast
 from readthedocs.projects.constants import (
-    BITBUCKET_URL, GITHUB_URL, GITLAB_URL, PRIVACY_CHOICES, PRIVATE)
+    BITBUCKET_URL,
+    GITHUB_URL,
+    GITLAB_URL,
+    PRIVACY_CHOICES,
+    PRIVATE,
+)
 from readthedocs.projects.models import APIProject, Project
 
 from .constants import (
-    BRANCH, BUILD_STATE, BUILD_STATE_FINISHED, BUILD_TYPES, LATEST,
-    NON_REPOSITORY_VERSIONS, STABLE, TAG, VERSION_TYPES)
+    BRANCH,
+    BUILD_STATE,
+    BUILD_STATE_FINISHED,
+    BUILD_TYPES,
+    LATEST,
+    NON_REPOSITORY_VERSIONS,
+    STABLE,
+    TAG,
+    VERSION_TYPES,
+)
 from .managers import VersionManager
 from .querysets import BuildQuerySet, RelatedBuildQuerySet, VersionQuerySet
 from .utils import (
-    get_bitbucket_username_repo, get_github_username_repo,
-    get_gitlab_username_repo)
+    get_bitbucket_username_repo,
+    get_github_username_repo,
+    get_gitlab_username_repo,
+)
 from .version_slug import VersionSlugField
 
 DEFAULT_VERSION_PRIVACY_LEVEL = getattr(

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -193,6 +193,10 @@ class Version(models.Model):
             return self.identifier[:8]
         return self.identifier
 
+    @property
+    def is_editable(self):
+        return self.type == BRANCH
+
     def get_subdomain_url(self):
         private = self.privacy_level == PRIVATE
         return self.project.get_docs_url(

--- a/readthedocs/restapi/templates/restapi/footer.html
+++ b/readthedocs/restapi/templates/restapi/footer.html
@@ -82,9 +82,11 @@
         <dd>
           <a href="{{ github_view_url }}">View</a>
         </dd>
+        {% if version.is_editable %}
         <dd>
           <a href="{{ github_edit_url }}">Edit</a>
         </dd>
+        {% endif %}
       </dl>
       {% elif bitbucket_url %}
       <dl>
@@ -99,9 +101,11 @@
         <dd>
           <a href="{{ gitlab_view_url }}">View</a>
         </dd>
+        {% if version.is_editable %}
         <dd>
           <a href="{{ gitlab_edit_url }}">Edit</a>
         </dd>
+        {% endif %}
       </dl>
       {% endif %}
       {% endblock %}

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -3,6 +3,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import mock
+from django_dynamic_fixture import get
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory, APITestCase
 
@@ -17,7 +18,7 @@ from readthedocs.rtd_tests.mocks.paths import fake_paths_by_regex
 
 class Testmaker(APITestCase):
     fixtures = ['test_data']
-    url = '/api/v2/footer_html/?project=pip&version=latest&page=index'
+    url = '/api/v2/footer_html/?project=pip&version=latest&page=index&docroot=/'
     factory = APIRequestFactory()
 
     @classmethod
@@ -98,6 +99,24 @@ class Testmaker(APITestCase):
         self.pip.save()
         response = self.render()
         self.assertTrue(response.data['show_version_warning'])
+
+    def test_show_edit_on_github(self):
+        version = self.pip.versions.get(slug=LATEST)
+        version.type = BRANCH
+        version.save()
+        response = self.render()
+        self.assertIn('On GitHub', response.data['html'])
+        self.assertIn('View', response.data['html'])
+        self.assertIn('Edit', response.data['html'])
+
+    def test_not_show_edit_on_github(self):
+        version = self.pip.versions.get(slug=LATEST)
+        version.type = TAG
+        version.save()
+        response = self.render()
+        self.assertIn('On GitHub', response.data['html'])
+        self.assertIn('View', response.data['html'])
+        self.assertNotIn('Edit', response.data['html'])
 
 
 class TestVersionCompareFooter(TestCase):

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import mock
-from django_dynamic_fixture import get
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory, APITestCase
 
@@ -12,7 +15,9 @@ from readthedocs.builds.models import Version
 from readthedocs.core.middleware import FooterNoSessionMiddleware
 from readthedocs.projects.models import Project
 from readthedocs.restapi.views.footer_views import (
-    footer_html, get_version_compare_data)
+    footer_html,
+    get_version_compare_data,
+)
 from readthedocs.rtd_tests.mocks.paths import fake_paths_by_regex
 
 


### PR DESCRIPTION
When the version is a tag, user's can't edit that version, only branches can be edited.

Currently, on the rtd theme we only generate the view link (the text says edit, but it's a view link).

As mention here https://github.com/rtfd/readthedocs.org/issues/1820#issuecomment-434887315, there is some code that was never used https://github.com/rtfd/readthedocs.org/blob/0f5d979c221da7140138359fc06660ebec6fff9b/readthedocs/doc_builder/backends/sphinx.py#L127-L132

As we don't use that on the theme, I think it can be removed (or maybe make it available to the theme?). IMO, we are fine deleting that code, the theme does a good job showing only the view link (users can figure out how to edit on each platform).

Close #1820