### PR TITLE
Fix search bug when an empty list of objects_id was passed

### DIFF
--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -14,7 +14,10 @@ def index_objects_to_es(
     app_label, model_name, document_class, index_name=None, chunk=None, objects_id=None
 ):
 
-    assert not (chunk and objects_id), "You can not pass both chunk and objects_id"
+    assert not (chunk and objects_id), \
+        "You can not pass both chunk and objects_id"
+    assert (chunk or objects_id), \
+        "You must pass a chunk or objects_id"
 
     model = apps.get_model(app_label, model_name)
     document = _get_document(model=model, document_class=document_class)


### PR DESCRIPTION
This makes it so we're explicitly checking for one being passed
so when an empty list is passed it fails.