### PR TITLE
Make 'default_version` field as readonly if no active versions are found.

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -241,9 +241,13 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
         )
 
         active_versions = self.get_all_active_versions()
-        self.fields['default_version'].widget = forms.Select(
-            choices=active_versions,
-        )
+
+        if active_versions:
+            self.fields['default_version'].widget = forms.Select(
+                choices=active_versions,
+            )
+        else:
+            self.fields['default_version'].widget.attrs['readonly'] = True
 
     def clean_conf_py_file(self):
         filename = self.cleaned_data.get('conf_py_file', '').strip()
@@ -269,7 +273,7 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
             version_qs = sort_version_aware(version_qs)
             all_versions = [(version.slug, version.verbose_name) for version in version_qs]
             return all_versions
-        return [()]
+        return None
 
 
 class UpdateProjectForm(

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -270,6 +270,17 @@ class TestProjectAdvancedForm(TestCase):
             },
         )
 
+    def test_default_version_field_if_no_active_version(self):
+        project_1 = get(Project)
+        project_1.versions.filter(active=True).update(active=False)
+
+        # No active versions of project exists
+        self.assertFalse(project_1.versions.filter(active=True).exists())
+
+        form = ProjectAdvancedForm(instance=project_1)
+        self.assertTrue(form.fields['default_version'].widget.attrs['readonly'])
+        self.assertEqual(form.fields['default_version'].initial, 'latest')
+
 
 class TestTranslationForms(TestCase):
 


### PR DESCRIPTION
If there are no active versions of a project, an error is raised when `Advanced Settings` page is accessed.


![screenshot from 2019-02-28 22-06-55](https://user-images.githubusercontent.com/29149191/53582390-62847000-3ba5-11e9-9dd0-2feb4bc51c3b.png)


![screenshot from 2019-02-28 22-46-15](https://user-images.githubusercontent.com/29149191/53584882-a7f76c00-3baa-11e9-9544-c6de94885fe3.png)
