### PR TITLE
Remove approvals requirement from mergable

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -19,11 +19,6 @@ mergeable:
           # Do not allow empty descriptions on PR.
           enabled: true
           message: 'Description can not be empty.'
-# Removed because it causes every PR to fail
-#      - do: approvals
-#        min:
-#          count: 1
-#          message: 'The PR must have a minimum of 1 approvals.'
       - do: label
         # Do not allow PR with label 'PR: work in progress'
         must_exclude:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -19,6 +19,7 @@ mergeable:
           # Do not allow empty descriptions on PR.
           enabled: true
           message: 'Description can not be empty.'
+# Removed because it causes every PR to fail
 #      - do: approvals
 #        min:
 #          count: 1

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -19,10 +19,10 @@ mergeable:
           # Do not allow empty descriptions on PR.
           enabled: true
           message: 'Description can not be empty.'
-      - do: approvals
-        min:
-          count: 1
-          message: 'The PR must have a minimum of 1 approvals.'
+#      - do: approvals
+#        min:
+#          count: 1
+#          message: 'The PR must have a minimum of 1 approvals.'
       - do: label
         # Do not allow PR with label 'PR: work in progress'
         must_exclude:


### PR DESCRIPTION
This just causes every PR to fail, which is terrible UX.