### PR TITLE
Shorten project name to match slug length

### DIFF
--- a/readthedocs/projects/migrations/0030_change-max-length-project-slug.py
+++ b/readthedocs/projects/migrations/0030_change-max-length-project-slug.py
@@ -46,6 +46,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='project',
             name='name',
-            field=models.SlugField(max_length=63, verbose_name='Name'),
+            field=models.CharField(max_length=63, verbose_name='Name'),
         ),
     ]

--- a/readthedocs/projects/migrations/0030_change-max-length-project-slug.py
+++ b/readthedocs/projects/migrations/0030_change-max-length-project-slug.py
@@ -19,6 +19,16 @@ def forwards_func(apps, schema_editor):
         project.slug = project.slug[:max_length]
         project.save()
 
+    projects_invalid_name = (
+        Project
+        .objects
+        .annotate(name_length=Length('name'))
+        .filter(name_length__gt=max_length)
+    )
+    for project in projects_invalid_name:
+        project.name = project.name[:max_length]
+        project.save()
+
 
 class Migration(migrations.Migration):
 
@@ -32,5 +42,10 @@ class Migration(migrations.Migration):
             model_name='project',
             name='slug',
             field=models.SlugField(max_length=63, unique=True, verbose_name='Slug'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='name',
+            field=models.SlugField(max_length=63, verbose_name='Name'),
         ),
     ]

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -80,7 +80,7 @@ class Project(models.Model):
     # Generally from conf.py
     users = models.ManyToManyField(User, verbose_name=_('User'),
                                    related_name='projects')
-    name = models.CharField(_('Name'), max_length=255)
+    name = models.CharField(_('Name'), max_length=63)
     # A DNS label can contain up to 63 characters.
     slug = models.SlugField(_('Slug'), max_length=63, unique=True)
     description = models.TextField(_('Description'), blank=True,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -80,8 +80,8 @@ class Project(models.Model):
     # Generally from conf.py
     users = models.ManyToManyField(User, verbose_name=_('User'),
                                    related_name='projects')
-    name = models.CharField(_('Name'), max_length=63)
     # A DNS label can contain up to 63 characters.
+    name = models.CharField(_('Name'), max_length=63)
     slug = models.SlugField(_('Slug'), max_length=63, unique=True)
     description = models.TextField(_('Description'), blank=True,
                                    help_text=_('The reStructuredText '


### PR DESCRIPTION
This updates the just-merged migration to handle name as well