### PR TITLE
Fire a signal for domain verification (eg. for SSL)

### DIFF
--- a/readthedocs/projects/signals.py
+++ b/readthedocs/projects/signals.py
@@ -14,3 +14,6 @@ after_build = django.dispatch.Signal(providing_args=["version"])
 project_import = django.dispatch.Signal(providing_args=["project"])
 
 files_changed = django.dispatch.Signal(providing_args=["project", "files"])
+
+# Used to force verify a domain (eg. for SSL cert issuance)
+domain_verify = django.dispatch.Signal(providing_args=["domain"])

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1396,7 +1396,7 @@ def finish_inactive_builds():
     )
 
 
-@app.task
+@app.task(queue='web')
 def retry_domain_verification(domain_pk):
     """
     Trigger domain verification on a domain

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -79,6 +79,7 @@ from .signals import (
     before_build,
     before_vcs,
     files_changed,
+    domain_verify,
 )
 
 log = logging.getLogger(__name__)
@@ -1392,4 +1393,18 @@ def finish_inactive_builds():
     log.info(
         'Builds marked as "Terminated due inactivity": %s',
         builds_finished,
+    )
+
+
+@app.task
+def retry_domain_verification(domain_pk):
+    """
+    Trigger domain verification on a domain
+
+    :param domain_pk: a `Domain` pk to verify
+    """
+    domain = Domain.objects.get(pk=domain_pk)
+    domain_verify.send(
+        sender=domain.__class__,
+        domain=domain,
     )


### PR DESCRIPTION
We have had a few issues where domains have taken a long time to issue SSL certificates (example https://github.com/rtfd/readthedocs.org/issues/4736#issuecomment-450508657). Cloudflare -- who provides our SSL certs for custom domains -- automatically retries verification requests but they have an exponential backoff and then they stop retrying after a couple weeks. That means that if you add your domain to RTD and then don't fix your DNS for a day or two, it can take days to verify your domain. Users could of course remove the domain from RTD and re-add it but few people seem to do that.

This PR fires a task which fires signals which are handled in the cloudflare code (not in the readthedocs.org repo) to automatically retry verification whenever somebody visits the domain list screen (`/dashboard/<project_slug>/domains/`)