### PR TITLE
Only use remote branches for our syncing.

### DIFF
--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -16,6 +16,7 @@ class CommunityTestSettings(CommunityDevSettings):
 
     DEBUG = False
     TEMPLATE_DEBUG = False
+    LOCAL_GIT_BRANCHES = True
 
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -15,6 +15,7 @@ import re
 import git
 from builtins import str
 from django.core.exceptions import ValidationError
+from django.conf import settings
 from git.exc import BadName
 
 from readthedocs.config import ALL
@@ -182,6 +183,8 @@ class Backend(BaseVCS):
         # ``repo.remotes.origin.refs`` returns remote branches
         if repo.remotes:
             branches += repo.remotes.origin.refs
+        if getattr(settings, 'LOCAL_GIT_BRANCHES', False):
+            branches += repo.branches
 
         for branch in branches:
             verbose_name = branch.name

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -178,11 +178,8 @@ class Backend(BaseVCS):
         repo = git.Repo(self.working_dir)
         versions = []
 
-        # ``repo.branches`` returns local branches and
-        branches = repo.branches
         # ``repo.remotes.origin.refs`` returns remote branches
-        if repo.remotes:
-            branches += repo.remotes.origin.refs
+        branches = repo.remotes.origin.refs
 
         for branch in branches:
             verbose_name = branch.name

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -177,9 +177,11 @@ class Backend(BaseVCS):
     def branches(self):
         repo = git.Repo(self.working_dir)
         versions = []
+        branches = []
 
         # ``repo.remotes.origin.refs`` returns remote branches
-        branches = repo.remotes.origin.refs
+        if repo.remotes:
+            branches += repo.remotes.origin.refs
 
         for branch in branches:
             verbose_name = branch.name


### PR DESCRIPTION
We don't care about branches local to us.
This causes bugs where a local and remote branch have the same name,
and we sync `stable` in and endless loop.

Fixes #4980