### PR TITLE
Check for two paths for each file

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1185,6 +1185,7 @@ class HTMLFile(ImportedFile):
             'sections': [],
         }
 
+    @property
     def processed_json(self):
         return self.get_processed_json()
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -11,7 +11,6 @@ from django.contrib.auth.models import User
 from django.core.files.storage import get_storage_class
 from django.db import models
 from django.urls import NoReverseMatch, reverse
-from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 from guardian.shortcuts import assign
@@ -1143,7 +1142,6 @@ class HTMLFile(ImportedFile):
 
     objects = HTMLFileManager()
 
-
     def get_processed_json(self):
         """
         Get the parsed JSON for search indexing.
@@ -1151,7 +1149,7 @@ class HTMLFile(ImportedFile):
         Check for two paths for each index file
         This is because HTMLDir can generate a file from two different places:
 
-        * foo.rst 
+        * foo.rst
         * foo/index.rst
 
         Both lead to `foo/index.html`

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1146,8 +1146,9 @@ class HTMLFile(ImportedFile):
 
     def get_processed_json(self):
         """
-        Check for two paths for each file
+        Get the parsed JSON for search indexing.
 
+        Check for two paths for each index file
         This is because HTMLDir can generate a file from two different places:
 
         * foo.rst 
@@ -1166,7 +1167,6 @@ class HTMLFile(ImportedFile):
         full_json_path = self.project.get_production_media_path(
             type_='json', version_slug=self.version.slug, include_file=False
         )
-
         try:
             for path in paths:
                 file_path = os.path.join(full_json_path, path)


### PR DESCRIPTION
This is because HTMLDir can generate a file from two different places:

* foo.rst
* foo/index.rst

Both lead to `foo/index.html`

fixes https://github.com/rtfd/readthedocs.org/issues/5368