### PR TITLE
Upgrade all packages removing py2 compatibility

### DIFF
--- a/readthedocs/restapi/views/model_views.py
+++ b/readthedocs/restapi/views/model_views.py
@@ -105,7 +105,6 @@ class ProjectViewSet(UserSelectViewSet):
     admin_serializer_class = ProjectAdminSerializer
     model = Project
     pagination_class = api_utils.ProjectPagination
-    filter_fields = ('slug',)  # django-filter<2.0.0
     filterset_fields = ('slug',)
 
     @decorators.action(detail=True)
@@ -250,10 +249,6 @@ class VersionViewSet(UserSelectViewSet):
     serializer_class = VersionSerializer
     admin_serializer_class = VersionAdminSerializer
     model = Version
-    filter_fields = (
-        'active',
-        'project__slug',
-    )  # django-filter<2.0.0
     filterset_fields = (
         'active',
         'project__slug',
@@ -266,7 +261,6 @@ class BuildViewSetBase(UserSelectViewSet):
     serializer_class = BuildSerializer
     admin_serializer_class = BuildAdminSerializer
     model = Build
-    filter_fields = ('project__slug', 'commit')  # django-filter<2.0.0
     filterset_fields = ('project__slug', 'commit')
 
 

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,6 +1,6 @@
 -r pip.txt
 # http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
-psycopg2==2.7.6.1 --no-binary psycopg2
+psycopg2==2.7.7 --no-binary psycopg2
 gunicorn==19.9.0
 django-redis-cache==1.8.1
 

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,8 +1,8 @@
 -r pip.txt
 # prospector 1.1.6.2 is not compatible with 2.1.0
-astroid<2.1.0
+astroid<=2.0.4
 # prospector 1.1.6.2 is not compatible with 2.2.2
-pylint<2.2.2
+pylint<=2.1.1
 pylint-django<2.0.5
 pylint-celery==0.3
 prospector==1.1.6.2

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,15 +1,9 @@
 -r pip.txt
-# We need these special cases of Python < 3 because we run tests with
-# Python 2 still
 # prospector 1.1.6.2 is not compatible with 2.1.0
-astroid==2.0.4; python_version > '3'
-astroid<1.7; python_version < '3'
+astroid<2.1.0
 # prospector 1.1.6.2 is not compatible with 2.2.2
-pylint==2.1.1; python_version > '3'
-pylint<2; python_version < '3'
-# prospector 1.1.6.2 is not compatible with 2.0.5
-pylint-django==2.0.2; python_version > '3'
-pylint-django<0.12; python_version < '3'
+pylint<2.2.2
+pylint-django<2.0.5
 pylint-celery==0.3
 prospector==1.1.6.2
 # prospector 1.1.6.2 is not compatible with 2.0.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,7 +1,7 @@
 # Base packages
-pip==18.1
+pip==19.0.1
 appdirs==1.4.3
-virtualenv==16.2.0
+virtualenv==16.3.0
 
 django==1.11.18
 django-tastypie==0.14.2
@@ -62,7 +62,7 @@ beautifulsoup4==4.7.1
 Unipath==1.1
 django-kombu==0.9.4
 mock==2.0.0
-stripe==2.18.0
+stripe==2.19.0
 
 django-formtools==2.1
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -51,8 +51,14 @@ GitPython==2.1.10
 
 # Search
 elasticsearch==6.2.0
+
+
+# elasticsearch-dsl==6.3.1 produces this error
+#   File "/home/travis/build/rtfd/readthedocs.org/.tox/py36/lib/python3.6/site-packages/django_elasticsearch_dsl/documents.py", line 8, in <module>
+#     from elasticsearch_dsl.document import DocTypeMeta as DSLDocTypeMeta
+# ImportError: cannot import name 'DocTypeMeta'
 elasticsearch-dsl==6.1.0
-django-elasticsearch-dsl==0.5.0
+django-elasticsearch-dsl==0.5.1
 pyquery==1.4.0
 
 # Utils

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -11,13 +11,7 @@ django-extensions==2.1.4
 djangorestframework==3.9.1
 
 # Filtering for the REST API
-# When Python2 gets deprecated we can upgrade django-filter
-# >   from .filterset import FilterSet
-# E     File "/home/travis/build/rtfd/readthedocs.org/.tox/py27/lib/python2.7/site-packages/django_filters/filterset.py", line 184
-# E       def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
-# E                                                     ^
-# E   SyntaxError: invalid syntax
-django-filter<2.0.0
+django-filter==2.1.0
 
 django-vanilla-views==1.0.6
 jsonfield==2.0.2


### PR DESCRIPTION
Upgrade all the packages, including (to note):

- [x] django-elasticsearch-dsl
- [x] django-filter

and removing py2 compatibility for linting.