### PR TITLE
Keep command output when it's killed

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -3,10 +3,13 @@
 """Documentation Builder Environments."""
 
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import logging
-import json
 import os
 import re
 import socket
@@ -32,13 +35,28 @@ from readthedocs.projects.constants import LOG_TEMPLATE
 from readthedocs.restapi.client import api as api_v2
 
 from .constants import (
-    DOCKER_HOSTNAME_MAX_LEN, DOCKER_IMAGE, DOCKER_LIMITS, DOCKER_OOM_EXIT_CODE,
-    DOCKER_SOCKET, DOCKER_TIMEOUT_EXIT_CODE, DOCKER_VERSION,
-    MKDOCS_TEMPLATE_DIR, SPHINX_TEMPLATE_DIR)
+    DOCKER_HOSTNAME_MAX_LEN,
+    DOCKER_IMAGE,
+    DOCKER_LIMITS,
+    DOCKER_OOM_EXIT_CODE,
+    DOCKER_SOCKET,
+    DOCKER_TIMEOUT_EXIT_CODE,
+    DOCKER_VERSION,
+    MKDOCS_TEMPLATE_DIR,
+    SPHINX_TEMPLATE_DIR,
+)
 from .exceptions import (
-    BuildEnvironmentCreationFailed, BuildEnvironmentError,
-    BuildEnvironmentException, BuildEnvironmentWarning, BuildTimeoutError,
-    ProjectBuildsSkippedError, VersionLockedError, YAMLParseError, MkDocsYAMLParseError)
+    BuildEnvironmentCreationFailed,
+    BuildEnvironmentError,
+    BuildEnvironmentException,
+    BuildEnvironmentWarning,
+    BuildTimeoutError,
+    MkDocsYAMLParseError,
+    ProjectBuildsSkippedError,
+    VersionLockedError,
+    YAMLParseError,
+)
+
 
 log = logging.getLogger(__name__)
 
@@ -295,8 +313,9 @@ class DockerBuildCommand(BuildCommand):
             # is in the last 15 lines of the command's output
             killed_in_output = 'Killed' in '\n'.join(self.output.splitlines()[-15:])
             if self.exit_code == DOCKER_OOM_EXIT_CODE or (self.exit_code == 1 and killed_in_output):
-                self.output = _('Command killed due to excessive memory '
-                                'consumption\n')
+                self.output += str(_(
+                    'Command killed due to excessive memory consumption\n'
+                ))
         except DockerAPIError:
             self.exit_code = -1
             if self.output is None or not self.output:

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -314,7 +314,7 @@ class DockerBuildCommand(BuildCommand):
             killed_in_output = 'Killed' in '\n'.join(self.output.splitlines()[-15:])
             if self.exit_code == DOCKER_OOM_EXIT_CODE or (self.exit_code == 1 and killed_in_output):
                 self.output += str(_(
-                    'Command killed due to excessive memory consumption\n'
+                    '\n\nCommand killed due to excessive memory consumption\n'
                 ))
         except DockerAPIError:
             self.exit_code = -1

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -6,7 +6,11 @@ Things to know:
 * the Command wrappers encapsulate the bytes and expose unicode
 """
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import json
 import os
@@ -27,14 +31,18 @@ from readthedocs.builds.constants import BUILD_STATE_CLONING
 from readthedocs.builds.models import Version
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.environments import (
-    BuildCommand, DockerBuildCommand, DockerBuildEnvironment,
-    LocalBuildEnvironment)
+    BuildCommand,
+    DockerBuildCommand,
+    DockerBuildEnvironment,
+    LocalBuildEnvironment,
+)
 from readthedocs.doc_builder.exceptions import BuildEnvironmentError
 from readthedocs.doc_builder.python_environments import Conda, Virtualenv
 from readthedocs.projects.models import Project
 from readthedocs.rtd_tests.mocks.environment import EnvironmentMockGroup
 from readthedocs.rtd_tests.mocks.paths import fake_paths_lookup
 from readthedocs.rtd_tests.tests.test_config_integration import create_load
+
 
 DUMMY_BUILD_ID = 123
 SAMPLE_UNICODE = u'HérÉ îß sömê ünïçó∂é'
@@ -1127,9 +1135,10 @@ class TestDockerBuildCommand(TestCase):
         cmd.build_env.get_client.return_value = self.mocks.docker_client
         type(cmd.build_env).container_id = PropertyMock(return_value='foo')
         cmd.run()
-        self.assertEqual(
-            str(cmd.output),
-            u'Command killed due to excessive memory consumption\n')
+        self.assertIn(
+            'Command killed due to excessive memory consumption\n',
+            str(cmd.output)
+        )
 
 
 class TestPythonEnvironment(TestCase):


### PR DESCRIPTION
Closes #4957 

### Before

![screenshot_2018-12-18 read the docs read the docs](https://user-images.githubusercontent.com/4975310/50191346-7a18c000-02fb-11e9-95d2-0af203b767d1.png)

###  After

![screenshot_2018-12-18 read the docs read the docs 2](https://user-images.githubusercontent.com/4975310/50191363-91f04400-02fb-11e9-9d45-4e7d9099eaa4.png)


Need to point out that it took me some attempts to trigger the memory issue, so, in the last picture I wasn't able to capture the full output, but in some previous tests the output was bigger

![screenshot_2018-12-18 read the docs read the docs 1](https://user-images.githubusercontent.com/4975310/50191457-f7dccb80-02fb-11e9-92ae-a1111dbe8f3d.png)

