### PR TITLE
Start building with sphinx 1.8

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -302,7 +302,7 @@ class Virtualenv(PythonEnvironment):
             requirements.extend([
                 self.project.get_feature_value(
                     Feature.USE_SPHINX_LATEST,
-                    positive='sphinx<=2',
+                    positive='sphinx<2',
                     negative='sphinx<2',
                 ),
                 'sphinx-rtd-theme<0.5',

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -302,8 +302,8 @@ class Virtualenv(PythonEnvironment):
             requirements.extend([
                 self.project.get_feature_value(
                     Feature.USE_SPHINX_LATEST,
-                    positive='sphinx<2',
-                    negative='sphinx<1.8',
+                    positive='sphinx<=2',
+                    negative='sphinx<2',
                 ),
                 'sphinx-rtd-theme<0.5',
                 'readthedocs-sphinx-ext<0.6',


### PR DESCRIPTION
Currently we use sphinx 1.7,
we already have some projects building with 1.8 (with feature flag)
and with custom requirements.

We also have fixed/adapted some of our code to support the
new version.

I'm also updating the projects with a feature flag to use 2.0
when it's available.

Release history https://pypi.org/project/Sphinx/#history