### PR TITLE
Require conda.file when using conda in v1

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -489,15 +489,14 @@ class BuildConfigV1(BuildConfigBase):
             raw_conda = self.raw_config['conda']
             with self.catch_validation_error('conda'):
                 validate_dict(raw_conda)
-            conda_environment = None
-            if 'file' in raw_conda:
-                with self.catch_validation_error('conda.file'):
-                    conda_environment = validate_file(
-                        raw_conda['file'],
-                        self.base_path,
-                    )
-            conda['environment'] = conda_environment
-
+            with self.catch_validation_error('conda.file'):
+                if 'file' not in raw_conda:
+                    raise ValidationError('file', VALUE_NOT_FOUND)
+                conda_environment = validate_file(
+                    raw_conda['file'],
+                    self.base_path,
+                )
+                conda['environment'] = conda_environment
             return conda
         return None
 

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -557,18 +557,10 @@ class TestValidateBuild:
         assert build.build.image == image
 
 
-def test_use_conda_default_false():
+def test_use_conda_default_none():
     build = get_build_config({})
     build.validate()
     assert build.conda is None
-
-
-def test_use_conda_respects_config():
-    build = get_build_config(
-        {'conda': {}},
-    )
-    build.validate()
-    assert isinstance(build.conda, Conda)
 
 
 def test_validates_conda_file(tmpdir):

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -582,6 +582,18 @@ def test_validates_conda_file(tmpdir):
     assert build.conda.environment == str(tmpdir.join('environment.yml'))
 
 
+def test_file_is_required_when_using_conda(tmpdir):
+    apply_fs(tmpdir, {'environment.yml': ''})
+    build = get_build_config(
+        {'conda': {'foo': 'environment.yml'}},
+        source_file=str(tmpdir.join('readthedocs.yml')),
+    )
+    with raises(InvalidConfig) as excinfo:
+        build.validate()
+    assert excinfo.value.key == 'conda.file'
+    assert excinfo.value.code == VALUE_NOT_FOUND
+
+
 def test_requirements_file_empty():
     build = get_build_config({})
     build.validate()


### PR DESCRIPTION
Some people are migrating from pip to conda,
but they were using a v1 config,
then when migrating they are using the conda option from v2 (which is called `conda.environment`)

We are not validating this, but using conda.file is mandatory
when using the conda option in v1 (or rtd will fail without any reason).

Close #5322
Close #5228