### PR TITLE
Improve project translation listing Design under admin tab

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -476,6 +476,9 @@ div.module.search-dashboard input {
     background-size: 24px 24px;
 }
 
+/* Admin project Translation */
+.module-translation { padding-bottom: 25px; }
+
 /* project bar */
 
 #project_bar { background: #E8ECEF url(../images/project-bar-bg.png) top left repeat; border-bottom: 1px solid #DAE1E5; overflow:hidden; position:relative; }

--- a/readthedocs/templates/projects/project_translations.html
+++ b/readthedocs/templates/projects/project_translations.html
@@ -33,18 +33,31 @@
       {% endblocktrans %}
     </a>
   {% else %}
-    {% if lang_projects %}
-      <h3> {% trans "Existing Translations" %} </h3>
-      <ul>
-        {% for lang_project in lang_projects %}
-          <li>
-            <a href="{{ lang_project.get_absolute_url }}">{{ lang_project.name }}</a>
-            ({{ lang_project.get_language_display }})
-            (<a href="{% url "projects_translations_delete" project.slug lang_project.slug  %}">{% trans "Remove" %}</a>)
-          </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
+    <h3> {% trans "Existing Translations" %} </h3>
+    <div class="module-translation">
+      <div class="module-list">
+        <div class="module-list-wrapper">
+          <ul>
+            {% for lang_project in lang_projects %}
+              <li class="module-item">
+                <a class="module-item-title" href="{{ lang_project.get_absolute_url }}">
+                  {{ lang_project.name }} ({{ lang_project.get_language_display }})
+                </a>
+                <ul class="module-item-menu">
+                  <li><a href="{% url "projects_translations_delete" project.slug lang_project.slug  %}">{% trans "Remove" %}</a></li>
+                </ul>
+              </li>
+            {% empty %}
+              <li class="module-item">
+                <p class="quiet">
+                  {% trans 'No translations are currently configured' %}
+                </p>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
     <p>
       {% trans "Choose which project you would like to add as a translation." %}
     </p>


### PR DESCRIPTION
This Improves the design of `Admin -> Translations` page.
closes #3708 
### _BEFORE_
![screenshot from 2019-03-01 14-07-34](https://user-images.githubusercontent.com/24854406/53624760-87232b00-3c2b-11e9-84cf-e78cd43d30ed.png)

### _AFTER_
![screenshot from 2019-03-01 13-58-19](https://user-images.githubusercontent.com/24854406/53624796-94d8b080-3c2b-11e9-8887-43457cbd6d4a.png)
----------------------------------
![screenshot from 2019-03-01 13-59-02](https://user-images.githubusercontent.com/24854406/53624808-9b672800-3c2b-11e9-8a1a-9c45e795219a.png)


