### PR TITLE
Tweak sidebar ad priority

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -67,6 +67,9 @@ function create_sidebar_placement() {
         if (!offset || offset.top > $(window).height()) {
             // If this is off screen, lower the priority
             priority = constants.LOW_PROMO_PRIORITY;
+        } else if (bowser && !bowser.mobile) {
+            // If this isn't mobile, then the ad will be ATF, so raise the priority
+            priority = constants.MAXIMUM_PROMO_PRIORITY;
         }
 
         return {


### PR DESCRIPTION
This is a tweak to increase the sidebar ad priority (vs footer ad priority) if the sidebar isn't long. Essentially, this change will prioritize showing a sidebar ad if the sidebar ad would be visible.