### PR TITLE
Clarify yaml config

### DIFF
--- a/docs/yaml-config.rst
+++ b/docs/yaml-config.rst
@@ -6,8 +6,8 @@ Read the Docs now has support for configuring builds with a YAML file.
 .. warning:: This feature is in a beta state.
              Please file an `issue`_ if you find anything wrong.
 
-The file must be in the root directory of your project, **not** in the `./docs` folder.
-and have the name ``readthedocs.yml`` or, if you prefer to have it be a dot file, ``.readthedocs.yml`` .
+The file should have the name ``readthedocs.yml`` or, if you prefer to have it be a dot file, ``.readthedocs.yml``. 
+It must be in the root directory of your project, **not** in the `./docs` folder.
 
 .. code:: none
 

--- a/docs/yaml-config.rst
+++ b/docs/yaml-config.rst
@@ -2,11 +2,21 @@ Read the Docs YAML Config
 =========================
 
 Read the Docs now has support for configuring builds with a YAML file.
-The file, ``readthedocs.yml``, must be in the root directory of your project.
 
 .. warning:: This feature is in a beta state.
              Please file an `issue`_ if you find anything wrong.
 
+The file must be in the root directory of your project, **not** in the `./docs` folder.
+and have the name ``readthedocs.yml`` or, if you prefer to have it be a dot file, ``.readthedocs.yml`` .
+
+.. code:: none
+
+    |-- your-project
+    |   |-- doc
+    |   |   |-- index.rst
+    |   |-- .readthedocs.yml
+    |   |-- .gitignore
+    |   |-- README.md
 
 Here is an example of what this file looks like:
 


### PR DESCRIPTION
Added language emphasizing that `readthedoc.yml` file has to be in the root of the project directory, and that both `readthedocs.yml` and `.readthedocs.yml` (dot file) are valid names.

I know this feature is still in beta, and so are the docs for it presumably, but neither of those things were quite obvious enough to me (possibly due to sleep deprivation). So thought I'd try to make them a little more obvious.