### PR TITLE
Protect against anchors with #

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1280,7 +1280,11 @@ def _update_intersphinx_data(version, path, commit):
             # ('Sphinx', '1.7.9', 'faq.html#epub-faq', 'Epub info')
             url = einfo[2]
             if '#' in url:
-                doc_name, anchor = url.split('#')
+                doc_name, anchor = url.split(
+                    '#',
+                    # The anchor can contain ``#`` characters
+                    maxsplit=1
+                )
             else:
                 doc_name, anchor = url, ''
             display_name = einfo[3]


### PR DESCRIPTION
The anchor can contain `#` characters.
We only need to split from the first one.

Sentry issue https://sentry.io/organizations/read-the-docs/issues/910935991/?project=148442&referrer=alert_email&statsPeriod=14d

If we keep having this weird cases, we should consider using urlparser.
I'll try to write tests for this new feature soon.