### PR TITLE
Remove deprecated "models.permalink"

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -15,7 +15,6 @@ from shutil import rmtree
 
 from builtins import object
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
@@ -24,6 +23,7 @@ from django.utils.translation import ugettext_lazy as _
 from guardian.shortcuts import assign
 from jsonfield import JSONField
 from taggit.managers import TaggableManager
+from django.urls import reverse
 
 from readthedocs.core.utils import broadcast
 from readthedocs.projects.constants import (
@@ -562,9 +562,8 @@ class Build(models.Model):
                 pk=self.pk,
             ))
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('builds_detail', [self.project.slug, self.pk])
+        return reverse('builds_detail', args=[self.project.slug, self.pk])
 
     @property
     def finished(self):

--- a/readthedocs/core/models.py
+++ b/readthedocs/core/models.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
+from django.urls import reverse
 
 STANDARD_EMAIL = 'anonymous@readthedocs.org'
 
@@ -43,9 +44,7 @@ class UserProfile(models.Model):
             {'username': self.user.username})
 
     def get_absolute_url(self):
-        return ('profiles_profile_detail', (), {'username': self.user.username})
-
-    get_absolute_url = models.permalink(get_absolute_url)
+        return reverse('profiles_profile_detail',  kwargs={'username': self.user.username})
 
     def get_contribution_details(self):
         """


### PR DESCRIPTION
**django.db.models.permalink()** is deprecated 4-5 years ago ([ticket #18974](https://code.djangoproject.com/ticket/18974)) and it is now completely removed in Django 2.1 ([Deprecation Timeline for Django 2.1](django.db.models.permalink()))