### PR TITLE
Fix pip installs

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -99,7 +99,7 @@ class PythonEnvironment:
                 '-m',
                 'pip',
                 'install',
-                '--ignore-installed',
+                '--force-reinstall',
                 '--cache-dir',
                 self.project.pip_cache_path,
                 '{path}{extra_requirements}'.format(


### PR DESCRIPTION
When readthedocs pip installs a previously installed core component the previous version doesn't get fully uninstalled. This is caused by the `--ignore-installed` flag and the results can be disastrous: https://stackoverflow.com/a/51916623