### PR TITLE
Workaround for a django-storages bug

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -83,8 +83,8 @@ textarea, input, select { font-family: SFMono-Regular, Menlo, Monaco, Consolas, 
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../fonts/fontawesome-webfont.eot?v=4.4.0');
-  src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.4.0') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff?v=4.4.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.4.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.4.0#fontawesomeregular') format('svg');
+  src: url('../fonts/fontawesome-webfont.eot');
+  src: url('../fonts/fontawesome-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff') format('woff'), url('../fonts/fontawesome-webfont.ttf') format('truetype'), url('../fonts/fontawesome-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Django-storages has a [bug](https://github.com/jschneier/django-storages/issues/609) in the AzureStorage that has problems with `?` and `=` in URLs. This gets triggered when these files are post-processed with Django's [ManifestFilesMixin](https://docs.djangoproject.com/en/2.1/ref/contrib/staticfiles/#manifestfilesmixin)