### PR TITLE
CSRF exempt for WebhookView when authenticate via user/pass

### DIFF
--- a/readthedocs/restapi/authentication.py
+++ b/readthedocs/restapi/authentication.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from rest_framework.authentication import SessionAuthentication
+
+
+class CsrfExemptSessionAuthentication(SessionAuthentication):
+    """
+    Session authentication class exempt of CSRF.
+
+    DRF by default when using a ``SessionAuthentication`` it enforces CSRF.
+
+    See: https://github.com/encode/django-rest-framework/blob/3.9.0/rest_framework/authentication.py#L134-L144
+    """
+
+    def enforce_csrf(self, request):
+        return

--- a/readthedocs/restapi/authentication.py
+++ b/readthedocs/restapi/authentication.py
@@ -3,12 +3,13 @@ from rest_framework.authentication import SessionAuthentication
 
 
 class CsrfExemptSessionAuthentication(SessionAuthentication):
+
     """
     Session authentication class exempt of CSRF.
 
     DRF by default when using a ``SessionAuthentication`` it enforces CSRF.
 
-    See: https://github.com/encode/django-rest-framework/blob/3.9.0/rest_framework/authentication.py#L134-L144
+    See: https://github.com/encode/django-rest-framework/blob/3.9.0/rest_framework/authentication.py#L134-L144  # noqa
     """
 
     def enforce_csrf(self, request):


### PR DESCRIPTION
I think this bug was introduced at https://github.com/rtfd/readthedocs.org/commit/f95cae35bafbd8f7b80027199bf64e94e048dd70

Closes #4986