### PR TITLE
Regroup settings

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -208,24 +208,23 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
     class Meta:
         model = Project
         fields = (
-            # Standard build edits
+            # Global settings.
+            'default_version',
+            'default_branch',
+            'privacy_level',
+            'analytics_code',
+            'show_version_warning',
+            'single_version',
+
+            # Options that can be set per-version using a config file.
+            'documentation_type',
             'install_project',
             'requirements_file',
-            'single_version',
             'conf_py_file',
-            'default_branch',
-            'default_version',
-            'show_version_warning',
             'enable_pdf_build',
             'enable_epub_build',
-            # Privacy
-            'privacy_level',
-            # 'version_privacy_level',
-            # Python specific
             'use_system_packages',
             'python_interpreter',
-            # Fringe
-            'analytics_code',
         )
 
     def __init__(self, *args, **kwargs):
@@ -287,7 +286,6 @@ class UpdateProjectForm(
             'repo_type',
             # Extra
             'description',
-            'documentation_type',
             'language',
             'programming_language',
             'project_url',

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -219,12 +219,12 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
             # Options that can be set per-version using a config file.
             'documentation_type',
             'requirements_file',
+            'python_interpreter',
             'install_project',
             'use_system_packages',
             'conf_py_file',
             'enable_pdf_build',
             'enable_epub_build',
-            'python_interpreter',
         )
 
     def __init__(self, *args, **kwargs):

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -218,12 +218,12 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
 
             # Options that can be set per-version using a config file.
             'documentation_type',
-            'install_project',
             'requirements_file',
+            'install_project',
+            'use_system_packages',
             'conf_py_file',
             'enable_pdf_build',
             'enable_epub_build',
-            'use_system_packages',
             'python_interpreter',
         )
 

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -1214,6 +1214,7 @@ class TestPublicPrivateSymlink(TempSiteRootTestCase):
                 # Required defaults
                 'python_interpreter': 'python',
                 'default_version': 'latest',
+                'documentation_type': 'sphinx',
 
                 'privacy_level': 'private',
             },


### PR DESCRIPTION
This is an initial proposal for #5413 

This only affects the order of the current settings, we can create real groups modifying the template, using two forms or using https://django-crispy-forms.readthedocs.io/en/latest/layouts.html

For now, I would like to get reviewed the order/group of these options, and if someone has an opinion about the best way of having separate groups using the adobe suggestions.