### PR TITLE
Update version of setuptools

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -284,7 +284,7 @@ class Virtualenv(PythonEnvironment):
             self.project.get_feature_value(
                 Feature.USE_SETUPTOOLS_LATEST,
                 positive='setuptools<41',
-                negative='setuptools<40',
+                negative='setuptools<41',
             ),
             'docutils==0.13.1',
             'mock==1.0.1',


### PR DESCRIPTION
the 40.x releases has a lot of bugfixes and compatibility changes
to support the latest version of pip, which we install by default now.

Changelog https://setuptools.readthedocs.io/en/latest/history.html#v40-8-0

Closes #5436