### PR TITLE
Tuning Elasticsearch for search improvements

### DIFF
--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -59,7 +59,7 @@ class PageDocument(RTDDocTypeMixin, DocType):
     title = fields.TextField(attr='processed_json.title')
     headers = fields.TextField(attr='processed_json.headers')
     content = fields.TextField(attr='processed_json.content')
-    path = fields.TextField(attr='processed_json.path')
+    path = fields.KeywordField(attr='processed_json.path')
 
     # Fields to perform search with weight
     search_fields = ['title^10', 'headers^5', 'content']

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -343,6 +343,8 @@ class CommunityBaseSettings(Settings):
     ES_INDEXES = {
         'project': {
             'name': 'project_index',
+            # We do not have much data in the project node, therefore only 1 shard with
+            # 1 replica is appropriate project index
             'settings': {'number_of_shards': 1,
                          'number_of_replicas': 1
                          }
@@ -350,6 +352,10 @@ class CommunityBaseSettings(Settings):
         'page': {
             'name': 'page_index',
             'settings': {
+                # We have 3 nodes, therefore having 3 shards and each one having 3 replica
+                # will be good fit for our infrastructure. So all the 9(3*3) shards will be
+                # allocated to 3 nodes. Therefore, if one nodes get failed, the data will be
+                # inside other nodes and Elasticsearch can serve properly.
                 'number_of_shards': 3,
                 'number_of_replicas': 3,
                 "index": {

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -343,18 +343,23 @@ class CommunityBaseSettings(Settings):
     ES_INDEXES = {
         'project': {
             'name': 'project_index',
-            'settings': {'number_of_shards': 5,
+            'settings': {'number_of_shards': 1,
                          'number_of_replicas': 1
                          }
         },
         'page': {
             'name': 'page_index',
             'settings': {
-                'number_of_shards': 5,
-                'number_of_replicas': 1,
+                'number_of_shards': 3,
+                'number_of_replicas': 3,
+                "index": {
+                    "sort.field": ["project", "version"]
+                }
             }
         },
     }
+    # Disable auto refresh for increasing index performance
+    ELASTICSEARCH_DSL_AUTO_REFRESH = False
 
     ALLOWED_HOSTS = ['*']
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -343,7 +343,7 @@ class CommunityBaseSettings(Settings):
     ES_INDEXES = {
         'project': {
             'name': 'project_index',
-            # We do not have much data in the project node, therefore only 1 shard with
+            # We do not have much data in the project index, therefore only 1 shard with
             # 1 replica is appropriate project index
             'settings': {'number_of_shards': 1,
                          'number_of_replicas': 1

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -18,6 +18,7 @@ class CommunityTestSettings(CommunityDevSettings):
     TEMPLATE_DEBUG = False
     ES_PAGE_IGNORE_SIGNALS = False
     ELASTICSEARCH_DSL_AUTOSYNC = False
+    ELASTICSEARCH_DSL_AUTO_REFRESH = False
 
     @property
     def ES_INDEXES(self):  # noqa - avoid pep8 N802

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -18,7 +18,7 @@ class CommunityTestSettings(CommunityDevSettings):
     TEMPLATE_DEBUG = False
     ES_PAGE_IGNORE_SIGNALS = False
     ELASTICSEARCH_DSL_AUTOSYNC = False
-    ELASTICSEARCH_DSL_AUTO_REFRESH = False
+    ELASTICSEARCH_DSL_AUTO_REFRESH = True
 
     @property
     def ES_INDEXES(self):  # noqa - avoid pep8 N802


### PR DESCRIPTION
As we will have 3 nodes, I think this conguration is good enough for our use case.
Moreover, the index will be sorted according to `project`. so I hope it will be faster.
Overall, I think it will mitigate the timeout issue that we were facing.

@ericholscher r?