### PR TITLE
Remove view docs dropdown

### DIFF
--- a/readthedocs/templates/core/project_list_detailed.html
+++ b/readthedocs/templates/core/project_list_detailed.html
@@ -33,6 +33,7 @@
     <span class="dropdown" style="position:absolute; right:0px; top:0px;">
       <span>
           <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
+          <a href="#">&#x25B6;</a>
       </span>
     </span>
     {% else %}

--- a/readthedocs/templates/core/project_list_detailed.html
+++ b/readthedocs/templates/core/project_list_detailed.html
@@ -32,10 +32,10 @@
     <ul class="module-item-menu">
       <li>
         {% if project.has_good_build %}
-          <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}
-          {% else %}
-            <a href="{{ project.get_builds_url }}">{% trans "No Docs" %}</a>
-          {% endif %}
+          <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
+        {% else %}
+          <a href="{{ project.get_builds_url }}">{% trans "No Docs" %}</a>
+        {% endif %}
       </li>
     </ul>
 

--- a/readthedocs/templates/core/project_list_detailed.html
+++ b/readthedocs/templates/core/project_list_detailed.html
@@ -33,14 +33,7 @@
     <span class="dropdown" style="position:absolute; right:0px; top:0px;">
       <span>
           <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
-        <a href="#">&#x25BC;</a>
       </span>
-      <ul>
-          <li><input type="search" placeholder="{% trans "Search" %}&hellip;" /></li>
-          {% for version in project.ordered_active_versions reversed %}
-              <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
-          {% endfor %}
-      </ul>
     </span>
     {% else %}
     <ul class="module-item-menu">

--- a/readthedocs/templates/core/project_list_detailed.html
+++ b/readthedocs/templates/core/project_list_detailed.html
@@ -29,18 +29,15 @@
     <span class="right-menu quiet">{% trans "No builds" %}</span>
     {% endif %}
 
-    {% if project.has_good_build %}
-    <span class="dropdown" style="position:absolute; right:0px; top:0px;">
-      <span>
-          <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
-          <a href="#">&#x25B6;</a>
-      </span>
-    </span>
-    {% else %}
     <ul class="module-item-menu">
-      <li><a href="{{ project.get_builds_url }}">{% trans "No Docs" %}</a></li>
+      <li>
+        {% if project.has_good_build %}
+          <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}
+          {% else %}
+            <a href="{{ project.get_builds_url }}">{% trans "No Docs" %}</a>
+          {% endif %}
+      </li>
     </ul>
-    {% endif %}
 
 
   </li>

--- a/readthedocs/templates/core/project_list_featured.html
+++ b/readthedocs/templates/core/project_list_featured.html
@@ -7,18 +7,15 @@
         <a href="{{ user.get_absolute_url }}" class="quiet">({{ user }})</a>
     {% endfor %}
 
-    {% if project.has_good_build %}
-    <span class="dropdown" style="position:absolute; right:0px; top:0px;">
-      <span>
-          <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
-        <a href="#">&#x25B6;</a>
-      </span>
-    </span>
-    {% else %}
     <ul class="module-item-menu">
-      <li><a href="{{ project.get_builds_url }}">{% trans "No Docs" %}</a></li>
+      <li>
+        {% if project.has_good_build %}
+          <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
+        {% else %}
+          <a href="{{ project.get_builds_url }}">{% trans "No Docs" %}</a>
+        {% endif %}
+      </li>
     </ul>
-    {% endif %}
 
   </li>
 

--- a/readthedocs/templates/core/project_list_featured.html
+++ b/readthedocs/templates/core/project_list_featured.html
@@ -11,6 +11,7 @@
     <span class="dropdown" style="position:absolute; right:0px; top:0px;">
       <span>
           <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
+        <a href="#">&#x25B6;</a>
       </span>
     </span>
     {% else %}

--- a/readthedocs/templates/core/project_list_featured.html
+++ b/readthedocs/templates/core/project_list_featured.html
@@ -11,14 +11,7 @@
     <span class="dropdown" style="position:absolute; right:0px; top:0px;">
       <span>
           <a href="{{ project.get_docs_url }}">{% trans "View Docs" %}</a>
-        <a href="#">&#x25BC;</a>
       </span>
-      <ul>
-          <li><input type="search" placeholder="{% trans "Search" %}&hellip;" /></li>
-          {% for version in project.ordered_active_versions reversed %}
-              <li><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></li>
-          {% endfor %}
-      </ul>
     </span>
     {% else %}
     <ul class="module-item-menu">


### PR DESCRIPTION
I'll continue @ericholscher's work here

It looks like this

![screenshot_2019-03-05 anonymoususer s profile read the docs](https://user-images.githubusercontent.com/4975310/53841933-1a31cd00-3f6c-11e9-9586-a8debaf869de.png)
![screenshot_2019-03-05 home read the docs](https://user-images.githubusercontent.com/4975310/53841934-1b62fa00-3f6c-11e9-93b7-2bec1d6d30f5.png)
