### PR TITLE
Remove dead code from config module

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -405,12 +405,6 @@ class BuildConfigV1(BuildConfigBase):
             self.env_config.update(
                 DOCKER_IMAGE_SETTINGS[build['image']]
             )
-        # Update docker settings from user config
-        if 'DOCKER_IMAGE_SETTINGS' in self.env_config and \
-                build['image'] in self.env_config['DOCKER_IMAGE_SETTINGS']:
-            self.env_config.update(
-                self.env_config['DOCKER_IMAGE_SETTINGS'][build['image']]
-            )
 
         # Allow to override specific project
         config_image = self.defaults.get('build_image')

--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -59,7 +59,6 @@ def load_yaml_config(version):
     img_settings = DOCKER_IMAGE_SETTINGS.get(img_name, None)
     if img_settings:
         env_config.update(img_settings)
-        env_config['DOCKER_IMAGE_SETTINGS'] = img_settings
 
     try:
         config = load_config(


### PR DESCRIPTION
`DOCKER_IMAGE_SETTINGS` has the same value as `env_config`.
It is used to update the python version supported for that image, but both have the same value, so it's redundant.

Related https://github.com/rtfd/readthedocs.org/pull/5056/files#r247609367