### PR TITLE
Communicate the project slug can be changed by requesting it

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -21,6 +21,9 @@ You can delete and re-create the project with the proper name to get a new slug,
 but you really shouldn't do this if you have existing inbound links,
 as it `breaks the internet <http://www.w3.org/Provider/Style/URI.html>`_.
 
+If that isn't enough, you can ask to team to do this by `creating an issue <https://github.com/rtfd/readthedocs.org/issues/new>`__.
+
+
 How do I change the version slug of my project?
 -----------------------------------------------
 


### PR DESCRIPTION
We currently don't allow users to change the slug. Although, we accept requests for changing the slug of a version (which also breaks the Internet). So, we are following the same pattern for project slug that will affect the URL where the docs are served.

Requesting this by creating an issue does not guarantee that the project slug will be changed, though.