### PR TITLE
Remove asserts from code.

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -175,7 +175,8 @@ class Version(models.Model):
             return self.identifier
 
         # By now we must have handled all special versions.
-        assert self.slug not in NON_REPOSITORY_VERSIONS
+        if self.slug in NON_REPOSITORY_VERSIONS:
+            raise Exception('All special versions must be handled by now.')
 
         if self.type in (BRANCH, TAG):
             # If this version is a branch or a tag, the verbose_name will

--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -196,9 +196,9 @@ class VersionSlugField(models.CharField):
             kwargs[self.attname] = slug
             count += 1
 
-        assert self.test_pattern.match(slug), (
-            'Invalid generated slug: {slug}'.format(slug=slug)
-        )
+        is_slug_valid = self.test_pattern.match(slug)
+        if not is_slug_valid:
+            raise Exception('Invalid generated slug: {slug}'.format(slug=slug))
         return slug
 
     def pre_save(self, model_instance, add):

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -18,6 +18,7 @@ from celery import group, chord
 
 from readthedocs.builds.constants import LATEST, BUILD_STATE_TRIGGERED
 from readthedocs.doc_builder.constants import DOCKER_LIMITS
+from readthedocs.projects.exceptions import InvalidParamsException
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +34,8 @@ def broadcast(type, task, args, kwargs=None, callback=None):  # pylint: disable=
     `callback` should be a task signature that will be run once,
     after all of the broadcast tasks have finished running.
     """
-    assert type in ['web', 'app', 'build']
+    if type not in ['web', 'app', 'build']:
+        raise InvalidParamsException('allowed value of `type` are web, app and build.')
     if kwargs is None:
         kwargs = {}
     default_queue = getattr(settings, 'CELERY_DEFAULT_QUEUE', 'celery')

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -106,7 +106,8 @@ class BuildCommand(BuildCommandResultMixin):
         self.cwd = cwd
         self.environment = os.environ.copy()
         if environment is not None:
-            assert 'PATH' not in environment, "PATH can't be set"
+            if 'PATH' in environment:
+                raise BuildEnvironmentError('\'PATH\' can\'t be set.')
             self.environment.update(environment)
 
         self.combine_output = combine_output
@@ -434,7 +435,8 @@ class BaseEnvironment:
         env_path = self.environment.pop('BIN_PATH', None)
         if 'bin_path' not in kwargs and env_path:
             kwargs['bin_path'] = env_path
-        assert 'environment' not in kwargs, "environment can't be passed in via commands."
+        if 'environment' in kwargs:
+            raise BuildEnvironmentError('environment can\'t be passed in via commands.')
         kwargs['environment'] = self.environment
 
         # ``build_env`` is passed as ``kwargs`` when it's called from a

--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -60,3 +60,10 @@ class ProjectSpamError(Exception):
     This error is not raised to users, we use this for banning users in the
     background.
     """
+
+
+class InvalidParamsException(Exception):
+
+    """Error raised when incorrect parameters are passed to a function/class."""
+
+    pass

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -67,7 +67,7 @@ from readthedocs.vcs_support import utils as vcs_support_utils
 from readthedocs.worker import app
 
 from .constants import LOG_TEMPLATE
-from .exceptions import ProjectConfigurationError, RepositoryError
+from .exceptions import ProjectConfigurationError, RepositoryError, InvalidParamsException
 from .models import Domain, HTMLFile, ImportedFile, Project
 from .signals import (
     after_build,
@@ -101,7 +101,8 @@ class SyncRepositoryMixin:
         :returns: a data-complete version object
         :rtype: builds.models.APIVersion
         """
-        assert (project or version_pk), 'project or version_pk is needed'
+        if not (project or version_pk):
+            raise InvalidParamsException('project or version_pk is needed')
         if version_pk:
             version_data = api_v2.version(version_pk).get()
         else:

--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django_elasticsearch_dsl.registries import registry
 
 from readthedocs.worker import app
+from readthedocs.projects.exceptions import InvalidParamsException
 from .utils import _get_index, _get_document
 
 log = logging.getLogger(__name__)
@@ -14,10 +15,11 @@ def index_objects_to_es(
     app_label, model_name, document_class, index_name=None, chunk=None, objects_id=None
 ):
 
-    assert not (chunk and objects_id), \
-        "You can not pass both chunk and objects_id"
-    assert (chunk or objects_id), \
-        "You must pass a chunk or objects_id"
+    if chunk and objects_id:
+        raise InvalidParamsException('You can not pass both chunk and objects_id.')
+
+    if not (chunk or objects_id):
+        raise InvalidParamsException('You must pass a chunk or objects_id.')
 
     model = apps.get_model(app_label, model_name)
     document = _get_document(model=model, document_class=document_class)


### PR DESCRIPTION
Closes #5433 

Following `grep` command was used to find the `assert` statements
```
grep -irn "assert" readthedocs.org/ --exclude-dir={user_builds,.tox,htmlcov,media,logs,static,rtd_tests,tests,docs,locale,templates} --exclude="*.pyc" --exclude="tests.py"
```