### PR TITLE
Automate docs version from our setup.cfg

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ django.setup()
 def get_version():
     """Return package version from setup.cfg."""
     config = RawConfigParser()
-    config.read('../setup.cfg')
+    config.read(os.path.join('..', 'setup.cfg'))
     return config.get('metadata', 'version')
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function, unicode_literals
 
 import os
 import sys
+from configparser import RawConfigParser
 
 import sphinx_rtd_theme
 
@@ -16,6 +17,13 @@ from django.utils import timezone
 
 import django
 django.setup()
+
+
+def get_version():
+    """Return package version from setup.cfg."""
+    config = RawConfigParser()
+    config.read('../setup.cfg')
+    return config.get('metadata', 'version')
 
 
 sys.path.append(os.path.abspath('_ext'))
@@ -40,7 +48,7 @@ project = u'Read the Docs'
 copyright = '2010-{}, Read the Docs, Inc & contributors'.format(
     timezone.now().year
 )
-version = '2.7'
+version = get_version()
 release = version
 exclude_patterns = ['_build']
 default_role = 'obj'


### PR DESCRIPTION
Our docs version is out of date (2.7), so this moves towards automating
this version. The version is displayed in intersphinx links and in the
title of the page. I didn't use the `readthedocs.__init__` method to
avoid an import into our docs.