### PR TITLE
Use python from virtualenv's bin directory when executing commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .DS_Store
 .cache
 .coverage
+.coverage.*
 .idea
 .vagrant
 .vscode
@@ -22,7 +23,7 @@ celerybeat-schedule.*
 deploy/.vagrant
 dist/*
 local_settings.py
-locks/*
+locks/**
 logs/*
 media/dash
 media/epub

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -77,8 +77,9 @@ class PythonEnvironment(object):
                     ','.join(self.config.python.extra_requirements)
                 )
             self.build_env.run(
-                'python',
-                self.venv_bin(filename='pip'),
+                self.venv_bin(filename='python'),
+                '-m',
+                'pip',
                 'install',
                 '--ignore-installed',
                 '--cache-dir',
@@ -89,7 +90,7 @@ class PythonEnvironment(object):
             )
         elif self.config.python.install_with_setup:
             self.build_env.run(
-                'python',
+                self.venv_bin(filename='python'),
                 'setup.py',
                 'install',
                 '--force',
@@ -229,8 +230,9 @@ class Virtualenv(PythonEnvironment):
     def install_core_requirements(self):
         """Install basic Read the Docs requirements into the virtualenv."""
         pip_install_cmd = [
-            'python',
-            self.venv_bin(filename='pip'),
+            self.venv_bin(filename='python'),
+            '-m',
+            'pip',
             'install',
             '--upgrade',
             '--cache-dir',
@@ -308,8 +310,9 @@ class Virtualenv(PythonEnvironment):
 
         if requirements_file_path:
             args = [
-                'python',
-                self.venv_bin(filename='pip'),
+                self.venv_bin(filename='python'),
+                '-m',
+                'pip',
                 'install',
             ]
             if self.project.has_feature(Feature.PIP_ALWAYS_UPGRADE):

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1166,8 +1166,9 @@ class TestPythonEnvironment(TestCase):
         ]
 
         self.pip_install_args = [
-            'python',
-            mock.ANY,  # pip path
+            mock.ANY,  # python path
+            '-m',
+            'pip',
             'install',
             '--upgrade',
             '--cache-dir',
@@ -1256,8 +1257,9 @@ class TestPythonEnvironment(TestCase):
             os.path.join(checkout_path, 'docs'): True,
         }
         args = [
-            'python',
-            mock.ANY,  # pip path
+            mock.ANY,  # python path
+            '-m',
+            'pip',
             'install',
             '--exists-action=w',
             '--cache-dir',


### PR DESCRIPTION
We are executing python commands like

`python /path/to/bin/command`

Sometimes it gives a non-deterministic behaviour.
Like using pip from the virtualenv in the first build
and using pip from the global installation other times.

Commands like sphinx-build and mkdocs have an `console_scripts` entry
point and shouldn't be a problem.

Now we are running the commands like `/path/to/bin/virtualenv/python -m pip install ...`, which gives a deterministic behaviour in every build.

I notice this problem while implementing https://github.com/rtfd/readthedocs.org/issues/5006.

When calling the `pyhton /path/to/pip list` command it gives an error (https://github.com/pypa/pip/issues/5373), and when calling `/path/to/pip list` it lists only the local packages, and in the second build `/path/to/pip list` list only the global packages. With this fix, `/path/to/python -m pip list` list global and local packages (in every build) as the docs say.

I'm not sure about conda, but I think we have a command that uses pip there. But first I'd like to have some opinions here. And maybe someone using rtd without docker can test this to make sure this doesn't break that workflow.