### PR TITLE
Use .exists in queryset

### DIFF
--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -157,7 +157,7 @@ class VersionSlugField(models.CharField):
 
         # increases the number while searching for the next valid slug
         # depending on the given slug, clean-up
-        while not slug or queryset.filter(**kwargs):
+        while not slug or queryset.filter(**kwargs).exists():
             slug = original_slug
             end = self.uniquifying_suffix(count)
             end_len = len(end)


### PR DESCRIPTION
The queryset gets evaluated here, we don't need the whole objects

https://docs.djangoproject.com/en/2.1/ref/models/querysets/#when-querysets-are-evaluated