### PR TITLE
SyntaxError caused by comma in python3

### DIFF
--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -59,7 +59,7 @@ def map_subproject_slug(view_func):
 
     @wraps(view_func)
     def inner_view(  # noqa
-            request, subproject=None, subproject_slug=None, *args, **kwargs,
+            request, subproject=None, subproject_slug=None, *args, **kwargs
     ):
         if subproject is None and subproject_slug:
             # Try to fetch by subproject alias first, otherwise we might end up


### PR DESCRIPTION
I was following the guide at  `https://docs.readthedocs.io/en/latest/custom_installs/local_rtd_vm.html`
It was failing on `./manage.py migrate` with `SyntaxError: invalid syntax on line 62`
Removing comma helped locally