### PR TITLE
Pin redis to the current stable and compatible version

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -43,7 +43,10 @@ lxml==4.2.5
 defusedxml==0.5.0
 
 # Basic tools
-redis==3.0.1
+# Redis 3.x has an incompatible change and fails
+# https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey
+# https://github.com/sebleier/django-redis-cache/pull/162
+redis==2.10.6
 # Celery 4.2 is incompatible with our code
 # when ALWAYS_EAGER = True
 celery==4.1.1


### PR DESCRIPTION
See https://github.com/sebleier/django-redis-cache/pull/162 and https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey