### PR TITLE
Logging exceptions rework

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -64,7 +64,7 @@ from readthedocs.vcs_support import utils as vcs_support_utils
 from readthedocs.worker import app
 
 from .constants import LOG_TEMPLATE
-from .exceptions import RepositoryError
+from .exceptions import ProjectConfigurationError, RepositoryError
 from .models import Domain, HTMLFile, ImportedFile, Project
 from .signals import (
     after_build,
@@ -327,7 +327,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             self.version = version
         self.project = {}
         if project is not None:
-        s    self.project = project
+            self.project = project
         if config is not None:
             self.config = config
         self.task = task

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -611,8 +611,6 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         Update the checkout of the repo to make sure it's the latest.
 
         This also syncs versions in the DB.
-
-        :param build_env: Build environment
         """
         self.setup_env.update_build(state=BUILD_STATE_CLONING)
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -266,8 +266,9 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin):
 
 
 # Exceptions under ``throws`` argument are considered ERROR from a Build
-# perspective but as a WARNING for the application itself. These exception are
-# logged as ``INFO`` and they are not sent to Sentry.
+# perspective (the build failed and can continue) but as a WARNING for the
+# application itself (RTD code didn't failed). These exception are logged as
+# ``INFO`` and they are not sent to Sentry.
 @app.task(
     bind=True,
     max_retries=5,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1044,7 +1044,7 @@ def symlink_project(project_pk):
         sym.run()
 
 
-@app.task(queue='web', throws=(BuildEnvironmentWarning,))
+@app.task(queue='web')
 def symlink_domain(project_pk, domain, delete=False):
     """
     Symlink domain.
@@ -1093,7 +1093,7 @@ def broadcast_remove_orphan_symlinks():
     broadcast(type='web', task=remove_orphan_symlinks, args=[])
 
 
-@app.task(queue='web', throws=(BuildEnvironmentWarning,))
+@app.task(queue='web')
 def symlink_subproject(project_pk):
     project = Project.objects.get(pk=project_pk)
     for symlink in [PublicSymlink, PrivateSymlink]:

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -52,6 +52,7 @@ from readthedocs.doc_builder.exceptions import (
     BuildEnvironmentError,
     BuildEnvironmentWarning,
     BuildTimeoutError,
+    MkDocsYAMLParseError,
     ProjectBuildsSkippedError,
     VersionLockedError,
     YAMLParseError,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -264,6 +264,9 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin):
         return False
 
 
+# Exceptions under ``throws`` argument are considered ERROR from a Build
+# perspective but as a WARNING for the application itself. These exception are
+# logged as ``INFO`` and they are not sent to Sentry.
 @app.task(
     bind=True,
     max_retries=5,
@@ -273,7 +276,11 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin):
         ProjectBuildsSkippedError,
         YAMLParseError,
         BuildTimeoutError,
+        BuildEnvironmentWarning,
+        RepositoryError,
+        ProjectConfigurationError,
         ProjectBuildsSkippedError,
+        MkDocsYAMLParseError,
     ),
 )
 def update_docs_task(self, project_id, *args, **kwargs):
@@ -320,7 +327,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             self.version = version
         self.project = {}
         if project is not None:
-            self.project = project
+        s    self.project = project
         if config is not None:
             self.config = config
         self.task = task


### PR DESCRIPTION
This PR,

- fixes the issue when calling `setup_vcs` and it raises an exception without stopping the build process
- removes `BuildEnvironmentWarning` from `Task.throws` argument in tasks that is not needed
- adds more "expected" exceptions for our `update_docs` tasks to not log them in Sentry as ERROR
- fixes a docstring
- applies `pre-commit`


Closes #5114 
Closes #3856 
Closes #4978 
Related #5073 
Related #5115 