### PR TITLE
Separate update and checkout steps

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -159,7 +159,8 @@ class SyncRepositoryMixin(object):
         """
         Update tags/branches hitting the API.
 
-        It may trigger a new build.
+        It may trigger a new build to the stable version
+        when hittig the ``sync_versions`` endpoint.
         """
         version_post_data = {'repo': version_repo.repo_url}
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -7,7 +7,11 @@ rebuilding documentation.
 """
 
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import datetime
 import hashlib
@@ -24,27 +28,39 @@ from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db.models import Q
-from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
 from slumber.exceptions import HttpClientError
 
 from readthedocs.builds.constants import (
-    BUILD_STATE_BUILDING, BUILD_STATE_CLONING, BUILD_STATE_FINISHED,
-    BUILD_STATE_INSTALLING, LATEST, LATEST_VERBOSE_NAME, STABLE_VERBOSE_NAME)
+    BUILD_STATE_BUILDING,
+    BUILD_STATE_CLONING,
+    BUILD_STATE_FINISHED,
+    BUILD_STATE_INSTALLING,
+    LATEST,
+    LATEST_VERBOSE_NAME,
+    STABLE_VERBOSE_NAME,
+)
 from readthedocs.builds.models import APIVersion, Build, Version
 from readthedocs.builds.signals import build_complete
 from readthedocs.builds.syncers import Syncer
 from readthedocs.config import ConfigError
 from readthedocs.core.resolver import resolve_path
-from readthedocs.core.symlink import PublicSymlink, PrivateSymlink
-from readthedocs.core.utils import send_email, broadcast, safe_unlink
+from readthedocs.core.symlink import PrivateSymlink, PublicSymlink
+from readthedocs.core.utils import broadcast, safe_unlink, send_email
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.constants import DOCKER_LIMITS
 from readthedocs.doc_builder.environments import (
-    DockerBuildEnvironment, LocalBuildEnvironment)
+    DockerBuildEnvironment,
+    LocalBuildEnvironment,
+)
 from readthedocs.doc_builder.exceptions import (
-    BuildEnvironmentError, BuildTimeoutError, ProjectBuildsSkippedError,
-    VersionLockedError, YAMLParseError)
+    BuildEnvironmentError,
+    BuildTimeoutError,
+    ProjectBuildsSkippedError,
+    VersionLockedError,
+    YAMLParseError,
+)
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.doc_builder.python_environments import Conda, Virtualenv
 from readthedocs.projects.models import APIProject
@@ -58,7 +74,12 @@ from .constants import LOG_TEMPLATE
 from .exceptions import RepositoryError
 from .models import Domain, ImportedFile, Project
 from .signals import (
-    after_build, after_vcs, before_build, before_vcs, files_changed)
+    after_build,
+    after_vcs,
+    before_build,
+    before_vcs,
+    files_changed,
+)
 
 log = logging.getLogger(__name__)
 

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -76,9 +76,9 @@ class TestGitBackend(RTDTestCase):
 
     def test_git_update_and_checkout(self):
         repo = self.project.vcs_repo()
-        code, *_ = repo.update()
+        code, _, _ = repo.update()
         self.assertEqual(code, 0)
-        code, *_ = repo.checkout()
+        code, _, _ = repo.checkout()
         self.assertEqual(code, 0)
         self.assertTrue(exists(repo.working_dir))
 
@@ -210,9 +210,9 @@ class TestHgBackend(RTDTestCase):
 
     def test_update_and_checkout(self):
         repo = self.project.vcs_repo()
-        code, *_ = repo.update()
+        code, _, _ = repo.update()
         self.assertEqual(code, 0)
-        code, *_ = repo.checkout()
+        code, _, _ = repo.checkout()
         self.assertEqual(code, 0)
         self.assertTrue(exists(repo.working_dir))
 

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -182,6 +182,7 @@ class TestGitBackend(RTDTestCase):
 
 
 class TestHgBackend(RTDTestCase):
+
     def setUp(self):
         hg_repo = make_test_hg()
         super(TestHgBackend, self).setUp()
@@ -189,9 +190,9 @@ class TestHgBackend(RTDTestCase):
         self.eric.set_password('test')
         self.eric.save()
         self.project = Project.objects.create(
-            name="Test Project",
-            repo_type="hg",
-            #Our top-level checkout
+            name='Test Project',
+            repo_type='hg',
+            # Our top-level checkout
             repo=hg_repo
         )
         self.project.users.add(self.eric)
@@ -207,9 +208,12 @@ class TestHgBackend(RTDTestCase):
                      self.project.vcs_repo().parse_branches(data)]
         self.assertEqual(expected_ids, given_ids)
 
-    def test_checkout(self):
+    def test_update_and_checkout(self):
         repo = self.project.vcs_repo()
-        repo.checkout()
+        code, *_ = repo.update()
+        self.assertEqual(code, 0)
+        code, *_ = repo.checkout()
+        self.assertEqual(code, 0)
         self.assertTrue(exists(repo.working_dir))
 
     def test_parse_tags(self):

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -74,9 +74,9 @@ class TestGitBackend(RTDTestCase):
                      self.project.vcs_repo().parse_branches(data)]
         self.assertEqual(expected_ids, given_ids)
 
-    def test_git_checkout(self):
+    def test_git_update(self):
         repo = self.project.vcs_repo()
-        repo.checkout()
+        repo.update()
         self.assertTrue(exists(repo.working_dir))
 
     def test_git_tags(self):
@@ -96,7 +96,7 @@ class TestGitBackend(RTDTestCase):
     def test_check_for_submodules(self):
         repo = self.project.vcs_repo()
 
-        repo.checkout()
+        repo.update()
         self.assertFalse(repo.are_submodules_available(self.dummy_conf))
 
         # The submodule branch contains one submodule
@@ -105,6 +105,7 @@ class TestGitBackend(RTDTestCase):
 
     def test_skip_submodule_checkout(self):
         repo = self.project.vcs_repo()
+        repo.update()
         repo.checkout('submodule')
         self.assertTrue(repo.are_submodules_available(self.dummy_conf))
         feature = fixture.get(
@@ -117,6 +118,7 @@ class TestGitBackend(RTDTestCase):
 
     def test_check_submodule_urls(self):
         repo = self.project.vcs_repo()
+        repo.update()
         repo.checkout('submodule')
         valid, _ = repo.validate_submodules(self.dummy_conf)
         self.assertTrue(valid)
@@ -160,7 +162,7 @@ class TestGitBackend(RTDTestCase):
             set(vcs.verbose_name for vcs in repo.branches)
         )
 
-        repo.checkout()
+        repo.update()
 
         # We don't have the eliminated branches and tags in the local repo
         self.assertEqual(

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -74,9 +74,10 @@ class TestGitBackend(RTDTestCase):
                      self.project.vcs_repo().parse_branches(data)]
         self.assertEqual(expected_ids, given_ids)
 
-    def test_git_update(self):
+    def test_git_update_and_checkout(self):
         repo = self.project.vcs_repo()
         repo.update()
+        repo.checkout()
         self.assertTrue(exists(repo.working_dir))
 
     def test_git_tags(self):

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -76,8 +76,10 @@ class TestGitBackend(RTDTestCase):
 
     def test_git_update_and_checkout(self):
         repo = self.project.vcs_repo()
-        repo.update()
-        repo.checkout()
+        code, *_ = repo.update()
+        self.assertEqual(code, 0)
+        code, *_ = repo.checkout()
+        self.assertEqual(code, 0)
         self.assertTrue(exists(repo.working_dir))
 
     def test_git_tags(self):

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -24,9 +24,8 @@ class Backend(BaseVCS):
         super(Backend, self).update()
         retcode = self.run('bzr', 'status', record=False)[0]
         if retcode == 0:
-            self.up()
-        else:
-            self.clone()
+            return self.up()
+        return self.clone()
 
     def up(self):
         retcode = self.run('bzr', 'revert')[0]

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 """Bazaar-related utilities."""
 
-from __future__ import absolute_import
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import csv
 import re
 
-from builtins import bytes, str  # pylint: disable=redefined-builtin
+from builtins import str  # pylint: disable=redefined-builtin
 from six import StringIO
 
 from readthedocs.projects.exceptions import RepositoryError

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -86,7 +86,6 @@ class Backend(BaseVCS):
 
     def checkout(self, identifier=None):
         super(Backend, self).checkout()
-        self.update()
         if not identifier:
             return self.up()
         return self.run('bzr', 'switch', identifier)

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -2,7 +2,11 @@
 """Git-related utilities."""
 
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import csv
 import logging

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -144,9 +144,7 @@ class Backend(BaseVCS):
         return [code, out, err]
 
     def clone(self):
-        """
-        Clone the repository.
-        """
+        """Clones the repository."""
         code, stdout, stderr = self.run(
             'git', 'clone', self.repo_url, '.'
         )

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 """Mercurial-related utilities."""
-from __future__ import absolute_import
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
 from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
 

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -104,9 +104,4 @@ class Backend(BaseVCS):
         super(Backend, self).checkout()
         if not identifier:
             identifier = 'tip'
-        retcode = self.run('hg', 'status', record=False)[0]
-        if retcode == 0:
-            self.run('hg', 'pull')
-        else:
-            self.clone()
         return self.run('hg', 'update', '--clean', identifier)

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 """Subversion-related utilities."""
 
-from __future__ import absolute_import
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import csv
 

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -36,9 +36,8 @@ class Backend(BaseVCS):
         # directories that's why I use `svn info` here.
         retcode = self.run('svn', 'info', record_as_success=True)[0]
         if retcode == 0:
-            self.up()
-        else:
-            self.co()
+            return self.up()
+        return self.co()
 
     def up(self):
         retcode = self.run('svn', 'revert', '--recursive', '.')[0]
@@ -99,10 +98,4 @@ class Backend(BaseVCS):
 
     def checkout(self, identifier=None):
         super(Backend, self).checkout()
-        retcode = self.run('svn', 'info', record=False)[0]
-        if retcode == 0:
-            result = self.up()
-        else:
-            result = self.co(identifier)
-        # result is (return_code, stdout, stderr)
-        return result
+        return self.co(identifier)


### PR DESCRIPTION
So, I can see that the update commands of the other VCS' do the same that the first part of checkout. And we don't use `update` in any part of the code.

Closes #4259

And half fixes (#4890), right now users without a `master` branch are blocked and can't do anything to build their docs (previously users could put any text on the `default branch`, but now it's a select field).

With this change, the first build will fail, but now they can select another version as `default branch`.

Still wip, a lot tests will break probably and I neeed to do the same with the other VCS'

### TODO

- [x] git
- [x] svn
- [x] hg
- [x] bzr