### PR TITLE
Convert an IRI path to URI before setting as NGINX header

### DIFF
--- a/readthedocs/rtd_tests/tests/test_doc_serving.py
+++ b/readthedocs/rtd_tests/tests/test_doc_serving.py
@@ -1,4 +1,6 @@
-from __future__ import absolute_import
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals, division, print_function
 import mock
 import django_dynamic_fixture as fixture
 
@@ -55,6 +57,16 @@ class TestPrivateDocs(BaseDocServing):
             self.assertEqual(r.status_code, 200)
             self.assertEqual(
                 r._headers['x-accel-redirect'][1], '/private_web_root/private/en/latest/usage.html'
+            )
+
+    @override_settings(PYTHON_MEDIA=False)
+    def test_private_nginx_serving_unicode_filename(self):
+        with mock.patch('readthedocs.core.views.serve.os.path.exists', return_value=True):
+            request = self.request(self.private_url, user=self.eric)
+            r = _serve_symlink_docs(request, project=self.private, filename='/en/latest/úñíčódé.html', privacy_level='private')
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(
+                r._headers['x-accel-redirect'][1], '/private_web_root/private/en/latest/%C3%BA%C3%B1%C3%AD%C4%8D%C3%B3d%C3%A9.html'
             )
 
     @override_settings(PYTHON_MEDIA=False)


### PR DESCRIPTION
Filepath can contains non-ASCII characters, so we need to convert to a valid URI before setting it as X-Accel-Redirec NGINX header because only ASCII characters are supported.

References,

* https://docs.djangoproject.com/en/1.11/ref/unicode/#uri-and-iri-handling
* https://github.com/benoitc/gunicorn/issues/1448

Closes https://github.com/rtfd/readthedocs-corporate/issues/409

> **NOTE**: I didn't test this locally because I don't have the setup needed (gunicorn + nginx) properly configured. So, we will need to be careful when deploying this into production.

One example of what this fixes is,

```
In [1]: from django.utils.encoding import iri_to_uri                                                                                                                                          

In [2]: iri_to_uri('camión.html')                                                                                                                                                             
Out[2]: 'cami%C3%B3n.html'
```