### PR TITLE
Try to put back codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,4 +2,4 @@ comment: off
 coverage:
   status:
     project: off
-
+    patch: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 matrix:
   include:
     - python: 3.6
-      env: TOXENV=py36 ES_VERSION=6.2.4 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+      env: TOXENV=py36,codecov ES_VERSION=6.2.4 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     - python: 3.6
       env: TOXENV=docs
     - python: 3.6


### PR DESCRIPTION
I only want to keep this page updated https://codecov.io/gh/rtfd/readthedocs.org, not activate the PR checks :)