### PR TITLE
Show some useful links on 404 default page

### DIFF
--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -124,9 +124,31 @@ def server_error_404(request, exception=None, template_name='404.html'):  # pyli
             )
         else:
             return response
-    r = render(request, template_name)
+    r = render(request, template_name, context=_get_404_context(request))
     r.status_code = 404
     return r
+
+
+def _get_404_context(request):
+    from readthedocs.redirects.utils import project_and_path_from_request, language_and_version_from_path
+    project = None
+    language = None
+    version_slug = None
+
+    full_path = request.get_full_path()
+    project, path = project_and_path_from_request(request, full_path)
+    if project and not project.single_version:
+        language, version_slug, path = language_and_version_from_path(path)
+
+    context = {
+        'default_docs_url': project.get_docs_url(),
+        'version_docs_url': project.get_docs_url(
+            version_slug=version_slug,
+            lang_slug=language,
+        ),
+        'full_path': full_path,
+    }
+    return context
 
 
 def do_not_track(request):

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -150,6 +150,11 @@ def serve_docs(
         request, project, subproject, lang_slug=None, version_slug=None,
         filename=''):
     """Exists to map existing proj, lang, version, filename views to the file format."""
+
+    # TODO: remove this, it's only for debugging purposes
+    # from readthedocs.core.views import server_error_404
+    # return server_error_404(request)
+
     if not version_slug:
         version_slug = project.get_default_version()
     try:

--- a/readthedocs/templates/404.html
+++ b/readthedocs/templates/404.html
@@ -16,25 +16,20 @@
 {% block language-select-form %}{% endblock %}
 
 {% block content %}
-    {% if suggestion %}
-      <div class="suggestions">
-          <h1>You've found something that doesn't exist.</h1>
-          <p>{{ suggestion.message }}</p>
-          {% ifequal suggestion.type 'top' %}
-          <p>
-              <a href="{{ suggestion.href }}">Go to the top of the documentation.</a>
-          </p>
-          {% endifequal %}
-          {% ifequal suggestion.type 'list' %}
-          <ul>
-            {% for item in suggestion.list %}
-              <li><a href="{% doc_url item.project item.version_slug item.pagename %}">{{ item.label }}</a></li>
-            {% endfor %}
-          </ul>
-          {% endifequal %}
-      </div>
+
+  {% block 404_useful_links %}
+    {% if default_docs_url %}
+      Top site default documentation: {{ default_docs_url }} </br>
     {% endif %}
-<pre style="line-height: 1.25; white-space: pre;">
+    {% if version_docs_url %}
+      Version/Language site documentation: {{ version_docs_url }} </br>
+    {% endif %}
+    {% if full_path %}
+      The page requested is {{ full_path }}</br>
+    {% endif %}
+  {% endblock %}
+
+  <pre style="%; line-height: 1.25; white-space: pre;">
 
         \          SORRY            /
          \                         /
@@ -58,5 +53,5 @@
           /          N            \
          /           q,            \
         /                           \
-</pre>
+  </pre>
 {% endblock %}


### PR DESCRIPTION
> NOTE: this is a POC to discuss what we want to show on this page. **Do not merge** yet.

With these changes, I'm adding

* default site documentation (based on default version and language)
* the root of the current version and language
* the current page requested that produces the 404

I'd like to add some style to it and show a message similar to

> The page `/en/auto-wipe/notfound` you requested does not exist. You can access the full documentation at {{ default site docs }}.

This way, lost readers will be able to "stay on the project's docs" instead of need to manually manipulate the URL to remove some parts.

![captura de pantalla_2019-01-10_16-27-08](https://user-images.githubusercontent.com/244656/50978391-9a036400-14f4-11e9-8995-eb9a847c2e1c.png)


Closes #2551