### PR TITLE
Fix error of travis (rename migration file)

### DIFF
--- a/readthedocs/projects/migrations/0039_change-default-python-interpreter.py
+++ b/readthedocs/projects/migrations/0039_change-default-python-interpreter.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('projects', '0037_add_htmlfile'),
+        ('projects', '0038_update-doctype-helptext'),
     ]
 
     operations = [


### PR DESCRIPTION
This fixes the travis error which is due to conflicting names of migration files.