### PR TITLE
Add test case for send_notifications on VersionLockedError

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -475,6 +475,11 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             # one after the other)
             if not isinstance(self.setup_env.failure, VersionLockedError):
                 self.send_notifications()
+            else:
+                # Done only for the purpose of testing
+                # It will be removed before merging
+                import sys
+                sys.exit(0)
 
             return False
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -475,11 +475,6 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             # one after the other)
             if not isinstance(self.setup_env.failure, VersionLockedError):
                 self.send_notifications()
-            else:
-                # Done only for the purpose of testing
-                # It will be removed before merging
-                import sys
-                sys.exit(0)
 
             return False
 


### PR DESCRIPTION
Fixes #4840 
This test checks that no notification is sent if the Version is locked.