### PR TITLE
Install ProBot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,9 @@
+# ProBot TODO bot
+# https://probot.github.io/apps/todo/
+
+todo:
+  autoAssign: false
+  blobLines: 7
+  caseSensitive: true
+  keyword: "TODO"
+

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,16 @@
+# ProBot No Response Bot
+# https://probot.github.io/apps/no-response/
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+
+# Label requiring a response
+responseRequiredLabel: 'Needed: more information'
+
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further. Thanks!

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -9,8 +9,9 @@ responseRequiredLabel: 'Needed: more information'
 
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >
-  This issue has been automatically closed because there has been no response
-  to our request for more information from the original author. With only the
-  information that is currently in the issue, we don't have enough information
-  to take action. Please reach out if you have or find the answers we need so
-  that we can investigate further. Thanks!
+  This issue has been automatically closed because
+  [there has been no response to our request for more information](https://docs.readthedocs.io/en/latest/contribute.html#initial-triage)
+  from the original author. With only the information that is currently in the issue,
+  we don't have enough information to take action.
+  Please reach out if you have or find the answers we need so that we can investigate further.
+  Thanks!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,26 @@
+# ProBot Stale Bot
+# https://probot.github.io/apps/stale/
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 45
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - 'Accepted'
+  - 'Needed: design decision'
+  - 'Status: blocked'
+
+# Label to use when marking an issue as stale
+staleLabel: 'Status: stale'
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This PR adds config files for [Stale](https://probot.github.io/apps/stale/) and [No Response](https://probot.github.io/apps/no-response/) and [todo](https://probot.github.io/apps/todo/)

### Stale

This bot will

1. check for issues that has no activity for 45 days
1. post a comment communicating this issue is becoming stale
1. tag the issue as `Status: stale`

After 7 days the issue was tagged as `Status: stale` if there was no activity, it will be closed.

> NOTE: `Accepted`, `Needed: design decision` and `Status: blocked` are exempt of this flow. They won't be closed.

### No Response

This bot will

1. check for issues marked as `Needed: more information`
1. if the issue was tagged more than 14 days ago the bot will close it

### todo

This bot will create an issue every time that we push a `# TODO:` in our code with the message and the lines affected.

### Delete Merged Branch

https://probot.github.io/apps/delete-merged-branch/

This bot will just delete branches that are merged automatically.

### Reminders

https://probot.github.io/apps/reminders/

This bot will help us with issues for our [Abandoned Project Policy](https://docs.readthedocs.io/en/latest/abandoned-projects.html)

----

There are more bots that could help us to manage our repositories. 

* [Dep](https://probot.github.io/apps/dep/): block PRs to be merged if depends on another issue/pr. We need to create a proper label for this
* [Mergeable](https://probot.github.io/apps/mergeable/): block PRs to be merged based on customizable rules. We need to check these rules and make some decisions.
* [Top Issues](https://probot.github.io/apps/topissues/): label an issue as Top based on :+1:'s. This will help us to know which are the issues that users want more than others. We need to create a label for this one.

----

I think we can grow from here after we see how it works and how our flow is affected. At the moment I only request these bots to be installed in `rtfd/readthedocs.org` but I'd like if we can configure them in all of our repos, though.

Closes #4111 