### PR TITLE
Skip builds when project is not active

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -14,13 +14,13 @@ import logging
 from builtins import object
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.urls import reverse
 from django.http import (
     HttpResponseForbidden,
     HttpResponsePermanentRedirect,
     HttpResponseRedirect,
 )
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, ListView
 
@@ -28,6 +28,7 @@ from readthedocs.builds.models import Build, Version
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.utils import trigger_build
 from readthedocs.projects.models import Project
+
 
 log = logging.getLogger(__name__)
 

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -54,6 +54,24 @@ class ProjectQuerySetBase(models.QuerySet):
             return self._add_user_repos(queryset, user)
         return queryset
 
+    def is_active(self, project):
+        """
+        Check if the project is active.
+
+        The check consists on,
+          * the Project shouldn't be marked as skipped.
+
+        :param project: project to be checked
+        :type project: readthedocs.projects.models.Project
+
+        :returns: whether or not the project is active
+        :rtype: bool
+        """
+        if project.skip:
+            return False
+
+        return True
+
     # Aliases
 
     def dashboard(self, user=None):

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -1,4 +1,5 @@
-"""Project model QuerySet classes"""
+# -*- coding: utf-8 -*-
+"""Project model QuerySet classes."""
 
 from __future__ import absolute_import
 
@@ -6,8 +7,9 @@ from django.db import models
 from django.db.models import Q
 from guardian.shortcuts import get_objects_for_user
 
-from . import constants
 from readthedocs.core.utils.extend import SettingsOverrideObject
+
+from . import constants
 
 
 class ProjectQuerySetBase(models.QuerySet):

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -287,6 +287,9 @@ class ImportWizardView(ProjectSpamMixin, PrivateViewMixin, SessionWizardView):
     def trigger_initial_build(self, project):
         """Trigger initial build."""
         update_docs, build = prepare_build(project)
+        if (update_docs, build) == (None, None):
+            return None
+
         task_promise = chain(
             attach_webhook.si(project.pk, self.request.user.pk),
             update_docs,

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -16,7 +16,6 @@ from celery import chain
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django.urls import reverse
 from django.http import (
     Http404,
     HttpResponseBadRequest,
@@ -25,6 +24,7 @@ from django.http import (
 )
 from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import ListView, TemplateView, View

--- a/readthedocs/restapi/views/integrations.py
+++ b/readthedocs/restapi/views/integrations.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Endpoints integrating with Github, Bitbucket, and other webhooks."""
 
 from __future__ import (

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -862,6 +862,22 @@ class IntegrationsTests(TestCase):
             },
         }
 
+    def test_webhook_skipped_project(self, trigger_build):
+        client = APIClient()
+        self.project.skip = True
+        self.project.save()
+
+        response = client.post(
+            '/api/v2/webhook/github/{0}/'.format(
+                self.project.slug,
+            ),
+            self.github_payload,
+            format='json',
+        )
+        self.assertDictEqual(response.data, {'detail': 'This project is currently disabled'})
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertFalse(trigger_build.called)
+
     def test_github_webhook_for_branches(self, trigger_build):
         """GitHub webhook API."""
         client = APIClient()

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -19,6 +19,18 @@ class CoreUtilTests(TestCase):
         self.version = get(Version, project=self.project)
 
     @mock.patch('readthedocs.projects.tasks.update_docs_task')
+    def test_trigger_skipped_project(self, update_docs_task):
+        self.project.skip = True
+        self.project.save()
+        result = trigger_build(
+            project=self.project,
+            version=self.version,
+        )
+        self.assertEqual(result, (None, None))
+        self.assertFalse(update_docs_task.signature.called)
+        self.assertFalse(update_docs_task.signature().apply_async.called)
+
+    @mock.patch('readthedocs.projects.tasks.update_docs_task')
     def test_trigger_custom_queue(self, update_docs):
         """Use a custom queue when routing the task"""
         self.project.build_queue = 'build03'

--- a/readthedocs/rtd_tests/tests/test_project_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_project_querysets.py
@@ -30,6 +30,13 @@ class ProjectQuerySetTests(TestCase):
             'ManagerFromParentRelatedProjectQuerySetBase'
         )
 
+    def test_is_active(self):
+        project = fixture.get(Project, skip=False)
+        self.assertTrue(Project.objects.is_active(project))
+
+        project = fixture.get(Project, skip=True)
+        self.assertFalse(Project.objects.is_active(project))
+
 
 class FeatureQuerySetTests(TestCase):
 


### PR DESCRIPTION
Allow to make the check extensible from output by defining an `is_active` method in the QuerySet. Besides, returns a proper HTTP status code and message when the project is disabled and the build is triggered via a webhook.

Also, this commit fixes different places where the `None` returned when `project.skip` was failing.

Needed by https://github.com/rtfd/readthedocs-corporate/issues/154
Closes #4257 