### PR TITLE
Don’t delay search delete on project delete

### DIFF
--- a/readthedocs/search/signals.py
+++ b/readthedocs/search/signals.py
@@ -73,6 +73,6 @@ def remove_project_delete(instance, *args, **kwargs):
         'objects_id': [instance.id],
     }
 
-    # Do not index if autosync is disabled globally
+    # Don't `delay` this because the objects will be deleted already
     if DEDConfig.autosync_enabled():
-        delete_objects_in_es.delay(**kwargs)
+        delete_objects_in_es(**kwargs)


### PR DESCRIPTION
This was causing an issue where we were trying to delete a project that didn’t exist, so it wasn’t getting removed from the index properly. It should be done in process, otherwise it’s a race condition.