### PR TITLE
Update installation guide to include submodules

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,14 +30,14 @@ In order to get all the dependencies successfully installed,
 you need these libraries.
 
 .. tabs::
-   
+
    .. tab:: Mac OS
 
       If you are having trouble on OS X Mavericks
       (or possibly other versions of OS X) with building ``lxml``,
       you probably might need to use Homebrew_ to ``brew install libxml2``,
       and invoke the install with::
-      
+
           CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
           LDFLAGS=-L/usr/local/opt/libxml2/lib \
           pip install -r requirements.txt
@@ -51,7 +51,7 @@ you need these libraries.
          sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
 
       If you don't have redis installed yet, you can do it with::
-         
+
          sudo apt-get install redis-server
 
    .. tab:: CentOS/RHEL 7
@@ -79,7 +79,7 @@ Get and run Read the Docs
 
 Clone the repository somewhere on your disk and enter to the repository::
 
-    git clone https://github.com/rtfd/readthedocs.org.git
+    git clone --recurse-submodules https://github.com/rtfd/readthedocs.org.git
     cd readthedocs.org
 
 Create a virtual environment and activate it::
@@ -163,7 +163,7 @@ See our :doc:`/intro/import-guide` page to learn more.
 Further steps
 -------------
 
-By now you can trigger builds on your local environment, 
+By now you can trigger builds on your local environment,
 to encapsulate the build process inside a Docker container,
 see :doc:`development/buildenvironments`.
 


### PR DESCRIPTION
Fixes #5408 
The clone step in the installation guide is updated to include submodules.