### PR TITLE
improvement on inserting mkdocs media

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -140,15 +140,25 @@ class BaseMkdocs(BaseBuilder):
                     ),
                 )
 
-        user_config.setdefault('extra_javascript', []).extend([
+        extra_javascript_list = [
             'readthedocs-data.js',
             '%score/js/readthedocs-doc-embed.js' % static_url,
             '%sjavascript/readthedocs-analytics.js' % static_url,
-        ])
-        user_config.setdefault('extra_css', []).extend([
+        ]
+        extra_css_list = [
             '%scss/badge_only.css' % static_url,
             '%scss/readthedocs-doc-embed.css' % static_url,
-        ])
+        ]
+
+        # Only add static file if the files are not already in the list
+        user_config.setdefault('extra_javascript', []).extend(
+            [js for js in extra_javascript_list if js not in user_config.get(
+                'extra_javascript')]
+        )
+        user_config.setdefault('extra_css', []).extend(
+            [css for css in extra_css_list if css not in user_config.get(
+                'extra_css')]
+        )
 
         # The docs path is relative to the location
         # of the mkdocs configuration file.

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -279,7 +279,6 @@ class MkdocsBuilderTest(TestCase):
                 mock.ANY,
             )
 
-
     @patch('readthedocs.doc_builder.base.BaseBuilder.run')
     @patch('readthedocs.projects.models.Project.checkout_path')
     def test_append_conf_create_yaml(self, checkout_path, run):
@@ -420,7 +419,6 @@ class MkdocsBuilderTest(TestCase):
             with self.assertRaises(MkDocsYAMLParseError):
                 self.searchbuilder.append_conf()
 
-
     @patch('readthedocs.doc_builder.base.BaseBuilder.run')
     @patch('readthedocs.projects.models.Project.checkout_path')
     def test_dont_override_theme(self, checkout_path, run):
@@ -488,4 +486,55 @@ class MkdocsBuilderTest(TestCase):
         generate_rtd_data.assert_called_with(
             docs_dir='docs',
             mkdocs_config=mock.ANY,
+        )
+
+    @patch('readthedocs.doc_builder.base.BaseBuilder.run')
+    @patch('readthedocs.projects.models.Project.checkout_path')
+    def test_append_conf_existing_yaml_with_extra(self, checkout_path, run):
+        tmpdir = tempfile.mkdtemp()
+        os.mkdir(os.path.join(tmpdir, 'docs'))
+        yaml_file = os.path.join(tmpdir, 'mkdocs.yml')
+        yaml.safe_dump(
+            {
+                'site_name': 'mkdocs',
+                'google_analytics': ['UA-1234-5', 'mkdocs.org'],
+                'docs_dir': 'docs',
+                'extra_css': [
+                    'http://readthedocs.org/static/css/badge_only.css'
+                ],
+                'extra_javascript': ['readthedocs-data.js'],
+            },
+            open(yaml_file, 'w'),
+        )
+        checkout_path.return_value = tmpdir
+
+        python_env = Virtualenv(
+            version=self.version,
+            build_env=self.build_env,
+            config=None,
+        )
+        self.searchbuilder = MkdocsHTML(
+            build_env=self.build_env,
+            python_env=python_env,
+        )
+        self.searchbuilder.append_conf()
+
+        run.assert_called_with('cat', 'mkdocs.yml', cwd=mock.ANY)
+
+        config = yaml.safe_load(open(yaml_file))
+
+        self.assertEqual(
+            config['extra_css'],
+            [
+                'http://readthedocs.org/static/css/badge_only.css',
+                'http://readthedocs.org/static/css/readthedocs-doc-embed.css',
+            ],
+        )
+        self.assertEqual(
+            config['extra_javascript'],
+            [
+                'readthedocs-data.js',
+                'http://readthedocs.org/static/core/js/readthedocs-doc-embed.js',
+                'http://readthedocs.org/static/javascript/readthedocs-analytics.js',
+            ],
         )


### PR DESCRIPTION
This Code Improves the Insertion of media files on `mkdocs.py`. By adding this we wont end up inserting our media files twice, which can happen in some cases.
closes #5340 