### PR TITLE
Disable django guardian warning

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -365,7 +365,7 @@ class CommunityBaseSettings(Settings):
         'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',  # NOQA
         'PAGE_SIZE': 10,
     }
-    SILENCED_SYSTEM_CHECKS = ['fields.W342']
+    SILENCED_SYSTEM_CHECKS = ['fields.W342', 'guardian.W001']
 
     # Logging
     LOG_FORMAT = '%(name)s:%(lineno)s[%(process)d]: %(levelname)s %(message)s'

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -48,8 +48,6 @@ class CommunityDevSettings(CommunityBaseSettings):
         'test:8000',
     )
 
-    SILENCED_SYSTEM_CHECKS = ['fields.W342', 'guardian.W001']
-
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super(CommunityDevSettings, self).LOGGING

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -48,6 +48,8 @@ class CommunityDevSettings(CommunityBaseSettings):
         'test:8000',
     )
 
+    SILENCED_SYSTEM_CHECKS = ['fields.W342', 'guardian.W001']
+
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super(CommunityDevSettings, self).LOGGING


### PR DESCRIPTION
This is of very low priority.
But this warning pops up everytime in the build

![screenshot from 2018-11-11 23-54-19](https://user-images.githubusercontent.com/29149191/48316776-e540e980-e60d-11e8-82c5-f972678b3093.png)

Fixes #4861 