### PR TITLE
Clean arttifacts before and after builds

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -262,8 +262,8 @@ class HtmlBuilder(BaseSphinx):
     def clean(self, **__):
         super().clean()
         if os.path.exists(self.json_path):
-            shutil.rmtree(self.json_path)
             log.info('Removing old artifact path: %s', self.json_path)
+            shutil.rmtree(self.json_path)
 
 
 class HtmlDirBuilder(HtmlBuilder):

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -78,8 +78,8 @@ class BaseBuilder:
     def clean(self, **__):
         """Clean the path where documentation will be built."""
         if os.path.exists(self.old_artifact_path):
-            shutil.rmtree(self.old_artifact_path)
             log.info('Removing old artifact path: %s', self.old_artifact_path)
+            shutil.rmtree(self.old_artifact_path)
 
     def docs_dir(self, docs_dir=None, **__):
         """Handle creating a custom docs_dir if it doesn't exist."""

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -845,9 +845,11 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         if self.build_force:
             html_builder.force()
         html_builder.append_conf()
+        html_builder.clean()
         success = html_builder.build()
         if success:
             html_builder.move()
+        html_builder.clean()
 
         # Gracefully attempt to move files via task on web workers.
         try:
@@ -912,8 +914,10 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             self.build_env,
             python_env=self.python_env,
         )
+        builder.clean()
         success = builder.build()
         builder.move()
+        builder.clean()
         return success
 
     def send_notifications(self):


### PR DESCRIPTION
We were doing this for some builders like html and pdf, but not for all ot them.
We are going to save some space after this.

This doesn't affect the builders so much, due that we use several builders, not just one. So depending of the load balancer a user could be using an empty or new build.

A next step should be trying to remove the whole project after building, but this is first step to test how it goes.