### PR TITLE
Update project notification copy to past tense

### DIFF
--- a/readthedocs/templates/projects/notifications/deprecated_github_webhook_email.html
+++ b/readthedocs/templates/projects/notifications/deprecated_github_webhook_email.html
@@ -1,4 +1,4 @@
-<p>Your project, {{ project.name }}, is currently using GitHub Services to trigger builds on Read the Docs. Effective January 31, 2019, GitHub will no longer process requests using the Services feature, and so Read the Docs will not receive notifications on updates to your repository.</p>
+<p>Your project, {{ project.name }}, is still configured to use GitHub Services to trigger builds on Read the Docs. Effective January 31, 2019, GitHub stopped processing requests using the Services feature, and so Read the Docs no longer receives notifications on updates to your repository.</p>
 
 <p>To continue building your Read the Docs project on changes to your repository, you will need to add a new webhook on your GitHub repository. You can either connect your GitHub account and configure a GitHub webhook integration, or you can add a generic webhook integration.</p>
 

--- a/readthedocs/templates/projects/notifications/deprecated_github_webhook_site.html
+++ b/readthedocs/templates/projects/notifications/deprecated_github_webhook_site.html
@@ -1,1 +1,1 @@
-Your project, {{ project.name }}, needs to be reconfigured in order to continue building automatically after January 31st, 2019. For more information, <a href="https://docs.readthedocs.io/en/latest/webhooks.html#webhook-github-services">see our documentation on webhook integrations</a>.
+Your project, {{ project.name }}, needs to be reconfigured in order to build automatically on changes to your repository. For more information, <a href="https://docs.readthedocs.io/en/latest/webhooks.html#webhook-github-services">see our documentation on webhook integrations</a>.


### PR DESCRIPTION
Our next notification will be after the GitHub cutoff. We will continue
to look at projects in the feature flag to see which ones now have an
integration configured. Two more notification rounds is probably
warranted.