### PR TITLE
Update docs for building with markdown

### DIFF
--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -96,13 +96,7 @@ Then in your ``conf.py``:
 
 .. code-block:: python
 
-    from recommonmark.parser import CommonMarkParser
-
-    source_parsers = {
-        '.md': CommonMarkParser,
-    }
-
-    source_suffix = ['.rst', '.md']
+   extensions = ['recommonmark']
 
 .. warning:: Markdown doesn't support a lot of the features of Sphinx,
           like inline markup and directives. However, it works for


### PR DESCRIPTION
We are installing the latest version of sphinx in the guide, we need to use this method to add markdown support

https://github.com/rtfd/recommonmark#getting-started