### PR TITLE
Allow extensions to control URL structure

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -59,6 +59,9 @@ class CommunityBaseSettings(Settings):
     CSRF_COOKIE_HTTPONLY = True
     CSRF_COOKIE_AGE = 30 * 24 * 60 * 60
 
+    # Read the Docs
+    READ_THE_DOCS_EXTENSIONS = ext
+
     # Application classes
     @property
     def INSTALLED_APPS(self):  # noqa

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -136,17 +136,11 @@ if settings.DO_NOT_TRACK_ENABLED:
     # Include Do Not Track URLs if DNT is supported
     groups.append(dnt_urls)
 
-if settings.USE_PROMOS:
-    # Include donation URL's
-    groups.append([
-        url(r'^sustainability/', include('readthedocsext.donate.urls')),
-    ])
 
-if 'readthedocsext.embed' in settings.INSTALLED_APPS:
-    api_urls.insert(
-        0,
-        url(r'^api/v1/embed/', include('readthedocsext.embed.urls')),
-    )
+if settings.READ_THE_DOCS_EXTENSIONS:
+    groups.append([
+        url(r'^', include('readthedocsext.urls'))
+    ])
 
 if not getattr(settings, 'USE_SUBDOMAIN', False) or settings.DEBUG:
     groups.insert(0, docs_urls)


### PR DESCRIPTION
- Adds a setting that can be checked if the RTD extensions are available
- If the extensions are available, they can control their own URL structure