### PR TITLE
Remove codecov patch CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,4 +2,5 @@ comment: off
 coverage:
   status:
     project: off
+    patch: off
 


### PR DESCRIPTION
I think this effectively turns off codecov.

I think it's better than failing PR's because of coverage.
It discourages contributions and confuses people,
it also makes review harder when I see an X and I think tests are broken.

I'm up for suggestions on how to make codecov useful,
but it feels like a failed experiment at this point :(