### PR TITLE
Remove deprecated imports from "urlresolvers"

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -13,7 +13,7 @@ import logging
 
 from builtins import object
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (
     HttpResponseForbidden,
     HttpResponsePermanentRedirect,

--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import cache
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
-from django.core.urlresolvers import get_urlconf, set_urlconf
+from django.urls.base import get_urlconf, set_urlconf
 from django.http import Http404, HttpResponseBadRequest
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import ugettext_lazy as _

--- a/readthedocs/gold/views.py
+++ b/readthedocs/gold/views.py
@@ -2,13 +2,17 @@
 """Gold subscription views."""
 
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.messages.views import SuccessMessageMixin
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.utils.translation import ugettext_lazy as _

--- a/readthedocs/integrations/admin.py
+++ b/readthedocs/integrations/admin.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 from django.contrib import admin
-from django.core import urlresolvers
+from django import urls
 from django.utils.safestring import mark_safe
 from pygments.formatters import HtmlFormatter
 
@@ -96,7 +96,7 @@ class IntegrationAdmin(admin.ModelAdmin):
         JSONField doesn't do well with fieldsets for whatever reason. This is
         just to link to the exchanges.
         """
-        url = urlresolvers.reverse('admin:{0}_{1}_changelist'.format(
+        url = urls.reverse('admin:{0}_{1}_changelist'.format(
             HttpExchange._meta.app_label,  # pylint: disable=protected-access
             HttpExchange._meta.model_name,  # pylint: disable=protected-access
         ))

--- a/readthedocs/oauth/models.py
+++ b/readthedocs/oauth/models.py
@@ -10,7 +10,7 @@ from builtins import object
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import URLValidator
 from django.db import models
 from django.db.models import Q

--- a/readthedocs/oauth/notifications.py
+++ b/readthedocs/oauth/notifications.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from messages_extends.constants import ERROR_PERSISTENT
 

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -7,7 +7,7 @@ import json
 import re
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from requests.exceptions import RequestException
 from allauth.socialaccount.providers.bitbucket_oauth2.views import (
     BitbucketOAuth2Adapter)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -7,7 +7,7 @@ import json
 import re
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from requests.exceptions import RequestException
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -9,7 +9,7 @@ import re
 
 from allauth.socialaccount.providers.gitlab.views import GitLabOAuth2Adapter
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from requests.exceptions import RequestException
 
 from readthedocs.builds.utils import get_gitlab_username_repo

--- a/readthedocs/profiles/views.py
+++ b/readthedocs/profiles/views.py
@@ -12,7 +12,7 @@ from django.contrib import messages
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext_lazy as _

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -11,7 +11,7 @@ from builtins import object  # pylint: disable=redefined-builtin
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -26,7 +26,7 @@ import requests
 from builtins import str
 from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _

--- a/readthedocs/projects/views/base.py
+++ b/readthedocs/projects/views/base.py
@@ -8,7 +8,7 @@ from builtins import object
 from datetime import timedelta
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils import timezone

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -16,7 +16,7 @@ from celery import chain
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (
     Http404,
     HttpResponseBadRequest,

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.cache import never_cache

--- a/readthedocs/restapi/views/task_views.py
+++ b/readthedocs/restapi/views/task_views.py
@@ -9,7 +9,7 @@ from __future__ import (
 
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from redis import ConnectionError
 from rest_framework import decorators, permissions
 from rest_framework.renderers import JSONRenderer

--- a/readthedocs/rtd_tests/tests/projects/test_admin_actions.py
+++ b/readthedocs/rtd_tests/tests/projects/test_admin_actions.py
@@ -2,7 +2,7 @@ import mock
 import django_dynamic_fixture as fixture
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.auth.models import User
-from django.core import urlresolvers
+from django import urls
 from django.test import TestCase
 
 from readthedocs.core.models import UserProfile
@@ -33,7 +33,7 @@ class ProjectAdminActionsTest(TestCase):
             'index': 0,
         }
         resp = self.client.post(
-            urlresolvers.reverse('admin:projects_project_changelist'),
+            urls.reverse('admin:projects_project_changelist'),
             action_data
         )
         self.assertTrue(self.project.users.filter(profile__banned=True).exists())
@@ -51,7 +51,7 @@ class ProjectAdminActionsTest(TestCase):
             'index': 0,
         }
         resp = self.client.post(
-            urlresolvers.reverse('admin:projects_project_changelist'),
+            urls.reverse('admin:projects_project_changelist'),
             action_data
         )
         self.assertFalse(self.project.users.filter(profile__banned=True).exists())
@@ -68,7 +68,7 @@ class ProjectAdminActionsTest(TestCase):
             'post': 'yes',
         }
         resp = self.client.post(
-            urlresolvers.reverse('admin:projects_project_changelist'),
+            urls.reverse('admin:projects_project_changelist'),
             action_data
         )
         self.assertFalse(Project.objects.filter(pk=self.project.pk).exists())

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -14,7 +14,7 @@ import mock
 from allauth.socialaccount.models import SocialAccount
 from builtins import str
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import QueryDict
 from django.test import TestCase
 from django.utils import six

--- a/readthedocs/rtd_tests/tests/test_gold.py
+++ b/readthedocs/rtd_tests/tests/test_gold.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
-from django.core.urlresolvers import reverse
+
+from django.urls import reverse
 from django.test import TestCase
 
 from django_dynamic_fixture import get, fixture

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from django.http import Http404
 from django.conf import settings
 from django.core.cache import cache
-from django.core.urlresolvers import get_urlconf, set_urlconf
+from django.urls.base import get_urlconf, set_urlconf
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -6,7 +6,7 @@ from allauth.socialaccount.models import SocialAccount
 from builtins import object
 from django.contrib.admindocs.views import extract_views_from_urlpatterns
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django_dynamic_fixture import get
 import mock
 from taggit.models import Tag

--- a/readthedocs/rtd_tests/tests/test_profile_views.py
+++ b/readthedocs/rtd_tests/tests/test_profile_views.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, unicode_literals
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django_dynamic_fixture import get
 

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -8,7 +8,7 @@ import tempfile
 
 import mock
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, override_settings
 from django_dynamic_fixture import get
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -6,7 +6,7 @@ from mock import patch
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.contrib.messages import constants as message_const
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http.response import HttpResponseRedirect
 from django.views.generic.base import ContextMixin
 from django.utils import timezone

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import json
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import pytest
 
 from readthedocs.builds.constants import BRANCH, STABLE, TAG

--- a/readthedocs/rtd_tests/tests/test_urls.py
+++ b/readthedocs/rtd_tests/tests/test_urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-from django.core.urlresolvers import reverse
-from django.core.urlresolvers import NoReverseMatch
+
+from django.urls import reverse, NoReverseMatch
 from django.test import TestCase
 
 

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -8,7 +8,7 @@ from __future__ import (
 
 import mock
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.utils.six.moves.urllib.parse import urlsplit
 from django_dynamic_fixture import get, new

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -2,7 +2,7 @@
 
 import pytest
 from django.core.management import call_command
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django_dynamic_fixture import G
 from pyquery import PyQuery as pq
 


### PR DESCRIPTION
**django.core.urlresolvers** module is deprecated in Django 1.10 ([Misc. updates of Django 1.10](https://docs.djangoproject.com/en/dev/releases/1.10/#id3)) and is completely removed in Django 2.0 ([Deprecation removed in 2.0](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-2-0)).

Also, I didn't find docs for **django.urls.base** but I have verified that **[get_urlconf()](https://github.com/django/django/blob/2ea1e0e58d3e0afffda4308a45e6c96693f3a7c9/django/urls/base.py#L143)** and **[set_urlconf()](https://github.com/django/django/blob/2ea1e0e58d3e0afffda4308a45e6c96693f3a7c9/django/urls/base.py#L131)** are present in **django.urls.base**