### PR TITLE
Remove `project_version_delete_html` view

### DIFF
--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -44,10 +44,6 @@ urlpatterns = [
         ProjectAdvancedUpdate.as_view(),
         name='projects_advanced'),
 
-    url(r'^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/delete_html/$',
-        private.project_version_delete_html,
-        name='project_version_delete_html'),
-
     url(r'^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/$',
         private.project_version_detail,
         name='project_version_detail'),

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -677,43 +677,6 @@ def project_redirects_delete(request, project_slug):
     )
 
 
-@login_required
-def project_version_delete_html(request, project_slug, version_slug):
-    """
-    Project version 'delete' HTML.
-
-    This marks a version as not built
-    """
-    project = get_object_or_404(
-        Project.objects.for_admin_user(request.user),
-        slug=project_slug,
-    )
-    version = get_object_or_404(
-        Version.objects.public(
-            user=request.user,
-            project=project,
-            only_active=False,
-        ),
-        slug=version_slug,
-    )
-
-    if not version.active:
-        version.built = False
-        version.save()
-        broadcast(
-            type='app',
-            task=tasks.clear_artifacts,
-            args=[version.get_artifact_paths()],
-        )
-    else:
-        return HttpResponseBadRequest(
-            "Can't delete HTML for an active version.",
-        )
-    return HttpResponseRedirect(
-        reverse('project_version_list', kwargs={'project_slug': project_slug}),
-    )
-
-
 class DomainMixin(ProjectAdminMixin, PrivateViewMixin):
     model = Domain
     form_class = DomainForm

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -102,10 +102,6 @@ class PrivateViewsAreProtectedTests(TestCase):
         response = self.client.get('/dashboard/pip/advanced/')
         self.assertRedirectToLogin(response)
 
-    def test_version_delete_html(self):
-        response = self.client.get('/dashboard/pip/version/0.8.1/delete_html/')
-        self.assertRedirectToLogin(response)
-
     def test_version_detail(self):
         response = self.client.get('/dashboard/pip/version/0.8.1/')
         self.assertRedirectToLogin(response)

--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -104,16 +104,13 @@ Versions
 
                       {% if request.user|is_admin:project %}
                         <ul class="module-item-menu">
-                          {% if version.built %}
-                            <li><a href="{% url "project_version_delete_html" project.slug version.slug %}">{% trans "Clean" %}</a></li>
-                          {% endif %}
                           <li><a href="{% url "project_version_detail" project.slug version.slug %}">{% trans "Edit" %}</a></li>
                         </ul>
                       {% endif %}
 
                     </li>
                   {% endblock inactive-versions %}
-                
+
                 {% endfor %}
               </ul>
             </div>


### PR DESCRIPTION
We used to have a "Clean" button in the Inactive Versions listing to remove built and disabled versions of the documentation.

This is not more possible, because when the version is disabled (mark as non active) we call `clean_artifacts` and remove all the HTML files for this version and mark it as `Version.build=False`. In the end, that button does not appear anymore.

Related #4937