### PR TITLE
Remove -e option

### DIFF
--- a/docs/yaml-config.rst
+++ b/docs/yaml-config.rst
@@ -280,7 +280,7 @@ Behind the scene the following Pip command will be run:
 
 .. code-block:: shell
 
-    $ pip install -e .[tests,docs]
+    $ pip install .[tests,docs]
 
 
 .. _issue: https://github.com/rtfd/readthedocs.org/issues


### PR DESCRIPTION
This removes the `-e` option from [yaml config documentation](https://docs.readthedocs.io/en/latest/yaml-config.html) which states that pip install is run in editable mode

Closes #4944