### PR TITLE
Use unicode-slugify to generate Version.slug

### DIFF
--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -83,7 +83,12 @@ class VersionSlugField(models.CharField):
 
     def _normalize(self, content):
         """
-        Normalize some invalid characters to become a dash (``-``).
+        Normalize some invalid characters (/, %, !, ?) to become a dash (``-``).
+
+        .. note::
+
+            We replace these characters to a dash to keep compatibility with the
+            old behavior and also because it makes this more readable.
 
         For example, ``release/1.0`` will become ``release-1.0``.
         """

--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -26,7 +26,7 @@ from operator import truediv
 
 from django.db import models
 from django.utils.encoding import force_text
-from slugify import slugify
+from slugify import slugify as unicode_slugify
 
 
 def get_fields_with_model(cls):
@@ -100,7 +100,7 @@ class VersionSlugField(models.CharField):
             return ''
 
         normalized = self._normalize(content)
-        slugified = slugify(
+        slugified = unicode_slugify(
             normalized,
             only_ascii=True,
             spaces=False,

--- a/readthedocs/rtd_tests/tests/test_version_slug.py
+++ b/readthedocs/rtd_tests/tests/test_version_slug.py
@@ -105,3 +105,15 @@ class VersionSlugFieldTests(TestCase):
         self.assertEqual(field.uniquifying_suffix(25), '_z')
         self.assertEqual(field.uniquifying_suffix(26), '_ba')
         self.assertEqual(field.uniquifying_suffix(52), '_ca')
+
+    def test_unicode(self):
+        version = Version.objects.create(
+            verbose_name='camión',
+            project=self.pip,
+        )
+        self.assertEqual(version.slug, 'camion')
+        version = Version.objects.create(
+            verbose_name='ŭñíč°də-branch',
+            project=self.pip,
+        )
+        self.assertEqual(version.slug, 'unicd-branch')

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -68,6 +68,9 @@ django-kombu==0.9.4
 mock==2.0.0
 stripe==2.19.0
 
+# unicode-slugify==0.1.5 is not released on PyPI yet
+git+https://github.com/mozilla/unicode-slugify@b696c37#egg=unicode-slugify
+
 django-formtools==2.1
 
 # docker is pinned to 3.1.3 because we found some strange behavior


### PR DESCRIPTION
Our regex were replacing "all invalid chars by `-`" which I think it's not a very good pattern because we ended up with slugs like `d-----branch---a` (multiple dashes together).

This implementation only replaces `/`, `%`, `!` and `?` with dashes to keep the behavior written in tests. I think that `/` is a good one to replace because it's a common way to separate words, but I'm not sold with the rest ones.

Besides, this PR uses `unicode-slugify` which work better with unicode project names using it's "best" ASCII representation.

Closes #1410 