### PR TITLE
Update django-guardian settings

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -331,7 +331,6 @@ class CommunityBaseSettings(Settings):
 
     # Guardian Settings
     GUARDIAN_RAISE_403 = True
-    # ANONYMOUS_USER_ID = -1
 
     # Stripe
     STRIPE_SECRET = None

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -331,7 +331,7 @@ class CommunityBaseSettings(Settings):
 
     # Guardian Settings
     GUARDIAN_RAISE_403 = True
-    ANONYMOUS_USER_ID = -1
+    # ANONYMOUS_USER_ID = -1
 
     # Stripe
     STRIPE_SECRET = None


### PR DESCRIPTION
RTD is using django-guardian (version: 1.4.9).

`ANONYMOUS_USER_ID` is deprecated ([changelog](https://django-guardian.readthedocs.io/en/stable/develop/changes.html#release-1-4-2-mar-09-2016)) in `1.4.2`

According to the new configurable variables, we should use `ANONYMOUS_USER_NAME`, whose default value is already set to `"AnonymousUser"` (Read [here](https://django-guardian.readthedocs.io/en/stable/configuration.html#anonymous-user-name)). So, I think that there is no need to set it again in our `settings/base.py`