### PR TITLE
Remove deprecated sudo from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - 2.7
   - 3.6
-sudo: false
 env:
   - ES_VERSION=1.3.9 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
 matrix:


### PR DESCRIPTION
It will be removed soon
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration