### PR TITLE
Update yaml-config.rst to not show impossible option "python: 3.6"

### DIFF
--- a/docs/yaml-config.rst
+++ b/docs/yaml-config.rst
@@ -18,7 +18,7 @@ Here is an example of what this file looks like:
      image: latest
    
    python:
-     version: 3.6
+     version: 3.5
      setup_py_install: true
 
 


### PR DESCRIPTION
It is really misleading to show that `python: 3.6` could be used (in the first example of this page), when it still cannot be used!
I tried [in this change to my `readthedocs.yml` file](https://github.com/SMPyBandits/SMPyBandits/commit/b29e893e8018c865f42d54d45737dce81353c9e5#diff-e3b87b9ac78b8654ec8ee32806cfcf02R5), and received instantly this error by email (see [this build](https://readthedocs.org/projects/smpybandits/builds/8126289/)):
```bash
Error: Problem in your project's configuration. Invalid "python.version": expected one of (2, 2.7, 3, 3.5), got 3.6
```