### PR TITLE
Remove header nav (Login/Logout button) on 404 pages

### DIFF
--- a/readthedocs/templates/error_header.html
+++ b/readthedocs/templates/error_header.html
@@ -14,24 +14,6 @@
             </h1>
         </div>
         <!-- END header title -->
-
-
-        <!-- BEGIN header nav -->
-        <div class="rtfd-header-nav">
-          <ul>
-            {% if request.user.is_authenticated %}
-              <li>
-                <a href="//{{ PRODUCTION_DOMAIN }}/accounts/logout/">{% trans "Log Out" %}</a>
-              </li>
-            {% else %}
-              <li>
-                <a href="//{{ PRODUCTION_DOMAIN }}/accounts/login/">{% trans "Log in" %}</a>
-              </li>
-            {% endif %}
-          </ul>
-        </div>
-        <!-- END header nav -->
-
       </div>
     </div>
     <!-- END header-->


### PR DESCRIPTION
We are using the same 404.html template for 404 errors when serving documentation (.io) and also on our platform (.org).

The Login/Logout button only shows the proper word when the 404 page comes from .org, but it always says "Login" when we hit .io 404 pages.

As this is only confusing and there is not value added here, I'm removing it completely.