### PR TITLE
Cleanup a little of documentation_type from footer

### DIFF
--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -95,13 +95,8 @@ def footer_html(request):
     main_project = project.main_language_project or project
 
     if page_slug and page_slug != 'index':
-        if (
-            main_project.documentation_type == 'sphinx_htmldir' or
-            main_project.documentation_type == 'mkdocs'
-        ):
+        if main_project.documentation_type == 'sphinx_htmldir':
             path = page_slug + '/'
-        elif main_project.documentation_type == 'sphinx_singlehtml':
-            path = 'index.html#document-' + page_slug
         else:
             path = page_slug + '.html'
     else:


### PR DESCRIPTION
This doesn't remove documentation_type completely from
the footer, but makes it more clear what we are really using.

We don't use `readthedocssinglehtml` as proven in https://github.com/rtfd/readthedocs-sphinx-ext/pull/58
We don't set `page` for mkdocs projects: https://github.com/rtfd/readthedocs.org/blob/f1c15d4f22af0ba7ebf762df1d49f7c28e8d01e5/readthedocs/doc_builder/backends/mkdocs.py#L207-L207

Ref #4638