### PR TITLE
Fix "clean_builds" command argument parsing

### DIFF
--- a/readthedocs/core/management/commands/clean_builds.py
+++ b/readthedocs/core/management/commands/clean_builds.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--days',
             dest='days',
-            type='int',
+            type=int,
             default=365,
             help='Find builds older than DAYS days, default: 365',
         )


### PR DESCRIPTION
Currently, the `clean_builds` command crashes with a "ValueError: 'int'
is not callable" exception.