### PR TITLE
Add temporary method for disabling shallow cloning (#5031)

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1013,6 +1013,7 @@ class Feature(models.Model):
     DONT_OVERWRITE_SPHINX_CONTEXT = 'dont_overwrite_sphinx_context'
     ALLOW_V2_CONFIG_FILE = 'allow_v2_config_file'
     MKDOCS_THEME_RTD = 'mkdocs_theme_rtd'
+    DONT_SHALLOW_CLONE = 'dont_shallow_clone'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1021,10 +1022,12 @@ class Feature(models.Model):
         (PIP_ALWAYS_UPGRADE, _('Always run pip install --upgrade')),
         (SKIP_SUBMODULES, _('Skip git submodule checkout')),
         (DONT_OVERWRITE_SPHINX_CONTEXT, _(
-            'Do not overwrite context vars in conf.py with Read the Docs context',)),
+            'Do not overwrite context vars in conf.py with Read the Docs context')),
         (ALLOW_V2_CONFIG_FILE, _(
             'Allow to use the v2 of the configuration file')),
         (MKDOCS_THEME_RTD, _('Use Read the Docs theme for MkDocs as default theme')),
+        (DONT_SHALLOW_CLONE, _(
+            'Do not shallow clone when cloning git repos')),
     )
 
     projects = models.ManyToManyField(

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -149,13 +149,26 @@ class TestGitBackend(RTDTestCase):
         repo.update()
         repo.checkout('submodule')
         self.assertTrue(repo.are_submodules_available(self.dummy_conf))
-        feature = fixture.get(
+        fixture.get(
             Feature,
             projects=[self.project],
             feature_id=Feature.SKIP_SUBMODULES,
         )
         self.assertTrue(self.project.has_feature(Feature.SKIP_SUBMODULES))
         self.assertFalse(repo.are_submodules_available(self.dummy_conf))
+
+    def test_use_shallow_clone(self):
+        repo = self.project.vcs_repo()
+        repo.update()
+        repo.checkout('submodule')
+        self.assertTrue(repo.use_shallow_clone())
+        fixture.get(
+            Feature,
+            projects=[self.project],
+            feature_id=Feature.DONT_SHALLOW_CLONE,
+        )
+        self.assertTrue(self.project.has_feature(Feature.DONT_SHALLOW_CLONE))
+        self.assertFalse(repo.use_shallow_clone())
 
     def test_check_submodule_urls(self):
         repo = self.project.vcs_repo()

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -131,11 +131,26 @@ class Backend(BaseVCS):
                 return False, []
         return True, submodules.keys()
 
+    def use_shallow_clone(self):
+        """
+        Test whether shallow clone should be performed.
+
+        .. note::
+
+            Temporarily, we support skipping this option as builds that rely on
+            git history can fail if using shallow clones. This should
+            eventually be configurable via the web UI.
+        """
+        from readthedocs.projects.models import Feature
+        return not self.project.has_feature(Feature.DONT_SHALLOW_CLONE)
+
     def fetch(self):
-        code, stdout, stderr = self.run(
-            'git', 'fetch', '--depth', str(self.repo_depth),
-            '--tags', '--prune', '--prune-tags',
-        )
+        cmd = ['git', 'fetch', '--tags', '--prune', '--prune-tags']
+
+        if self.use_shallow_clone():
+            cmd.extend(['--depth', str(self.repo_depth)])
+
+        code, stdout, stderr = self.run(*cmd)
         if code != 0:
             raise RepositoryError
         return code, stdout, stderr
@@ -152,10 +167,14 @@ class Backend(BaseVCS):
 
     def clone(self):
         """Clones the repository."""
-        code, stdout, stderr = self.run(
-            'git', 'clone', '--depth', str(self.repo_depth),
-            '--no-single-branch', self.repo_url, '.'
-        )
+        cmd = ['git', 'clone', '--no-single-branch']
+
+        if self.use_shallow_clone():
+            cmd.extend(['--depth', str(self.repo_depth)])
+
+        cmd.extend([self.repo_url, '.'])
+
+        code, stdout, stderr = self.run(*cmd)
         if code != 0:
             raise RepositoryError
         return code, stdout, stderr


### PR DESCRIPTION
This adds a project feature that allows us to use a standard clone and
fetch rather than the shallow clone/fetch introduced in #4939.
Eventually we should move this to the web UI, but doing so requires some
work to make sure, for example, that git options are only show when
'Project.repo_type' is 'git'.

Closes #5031 