### PR TITLE
Don't depend on specific data when catching exception

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -390,6 +390,9 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                     'stack': True,
                     'tags': {
                         'build': build_pk,
+                        # We can't depend on these objects because the api
+                        # could fail. But self.project and self.version are
+                        # initialized as empty dicts in the init method.
                         'project': self.project.slug if self.project else None,
                         'version': self.version.slug if self.version else None,
                     },

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -390,8 +390,8 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                     'stack': True,
                     'tags': {
                         'build': build_pk,
-                        'project': self.project.slug,
-                        'version': self.version.slug,
+                        'project': self.project.slug if self.project else None,
+                        'version': self.version.slug if self.version else None,
                     },
                 },
             )


### PR DESCRIPTION
We are catching all exceptions here,
but we are depending on self.project and self.version
be correctly returned from the api.
This doesn't always happen, and it's raising another error.

We should catch more specific errors, but we are not seeing those errors bc of this error (hope that makes sense :eyes: )

Sentry issue https://sentry.io/organizations/read-the-docs/issues/754905187/?project=148442&referrer=RegressionActivityEmail&statsPeriod=14d