### PR TITLE
Remove localmendia and search parameters

### DIFF
--- a/readthedocs/rtd_tests/mocks/environment.py
+++ b/readthedocs/rtd_tests/mocks/environment.py
@@ -34,6 +34,10 @@ class EnvironmentMockGroup(object):
                 'readthedocs.doc_builder.backends.sphinx.HtmlBuilder.build'),
             'html_move': mock.patch(
                 'readthedocs.doc_builder.backends.sphinx.HtmlBuilder.move'),
+            'localmedia_build': mock.patch(
+                'readthedocs.doc_builder.backends.sphinx.LocalMediaBuilder.build'),
+            'localmedia_move': mock.patch(
+                'readthedocs.doc_builder.backends.sphinx.LocalMediaBuilder.move'),
             'pdf_build': mock.patch(
                 'readthedocs.doc_builder.backends.sphinx.PdfBuilder.build'),
             'pdf_move': mock.patch(

--- a/readthedocs/rtd_tests/mocks/environment.py
+++ b/readthedocs/rtd_tests/mocks/environment.py
@@ -46,6 +46,12 @@ class EnvironmentMockGroup(object):
                 'readthedocs.doc_builder.backends.sphinx.EpubBuilder.build'),
             'epub_move': mock.patch(
                 'readthedocs.doc_builder.backends.sphinx.EpubBuilder.move'),
+            'move_mkdocs': mock.patch(
+                'readthedocs.doc_builder.backends.mkdocs.BaseMkdocs.move'),
+            'append_conf_mkdocs': mock.patch(
+                'readthedocs.doc_builder.backends.mkdocs.BaseMkdocs.append_conf'),
+            'html_build_mkdocs': mock.patch(
+                'readthedocs.doc_builder.backends.mkdocs.MkdocsHTML.build'),
             'glob': mock.patch('readthedocs.doc_builder.backends.sphinx.glob'),
 
             'docker': mock.patch('readthedocs.doc_builder.environments.APIClient'),

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -48,8 +48,10 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = load_yaml_config(version)
-        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
-                              version=version, search=False, localmedia=False, config=config)
+        task = UpdateDocsTaskStep(
+            build_env=build_env, project=project, python_env=python_env,
+            version=version, config=config
+        )
         task.build_docs()
 
         # Get command and check first part of command list is a call to sphinx
@@ -74,8 +76,10 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = load_yaml_config(version)
-        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
-                              version=version, search=False, localmedia=False, config=config)
+        task = UpdateDocsTaskStep(
+            build_env=build_env, project=project, python_env=python_env,
+            version=version, config=config
+        )
 
         task.build_docs()
 
@@ -101,8 +105,10 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = load_yaml_config(version)
-        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
-                              version=version, search=False, localmedia=False, config=config)
+        task = UpdateDocsTaskStep(
+            build_env=build_env, project=project, python_env=python_env,
+            version=version, config=config
+        )
         task.build_docs()
 
         # The HTML and the Epub format were built.
@@ -128,8 +134,10 @@ class BuildEnvironmentTests(TestCase):
         python_env = Virtualenv(version=version, build_env=build_env)
 
         config = load_yaml_config(version)
-        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
-                              version=version, search=False, localmedia=False, config=config)
+        task = UpdateDocsTaskStep(
+            build_env=build_env, project=project, python_env=python_env,
+            version=version, config=config
+        )
         task.build_docs()
 
         # The HTML and the Epub format were built.
@@ -159,8 +167,10 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = load_yaml_config(version)
-        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
-                              version=version, search=False, localmedia=False, config=config)
+        task = UpdateDocsTaskStep(
+            build_env=build_env, project=project, python_env=python_env,
+            version=version, config=config
+        )
 
         # Mock out the separate calls to Popen using an iterable side_effect
         returns = [
@@ -203,8 +213,10 @@ class BuildEnvironmentTests(TestCase):
         build_env = LocalBuildEnvironment(project=project, version=version, build={})
         python_env = Virtualenv(version=version, build_env=build_env)
         config = load_yaml_config(version)
-        task = UpdateDocsTaskStep(build_env=build_env, project=project, python_env=python_env,
-                              version=version, search=False, localmedia=False, config=config)
+        task = UpdateDocsTaskStep(
+            build_env=build_env, project=project, python_env=python_env,
+            version=version, config=config
+        )
 
         # Mock out the separate calls to Popen using an iterable side_effect
         returns = [


### PR DESCRIPTION
These aren't used anywhere, as we always depend on the config (or project) for this decisions.

I'm also removing the `HTML_ONLY_PROJECTS` setting, I guess that was acting as a feature flag a long time ago when users couldn't disable epub and pdf by themselves?