### PR TITLE
Feature flag to use `readthedocs/build:testing` image

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -729,15 +729,15 @@ class DockerBuildEnvironment(BuildEnvironment):
         )
 
         # Decide what Docker image to use, based on priorities:
-        # Use the Docker image set by user or,
-        if self.config and self.config.build.image:
-            self.container_image = self.config.build.image
-        # the image overridden by the project (manually set by an admin) or,
-        if self.project.container_image:
-            self.container_image = self.project.container_image
-        # ``testing`` image if the project has this feature flag
+        # Use the Docker image set by our feature flag: ``testing`` or,
         if self.project.has_feature(Feature.USE_TESTING_BUILD_IMAGE):
             self.container_image = 'readthedocs/build:testing'
+        # the image set by user or,
+        if self.config and self.config.build.image:
+            self.container_image = self.config.build.image
+        # the image overridden by the project (manually set by an admin).
+        if self.project.container_image:
+            self.container_image = self.project.container_image
 
         if self.project.container_mem_limit:
             self.container_mem_limit = self.project.container_mem_limit

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -32,6 +32,7 @@ from readthedocs.builds.constants import BUILD_STATE_FINISHED
 from readthedocs.builds.models import BuildCommandResultMixin
 from readthedocs.core.utils import slugify
 from readthedocs.projects.constants import LOG_TEMPLATE
+from readthedocs.projects.models import Feature
 from readthedocs.restapi.client import api as api_v2
 
 from .constants import (
@@ -726,10 +727,18 @@ class DockerBuildEnvironment(BuildEnvironment):
                 project_name=self.project.slug,
             )[:DOCKER_HOSTNAME_MAX_LEN],
         )
+
+        # Decide what Docker image to use, based on priorities:
+        # Use the Docker image set by user or,
         if self.config and self.config.build.image:
             self.container_image = self.config.build.image
+        # the image overridden by the project (manually set by an admin) or,
         if self.project.container_image:
             self.container_image = self.project.container_image
+        # ``testing`` image if the project has this feature flag
+        if self.project.has_feature(Feature.USE_TESTING_BUILD_IMAGE):
+            self.container_image = 'readthedocs/build:testing'
+
         if self.project.container_mem_limit:
             self.container_mem_limit = self.project.container_mem_limit
         if self.project.container_time_limit:

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1009,6 +1009,7 @@ class Feature(models.Model):
     ALLOW_V2_CONFIG_FILE = 'allow_v2_config_file'
     MKDOCS_THEME_RTD = 'mkdocs_theme_rtd'
     DONT_SHALLOW_CLONE = 'dont_shallow_clone'
+    USE_TESTING_BUILD_IMAGE = 'use_testing_build_image'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1023,6 +1024,8 @@ class Feature(models.Model):
         (MKDOCS_THEME_RTD, _('Use Read the Docs theme for MkDocs as default theme')),
         (DONT_SHALLOW_CLONE, _(
             'Do not shallow clone when cloning git repos')),
+        (USE_TESTING_BUILD_IMAGE, _(
+            'Use Docker image labelled as `testing` to build the docs')),
     )
 
     projects = models.ManyToManyField(


### PR DESCRIPTION
This is a new simple feature flag to allow us to put some projects under `readthedocs/build:testing` image so we can start testing `5.0rc1` in some sampled projects.

I decided to use `:testing` so now we can tag `5.0rc1` as `testing`

    docker tag readthedocs/build:5.0rc1 readthedocs/build:testing

and later (in months) we can re-tag it to `6.0rc1` for example just by running another docker command in the builders without modifying Python code.

I'd like to merge this soon and deploy it so we can start our new release process.

Closes #5106 