### PR TITLE
Allow source_suffix to be a dictionary

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -27,8 +27,15 @@ from sphinx import version_info
 if globals().get('source_suffix', False):
     if isinstance(source_suffix, string_types):
         SUFFIX = source_suffix
-    else:
+    elif isinstance(source_suffix, (list, tuple)):
+        # Sphinx >= 1.3 supports list/tuple to define multiple suffixes
         SUFFIX = source_suffix[0]
+    elif isinstance(source_suffix, dict):
+        # Sphinx >= 1.8 supports a mapping dictionary for mulitple suffixes
+        SUFFIX = source_suffix.keys()[0]
+    else:
+        # default to .rst
+        SUFFIX = '.rst'
 else:
     SUFFIX = '.rst'
 


### PR DESCRIPTION
Sphinx >= 1.8 supports a dictionary for `source_suffix`:

https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-source_suffix

Once merged and deploy, this build should pass: https://readthedocs.org/projects/test-builds/builds/8459471/

I tested this locally and that project builds properly.