### PR TITLE
Add basic auth to the generic webhook API.

### DIFF
--- a/readthedocs/restapi/views/integrations.py
+++ b/readthedocs/restapi/views/integrations.py
@@ -368,6 +368,8 @@ class APIWebhookView(WebhookMixin, APIView):
 
     integration_type = Integration.API_WEBHOOK
     permission_classes = [IsAuthenticatedOrHasToken]
+    # This is to support curl requests with a shared user across projects
+    # curl -X POST -d "branches=branch" -u user:pass -e URL /api/v2/webhook/test-builds/{pk}/
     authentication_classes = [BasicAuthentication]
 
     def get_project(self, **kwargs):

--- a/readthedocs/restapi/views/integrations.py
+++ b/readthedocs/restapi/views/integrations.py
@@ -8,6 +8,7 @@ import re
 
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions, status
+from rest_framework.authentication import BasicAuthentication
 from rest_framework.exceptions import NotFound, ParseError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -367,6 +368,7 @@ class APIWebhookView(WebhookMixin, APIView):
 
     integration_type = Integration.API_WEBHOOK
     permission_classes = [IsAuthenticatedOrHasToken]
+    authentication_classes = [BasicAuthentication]
 
     def get_project(self, **kwargs):
         """


### PR DESCRIPTION
Fix a bug we've had where:

* The `WebhookView` is doing Basic Auth on the user, and then setting it properly on the request
* The `APIWebhookView` then is doing Session Auth, and doing CSRF checks on it, because that requst has a valid user

A fix is to remove all the auth methods from the "parent" view,
which this PR does. 

* Replaces #5009
* Fixes #4986