### PR TITLE
Adapt code to remove and ignore warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,17 @@
 [pytest]
 addopts = --reuse-db
 python_files = tests.py test_*.py *_tests.py
+filterwarnings =
+    # TODO: this filter has to be removed before migrating to Django
+    # 2.0 and the code has to be upgrade accordingly
+    ignore::django.utils.deprecation.RemovedInDjango20Warning
+
+    # Ignore external dependencies warning deprecations
+    # django-guardian
+    ignore:Shortcut function 'assign'.*:DeprecationWarning
+    # textclassifier
+    ignore:The 'warn' method is deprecated, use 'warning' instead:DeprecationWarning
+    # django-rest-framework
+    ignore:Pagination may yield inconsistent results with an unordered object_list.*:django.core.paginator.UnorderedObjectListWarning
+    # docutils
+    ignore:'U' mode is deprecated:DeprecationWarning

--- a/readthedocs/api/utils.py
+++ b/readthedocs/api/utils.py
@@ -52,7 +52,7 @@ class EnhancedModelResource(ModelResource):
 class OwnerAuthorization(Authorization):
     def apply_limits(self, request, object_list):
         if request and hasattr(request, 'user') and request.method != 'GET':
-            if request.user.is_authenticated():
+            if request.user.is_authenticated:
                 object_list = object_list.filter(users__in=[request.user])
             else:
                 object_list = object_list.none()

--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -21,7 +21,7 @@ class VersionQuerySetBase(models.QuerySet):
     def _add_user_repos(self, queryset, user):
         if user.has_perm('builds.view_version'):
             return self.all().distinct()
-        if user.is_authenticated():
+        if user.is_authenticated:
             user_queryset = get_objects_for_user(user, 'builds.view_version')
             queryset = user_queryset | queryset
         return queryset.distinct()
@@ -84,7 +84,7 @@ class BuildQuerySetBase(models.QuerySet):
     def _add_user_repos(self, queryset, user=None):
         if user.has_perm('builds.view_version'):
             return self.all().distinct()
-        if user.is_authenticated():
+        if user.is_authenticated:
             user_queryset = get_objects_for_user(user, 'builds.view_version')
             pks = user_queryset.values_list('pk', flat=True)
             queryset = self.filter(version__pk__in=pks) | queryset
@@ -116,7 +116,7 @@ class RelatedBuildQuerySetBase(models.QuerySet):
     def _add_user_repos(self, queryset, user=None):
         if user.has_perm('builds.view_version'):
             return self.all().distinct()
-        if user.is_authenticated():
+        if user.is_authenticated:
             user_queryset = get_objects_for_user(user, 'builds.view_version')
             pks = user_queryset.values_list('pk', flat=True)
             queryset = self.filter(

--- a/readthedocs/core/utils/tasks/permission_checks.py
+++ b/readthedocs/core/utils/tasks/permission_checks.py
@@ -5,7 +5,7 @@ __all__ = ('user_id_matches',)
 
 def user_id_matches(request, state, context):  # pylint: disable=unused-argument
     user_id = context.get('user_id', None)
-    if user_id is not None and request.user.is_authenticated():
+    if user_id is not None and request.user.is_authenticated:
         if request.user.id == user_id:
             return True
     return False

--- a/readthedocs/notifications/storages.py
+++ b/readthedocs/notifications/storages.py
@@ -68,7 +68,7 @@ class FallbackUniqueStorage(FallbackStorage):
 
     def add(self, level, message, extra_tags='', *args, **kwargs):  # noqa
         user = kwargs.get('user') or self.request.user
-        if not user.is_anonymous():
+        if not user.is_anonymous:
             persist_messages = (PersistentMessage.objects
                                 .filter(message=message,
                                         user=user,
@@ -136,7 +136,7 @@ class NonPersistentStorage(PersistentStorage):
         user = kwargs.get("user") or self.get_user()
 
         try:
-            anonymous = user.is_anonymous()
+            anonymous = user.is_anonymous
         except TypeError:
             anonymous = user.is_anonymous
         if anonymous:

--- a/readthedocs/oauth/querysets.py
+++ b/readthedocs/oauth/querysets.py
@@ -13,7 +13,7 @@ class RelatedUserQuerySetBase(models.QuerySet):
 
     def api(self, user=None):
         """Return objects for user"""
-        if not user.is_authenticated():
+        if not user.is_authenticated:
             return self.none()
         return self.filter(users=user)
 

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -19,7 +19,7 @@ class ProjectQuerySetBase(models.QuerySet):
     def _add_user_repos(self, queryset, user):
         if user.has_perm('projects.view_project'):
             return self.all().distinct()
-        if user.is_authenticated():
+        if user.is_authenticated:
             user_queryset = get_objects_for_user(user, 'projects.view_project')
             queryset = user_queryset | queryset
         return queryset.distinct()
@@ -32,7 +32,7 @@ class ProjectQuerySetBase(models.QuerySet):
         return queryset
 
     def for_admin_user(self, user):
-        if user.is_authenticated():
+        if user.is_authenticated:
             return self.filter(users__in=[user])
         return self.none()
 
@@ -83,7 +83,7 @@ class RelatedProjectQuerySetBase(models.QuerySet):
         # Hack around get_objects_for_user not supporting global perms
         if user.has_perm('projects.view_project'):
             return self.all().distinct()
-        if user.is_authenticated():
+        if user.is_authenticated:
             # Add in possible user-specific views
             project_qs = get_objects_for_user(user, 'projects.view_project')
             pks = project_qs.values_list('pk', flat=True)

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -221,7 +221,7 @@ def elastic_project_search(request, project_slug):
     query = request.GET.get('q', None)
     if query:
         user = ''
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             user = request.user
         log.info(
             LOG_TEMPLATE.format(

--- a/readthedocs/restapi/serializers.py
+++ b/readthedocs/restapi/serializers.py
@@ -169,7 +169,7 @@ class RemoteRepositorySerializer(serializers.ModelSerializer):
 
     def get_matches(self, obj):
         request = self.context['request']
-        if request.user is not None and request.user.is_authenticated():
+        if request.user is not None and request.user.is_authenticated:
             return obj.matches(request.user)
 
 

--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -36,26 +36,26 @@ from .views.model_views import (
 )
 
 router = routers.DefaultRouter()
-router.register(r'build', BuildViewSet, base_name='build')
-router.register(r'command', BuildCommandViewSet, base_name='buildcommandresult')
-router.register(r'version', VersionViewSet, base_name='version')
-router.register(r'project', ProjectViewSet, base_name='project')
-router.register(r'notification', NotificationViewSet, base_name='emailhook')
-router.register(r'domain', DomainViewSet, base_name='domain')
+router.register(r'build', BuildViewSet, basename='build')
+router.register(r'command', BuildCommandViewSet, basename='buildcommandresult')
+router.register(r'version', VersionViewSet, basename='version')
+router.register(r'project', ProjectViewSet, basename='project')
+router.register(r'notification', NotificationViewSet, basename='emailhook')
+router.register(r'domain', DomainViewSet, basename='domain')
 router.register(
     r'remote/org',
     RemoteOrganizationViewSet,
-    base_name='remoteorganization',
+    basename='remoteorganization',
 )
 router.register(
     r'remote/repo',
     RemoteRepositoryViewSet,
-    base_name='remoterepository',
+    basename='remoterepository',
 )
 router.register(
     r'remote/account',
     SocialAccountViewSet,
-    base_name='remoteaccount',
+    basename='remoteaccount',
 )
 
 urlpatterns = [

--- a/readthedocs/restapi/views/integrations.py
+++ b/readthedocs/restapi/views/integrations.py
@@ -374,7 +374,7 @@ class APIWebhookView(WebhookMixin, APIView):
         the integration token to be specified as a POST argument.
         """
         # If the user is not an admin of the project, fall back to token auth
-        if self.request.user.is_authenticated():
+        if self.request.user.is_authenticated:
             try:
                 return (Project.objects
                         .for_admin_user(self.request.user)

--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -11,7 +11,6 @@ from builtins import str
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from rest_framework import decorators, permissions, status, viewsets
-from rest_framework.decorators import detail_route
 from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.response import Response
 
@@ -95,7 +94,7 @@ class ProjectViewSet(UserSelectViewSet):
     filter_fields = ('slug',)  # django-filter<2.0.0
     filterset_fields = ('slug',)
 
-    @decorators.detail_route()
+    @decorators.action(detail=True)
     def valid_versions(self, request, **kwargs):
         """Maintain state of versions that are wanted."""
         project = get_object_or_404(
@@ -118,14 +117,14 @@ class ProjectViewSet(UserSelectViewSet):
             'flat': version_strings,
         })
 
-    @detail_route()
+    @decorators.action(detail=True)
     def translations(self, *_, **__):
         translations = self.get_object().translations.all()
         return Response({
             'translations': ProjectSerializer(translations, many=True).data,
         })
 
-    @detail_route()
+    @decorators.action(detail=True)
     def subprojects(self, request, **kwargs):
         project = get_object_or_404(
             Project.objects.api(request.user), pk=kwargs['pk'])
@@ -135,7 +134,7 @@ class ProjectViewSet(UserSelectViewSet):
             'subprojects': ProjectSerializer(children, many=True).data,
         })
 
-    @detail_route()
+    @decorators.action(detail=True)
     def active_versions(self, request, **kwargs):
         project = get_object_or_404(
             Project.objects.api(request.user), pk=kwargs['pk'])
@@ -144,7 +143,7 @@ class ProjectViewSet(UserSelectViewSet):
             'versions': VersionSerializer(versions, many=True).data,
         })
 
-    @decorators.detail_route(permission_classes=[permissions.IsAdminUser])
+    @decorators.action(detail=True, permission_classes=[permissions.IsAdminUser])
     def token(self, request, **kwargs):
         project = get_object_or_404(
             Project.objects.api(request.user), pk=kwargs['pk'])
@@ -153,7 +152,7 @@ class ProjectViewSet(UserSelectViewSet):
             'token': token,
         })
 
-    @decorators.detail_route()
+    @decorators.action(detail=True)
     def canonical_url(self, request, **kwargs):
         project = get_object_or_404(
             Project.objects.api(request.user), pk=kwargs['pk'])
@@ -161,8 +160,10 @@ class ProjectViewSet(UserSelectViewSet):
             'url': project.get_docs_url(),
         })
 
-    @decorators.detail_route(
-        permission_classes=[permissions.IsAdminUser], methods=['post'])
+    @decorators.action(
+        detail=True, permission_classes=[permissions.IsAdminUser],
+        methods=['post'],
+    )
     def sync_versions(self, request, **kwargs):  # noqa: D205
         """
         Sync the version data in the repo (on the build server).

--- a/readthedocs/rtd_tests/base.py
+++ b/readthedocs/rtd_tests/base.py
@@ -170,4 +170,4 @@ class WizardTestCase(RequestFactoryTestMixin, TestCase):
         self.assertIn(field, response.context_data['wizard']['form'].errors)
         if match is not None:
             error = response.context_data['wizard']['form'].errors[field]
-            self.assertRegexpMatches(six.text_type(error), match)  # noqa
+            self.assertRegex(six.text_type(error), match)  # noqa

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -56,8 +56,8 @@ class BuildEnvironmentTests(TestCase):
         # Get command and check first part of command list is a call to sphinx
         self.assertEqual(self.mocks.popen.call_count, 3)
         cmd = self.mocks.popen.call_args_list[2][0]
-        self.assertRegexpMatches(cmd[0][0], r'python')
-        self.assertRegexpMatches(cmd[0][1], r'sphinx-build')
+        self.assertRegex(cmd[0][0], r'python')
+        self.assertRegex(cmd[0][1], r'sphinx-build')
 
     @mock.patch('readthedocs.doc_builder.config.load_config')
     def test_build_respects_pdf_flag(self, load_config):

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1001,7 +1001,7 @@ class TestBuildCommand(TestCase):
         cmd = BuildCommand(path)
         cmd.run()
         missing_re = re.compile(r'(?:No such file or directory|not found)')
-        self.assertRegexpMatches(cmd.error, missing_re)
+        self.assertRegex(cmd.error, missing_re)
 
     def test_input(self):
         """Test input to command."""

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1091,7 +1091,7 @@ class TestDockerBuildCommand(TestCase):
             cmd.get_wrapped_command(),
             ('/bin/sh -c '
              "'cd /tmp/foobar && PATH=/tmp/foo:$PATH "
-             "python /tmp/foo/pip install Django\>1.7'"),
+             r"python /tmp/foo/pip install Django\>1.7'"),
         )
 
     def test_unicode_output(self):

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -63,26 +63,26 @@ class Testmaker(APITestCase):
             self.assertEqual(r.data['version_compare'], {'MOCKED': True})
 
     def test_pdf_build_mentioned_in_footer(self):
-        with fake_paths_by_regex('\.pdf$'):
+        with fake_paths_by_regex(r'\.pdf$'):
             response = self.render()
         self.assertIn('pdf', response.data['html'])
 
     def test_pdf_not_mentioned_in_footer_when_build_is_disabled(self):
         self.pip.enable_pdf_build = False
         self.pip.save()
-        with fake_paths_by_regex('\.pdf$'):
+        with fake_paths_by_regex(r'\.pdf$'):
             response = self.render()
         self.assertNotIn('pdf', response.data['html'])
 
     def test_epub_build_mentioned_in_footer(self):
-        with fake_paths_by_regex('\.epub$'):
+        with fake_paths_by_regex(r'\.epub$'):
             response = self.render()
         self.assertIn('epub', response.data['html'])
 
     def test_epub_not_mentioned_in_footer_when_build_is_disabled(self):
         self.pip.enable_epub_build = False
         self.pip.save()
-        with fake_paths_by_regex('\.epub$'):
+        with fake_paths_by_regex(r'\.epub$'):
             response = self.render()
         self.assertNotIn('epub', response.data['html'])
 

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -54,32 +54,32 @@ class TestProject(ProjectMixin, TestCase):
 
     def test_has_pdf(self):
         # The project has a pdf if the PDF file exists on disk.
-        with fake_paths_by_regex('\.pdf$'):
+        with fake_paths_by_regex(r'\.pdf$'):
             self.assertTrue(self.pip.has_pdf(LATEST))
 
         # The project has no pdf if there is no file on disk.
-        with fake_paths_by_regex('\.pdf$', exists=False):
+        with fake_paths_by_regex(r'\.pdf$', exists=False):
             self.assertFalse(self.pip.has_pdf(LATEST))
 
     def test_has_pdf_with_pdf_build_disabled(self):
         # The project has NO pdf if pdf builds are disabled
         self.pip.enable_pdf_build = False
-        with fake_paths_by_regex('\.pdf$'):
+        with fake_paths_by_regex(r'\.pdf$'):
             self.assertFalse(self.pip.has_pdf(LATEST))
 
     def test_has_epub(self):
         # The project has a epub if the PDF file exists on disk.
-        with fake_paths_by_regex('\.epub$'):
+        with fake_paths_by_regex(r'\.epub$'):
             self.assertTrue(self.pip.has_epub(LATEST))
 
         # The project has no epub if there is no file on disk.
-        with fake_paths_by_regex('\.epub$', exists=False):
+        with fake_paths_by_regex(r'\.epub$', exists=False):
             self.assertFalse(self.pip.has_epub(LATEST))
 
     def test_has_epub_with_epub_build_disabled(self):
         # The project has NO epub if epub builds are disabled
         self.pip.enable_epub_build = False
-        with fake_paths_by_regex('\.epub$'):
+        with fake_paths_by_regex(r'\.epub$'):
             self.assertFalse(self.pip.has_epub(LATEST))
 
     @patch('readthedocs.projects.models.Project.find')

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -313,8 +313,8 @@ class TestImportDemoView(MockBuildTestCase):
         self.assertEqual(resp_redir.status_code, 200)
         messages = list(resp_redir.context['messages'])
         self.assertEqual(messages[0].level, message_const.SUCCESS)
-        self.assertRegexpMatches(messages[0].message,
-                                 r'already imported')
+        self.assertRegex(messages[0].message,
+                         r'already imported')
 
         self.assertEqual(project,
                          Project.objects.get(slug='eric-demo'))
@@ -339,8 +339,8 @@ class TestImportDemoView(MockBuildTestCase):
         self.assertEqual(resp_redir.status_code, 200)
         messages = list(resp_redir.context['messages'])
         self.assertEqual(messages[0].level, message_const.ERROR)
-        self.assertRegexpMatches(messages[0].message,
-                                 r'There was a problem')
+        self.assertRegex(messages[0].message,
+                         r'There was a problem')
 
         self.assertEqual(project,
                          Project.objects.get(slug='eric-demo'))

--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -23,7 +23,7 @@ class SubprojectFormTests(TestCase):
         )
         form.full_clean()
         self.assertEqual(len(form.errors['child']), 1)
-        self.assertRegexpMatches(
+        self.assertRegex(
             form.errors['child'][0],
             r'This field is required.'
         )
@@ -39,7 +39,7 @@ class SubprojectFormTests(TestCase):
         )
         form.full_clean()
         self.assertEqual(len(form.errors['child']), 1)
-        self.assertRegexpMatches(
+        self.assertRegex(
             form.errors['child'][0],
             r'Select a valid choice.'
         )
@@ -62,7 +62,7 @@ class SubprojectFormTests(TestCase):
         )
         form.full_clean()
         self.assertEqual(len(form.errors['child']), 1)
-        self.assertRegexpMatches(
+        self.assertRegex(
             form.errors['child'][0],
             r'Select a valid choice.'
         )
@@ -119,7 +119,7 @@ class SubprojectFormTests(TestCase):
         )
         form.full_clean()
         self.assertEqual(len(form.errors['parent']), 1)
-        self.assertRegexpMatches(
+        self.assertRegex(
             form.errors['parent'][0],
             r'Subproject nesting is not supported'
         )

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -72,7 +72,7 @@ def elastic_search(request):
 
     if user_input.query:
         user = ''
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             user = request.user
         log.info(
             LOG_TEMPLATE.format(


### PR DESCRIPTION
Adapt some parts of the code to remove warnings and ignore Django 2.0 and external dependencies warnings also.

We do not control external dependencies warnings and we can't upgrade them. We rely on them to update their code before we migrate to Django 2.0. Before migrating to Django 2.0 we will need to remove this `ignore` filters and run all the tests to check what dependencies are still not compatible. In the meantime, we remove all this garbage from the summary output.