### PR TITLE
Update GSOC page to mention we're accepted.

### DIFF
--- a/docs/gsoc.rst
+++ b/docs/gsoc.rst
@@ -49,6 +49,7 @@ Currently we have a few folks signed up:
 * Eric Holscher
 * Manuel Kaufmann
 * Anthony Johnson
+* Safwan Rahman
 
 .. warning:: Please do not reach out directly to anyone about the Summer of Code.
              It will **not** increase your chances of being accepted!

--- a/docs/gsoc.rst
+++ b/docs/gsoc.rst
@@ -1,13 +1,13 @@
 Google Summer of Code
 =====================
 
-.. 
-    .. note:: Thanks for your interest in Read the Docs!
-              We are working hard to update the ideas list now that we are accepted in GSOC.
-              Please give us a little while to work on things,
-              and check back on this page for updates.
+.. note:: Thanks for your interest in Read the Docs!
+          Please follow the instructions in `Getting Started`_,
+          as a good place to start.
+          **Contacting us will not increase your chance of being accepted,
+          but opening Pull Requests with docs and tests will.**
 
-Read the Docs is hoping to be in the Google Summer of Code in 2019.
+Read the Docs is excited to be in the Google Summer of Code in 2019.
 This page will contain all the information for students and anyone else interested in helping.
 
 Skills
@@ -26,18 +26,6 @@ We're happy to help you get up to speed,
 but the more you are able to demonstrate ability in advance,
 the more likely we are to choose your application! 
 
-Mentors
--------
-
-Currently we have a few folks signed up:
-
-* Eric Holscher
-* Manuel Kaufmann
-* Anthony Johnson
-
-.. warning:: Please do not reach out directly to anyone about the Summer of Code.
-             It will **not** increase your chances of being accepted!
-
 Getting Started
 ---------------
 
@@ -52,6 +40,18 @@ Want to get involved?
 ---------------------
 
 If you're interested in participating in GSoC as a student, you can apply during the normal process provided by Google. We are currently overwhelmed with interest, so we are not able to respond individually to each person who is interested.
+
+Mentors
+-------
+
+Currently we have a few folks signed up:
+
+* Eric Holscher
+* Manuel Kaufmann
+* Anthony Johnson
+
+.. warning:: Please do not reach out directly to anyone about the Summer of Code.
+             It will **not** increase your chances of being accepted!
 
 Project Ideas
 -------------


### PR DESCRIPTION
This also adds more of a callout about not emailing us.
Last year we got flooded with questions.