### PR TITLE
Fix Sphinx conf.py inserts

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -13,7 +13,6 @@
 # https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
 #
 
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import importlib
 import sys
@@ -82,9 +81,9 @@ context = {
         ("{{ slug }}", "{{ url }}"),{% endfor %}
     ],
     'slug': '{{ project.slug }}',
-    'name': '{{ project.name }}',
-    'rtd_language': '{{ project.language }}',
-    'programming_language': '{{ project.programming_language }}',
+    'name': u'{{ project.name }}',
+    'rtd_language': u'{{ project.language }}',
+    'programming_language': u'{{ project.programming_language }}',
     'canonical_url': '{{ project.get_canonical_url }}',
     'analytics_code': '{{ project.analytics_code }}',
     'single_version': {{ project.single_version }},

--- a/readthedocs/rtd_tests/files/conf.py
+++ b/readthedocs/rtd_tests/files/conf.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division, print_function, unicode_literals
-
 from datetime import datetime
 
 from recommonmark.parser import CommonMarkParser
@@ -13,7 +12,7 @@ source_parsers = {
             '.md': CommonMarkParser,
         }
 master_doc = 'index'
-project = 'Pip'
+project = u'Pip'
 copyright = str(datetime.now().year)
 version = '0.8.1'
 release = '0.8.1'

--- a/readthedocs/rtd_tests/files/conf.py
+++ b/readthedocs/rtd_tests/files/conf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division, print_function, unicode_literals
+
 from datetime import datetime
 
 from recommonmark.parser import CommonMarkParser
@@ -23,5 +24,5 @@ html_theme = 'sphinx_rtd_theme'
 file_insertion_enabled = False
 latex_documents = [
   ('index', 'pip.tex', 'Pip Documentation',
-   '', 'manual'),
+   u'', 'manual'),
 ]

--- a/readthedocs/rtd_tests/files/conf.py
+++ b/readthedocs/rtd_tests/files/conf.py
@@ -23,6 +23,6 @@ htmlhelp_basename = 'pip'
 html_theme = 'sphinx_rtd_theme'
 file_insertion_enabled = False
 latex_documents = [
-  ('index', 'pip.tex', 'Pip Documentation',
+  ('index', 'pip.tex', u'Pip Documentation',
    u'', 'manual'),
 ]

--- a/readthedocs/templates/sphinx/conf.py.conf
+++ b/readthedocs/templates/sphinx/conf.py.conf
@@ -13,7 +13,7 @@ source_parsers = {
             '.md': CommonMarkParser,
         }
 master_doc = 'index'
-project = '{{ project.name }}'
+project = u'{{ project.name }}'
 copyright = str(datetime.now().year)
 version = '{{ version.verbose_name }}'
 release = '{{ version.verbose_name }}'
@@ -23,6 +23,6 @@ htmlhelp_basename = '{{ project.slug }}'
 html_theme = 'sphinx_rtd_theme'
 file_insertion_enabled = False
 latex_documents = [
-  ('index', '{{ project.slug }}.tex', '{{ project.name }} Documentation',
-   '{{ project.copyright }}', 'manual'),
+  ('index', '{{ project.slug }}.tex', u'{{ project.name }} Documentation',
+   u'{{ project.copyright }}', 'manual'),
 ]


### PR DESCRIPTION
These were breaking builds:

``ConfigError: There is a syntax error in your configuration file: from __future__ imports must occur at the beginning of the file (conf.py, line 45)``

These configs were working fine on Python 2 and 3 builds previously,
I don't think they need to be changed.

Reverts https://github.com/rtfd/readthedocs.org/commit/06b07cc6ffd3aa64ec84442e0821f4a9425b5ac4#diff-6a827604d651f579d03b359bbcd495e3R16

Fix #5148