### PR TITLE
index project asynchronously

### DIFF
--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -21,6 +21,7 @@ class ProjectDocument(RTDDocTypeMixin, DocType):
     class Meta(object):
         model = Project
         fields = ('name', 'slug', 'description')
+        ignore_signals = settings.ES_PROJECT_IGNORE_SIGNALS
 
     url = fields.TextField(attr='get_absolute_url')
     users = fields.NestedField(properties={

--- a/readthedocs/search/signals.py
+++ b/readthedocs/search/signals.py
@@ -1,13 +1,14 @@
 """We define custom Django signals to trigger before executing searches."""
 from __future__ import absolute_import
 import django.dispatch
+from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django_elasticsearch_dsl.apps import DEDConfig
 from django_elasticsearch_dsl.registries import registry
 
-from readthedocs.projects.models import HTMLFile
+from readthedocs.projects.models import HTMLFile, Project
 from readthedocs.projects.signals import bulk_post_create, bulk_post_delete
-from readthedocs.search.documents import PageDocument
+from readthedocs.search.documents import PageDocument, ProjectDocument
 from readthedocs.search.tasks import index_objects_to_es
 
 before_project_search = django.dispatch.Signal(providing_args=["body"])
@@ -35,3 +36,25 @@ def remove_html_file(instance_list, **_):
     # Do not index if autosync is disabled globally
     if DEDConfig.autosync_enabled():
         registry.delete(instance_list)
+
+
+@receiver(post_save, sender=Project)
+def index_project(instance, *args, **kwargs):
+    kwargs = {
+        'app_label': Project._meta.app_label,
+        'model_name': Project.__name__,
+        'document_class': str(ProjectDocument),
+        'index_name': None,  # No need to change the index name
+        'objects_id': [instance.id],
+    }
+
+    # Do not index if autosync is disabled globally
+    if DEDConfig.autosync_enabled():
+        index_objects_to_es.delay(**kwargs)
+
+
+@receiver(pre_delete, sender=Project)
+def remove_project(instance, *args, **kwargs):
+    # Do not index if autosync is disabled globally
+    if DEDConfig.autosync_enabled():
+        registry.delete(instance)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -329,6 +329,7 @@ class CommunityBaseSettings(Settings):
     # Chunk size for elasticsearch reindex celery tasks
     ES_TASK_CHUNK_SIZE = 100
     ES_PAGE_IGNORE_SIGNALS = True
+    ES_PROJECT_IGNORE_SIGNALS = True
 
     # ANALYZER = 'analysis': {
     #     'analyzer': {

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -17,6 +17,7 @@ class CommunityTestSettings(CommunityDevSettings):
     DEBUG = False
     TEMPLATE_DEBUG = False
     ES_PAGE_IGNORE_SIGNALS = False
+    ES_PROJECT_IGNORE_SIGNALS = False
     ELASTICSEARCH_DSL_AUTOSYNC = False
     ELASTICSEARCH_DSL_AUTO_REFRESH = True
 


### PR DESCRIPTION
This will index the project asynchronously. So though the elasticsearch is not available, the project creation will work.