### PR TITLE
Allow all /api/v2/ CORS if the Domain is known

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -49,6 +49,12 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
     if request.path_info.startswith('/api/v2/sustainability'):
         return True
 
+    # Don't do domain checking for APIv2 when the Domain is known
+    if request.path_info.startswith('/api/v2/'):
+        domain = Domain.objects.filter(domain__icontains=host)
+        if domain.exists():
+            return True
+
     valid_url = False
     for url in WHITELIST_URLS:
         if request.path_info.startswith(url):
@@ -69,7 +75,7 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
 
         domain = Domain.objects.filter(
             Q(domain__icontains=host),
-            Q(project=project) | Q(project__subprojects__child=project)
+            Q(project=project) | Q(project__subprojects__child=project),
         )
         if domain.exists():
             return True

--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -13,6 +13,7 @@ from django.dispatch import Signal
 from django.db.models import Q, Count
 from django.dispatch import receiver
 from future.backports.urllib.parse import urlparse
+from rest_framework.permissions import SAFE_METHODS
 
 from readthedocs.oauth.models import RemoteOrganization
 from readthedocs.projects.models import Project, Domain
@@ -50,7 +51,7 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
         return True
 
     # Don't do domain checking for APIv2 when the Domain is known
-    if request.path_info.startswith('/api/v2/'):
+    if request.path_info.startswith('/api/v2/') and request.method in SAFE_METHODS:
         domain = Domain.objects.filter(domain__icontains=host)
         if domain.exists():
             return True

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -217,3 +217,12 @@ class TestCORSMiddleware(TestCase):
         )
         resp = self.middleware.process_response(request, {})
         self.assertNotIn('Access-Control-Allow-Origin', resp)
+
+        # POST is not allowed
+        request = self.factory.post(
+            '/api/v2/version/',
+            {'project__slug': self.project.slug, 'active': True},
+            HTTP_ORIGIN='http://my.valid.domain',
+        )
+        resp = self.middleware.process_response(request, {})
+        self.assertNotIn('Access-Control-Allow-Origin', resp)


### PR DESCRIPTION
Currently, if any documentation project tries to use our APIv2 from a custom domain by doing an AJAX request, it will be blocked because of CORS.

This PR adds a new checking for this by allowing CORS on all the URLs that start with `/api/v2/` and the HTTP_ORIGIN header is a known Domain in our platform.

Raised at https://github.com/humitos/sphinx-version-warning/issues/23