### PR TITLE
Fix requirements for local installation

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -14,4 +14,3 @@ pylint-celery==0.3
 prospector==1.1.6.2
 # prospector 1.1.6.2 is not compatible with 2.0.0
 pyflakes<2.0.0
-Pygments==2.3.1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -29,6 +29,8 @@ requests-toolbelt==0.8.0
 slumber==0.7.1
 lxml==4.2.5
 defusedxml==0.5.0
+pyyaml==3.13
+Pygments==2.3.1
 
 # Basic tools
 # Redis 3.x has an incompatible change and fails


### PR DESCRIPTION
pip install -r requirements.txt on a clean installation
doesn't install all the requirements.

This wasn't detected by travis because we install from
requirements/testing.txt pyyaml was a dependency of yamale.