### PR TITLE
Generic message for parser error of config file

### DIFF
--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -43,7 +43,7 @@ class ProjectBuildsSkippedError(BuildEnvironmentError):
 
 class YAMLParseError(BuildEnvironmentError):
     GENERIC_WITH_PARSE_EXCEPTION = ugettext_noop(
-        'Problem parsing YAML configuration. {exception}',
+        'Problem in your project\'s configuration. {exception}',
     )
 
 


### PR DESCRIPTION
Now that we move the config file to the rtd code, and that we do all the validation stuff inside the config module, this message isn't correct, because a user can build their project using only the config from the web admin, but internally we use the config module for some validations.

Fix #4401