### PR TITLE
Fix an issue where we were not properly filtering projects

### DIFF
--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -65,6 +65,10 @@ class PageSearchAPIView(generics.ListAPIView):
         kwargs = {'filter_by_user': False}
         kwargs['projects_list'] = [p.slug for p in self.get_all_projects()]
         kwargs['versions_list'] = self.request.query_params.get('version')
+        if not kwargs['projects_list']:
+            raise ValidationError("Unable to find a project to search")
+        if not kwargs['versions_list']:
+            raise ValidationError("Unable to find a version to search")
         user = self.request.user
         queryset = PageDocument.faceted_search(
             query=query, user=user, **kwargs

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -81,9 +81,9 @@ class PageDocument(DocType):
         }
 
         filters = {}
-        if projects_list:
+        if projects_list is not None:
             filters['project'] = projects_list
-        if versions_list:
+        if versions_list is not None:
             filters['version'] = versions_list
 
         kwargs['filters'] = filters

--- a/readthedocs/search/tests/test_api.py
+++ b/readthedocs/search/tests/test_api.py
@@ -60,7 +60,7 @@ class TestDocumentSearch(object):
         query = get_search_query_from_project_file(project_slug=project.slug)
         latest_version = project.versions.all()[0]
         # Create another version
-        dummy_version = G(Version, project=project)
+        dummy_version = G(Version, project=project, active=True)
         # Create HTMLFile same as the latest version
         latest_version_files = HTMLFile.objects.all().filter(version=latest_version)
         for f in latest_version_files:

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -20,9 +20,9 @@ def get_project_list_or_404(project_slug, user, version_slug=None):
     """
     Return list of project and its subprojects.
 
-    It filters by Version privacy instead of Project privacy.
+    It filters by Version privacy instead of Project privacy,
+    so we can support public versions on private projects.
     """
-    # Support private projects with public versions
     project_list = []
     main_project = get_object_or_404(Project, slug=project_slug)
     subprojects = Project.objects.filter(superprojects__parent_id=main_project.id)


### PR DESCRIPTION
There were some edge cases where the `public` queryset method on Project’s and Version’s could return an empty list. This lead to not properly filtering the queryset in the docsearch API. Properly raise an exception in this case, so that we don’t return search results that aren’t properly filtered.