### PR TITLE
Optimize the version list screen

### DIFF
--- a/readthedocs/core/permissions.py
+++ b/readthedocs/core/permissions.py
@@ -9,6 +9,8 @@ class AdminPermissionBase:
 
     @classmethod
     def is_admin(cls, user, project):
+        # This explicitly uses "user in project.users.all" so that
+        # users on projects can be cached using prefetch_related or prefetch_related_objects
         return user in project.users.all() or user.is_superuser
 
     @classmethod

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -272,7 +272,7 @@ def project_versions(request, project_slug):
     if wiped and wiped_version.count():
         messages.success(request, 'Version wiped: ' + wiped)
 
-    # Optimize for the future project permission checks
+    # Optimize project permission checks
     prefetch_related_objects([project], 'users')
 
     return render(

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -13,6 +13,7 @@ from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.files.storage import get_storage_class
+from django.db.models import prefetch_related_objects
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -270,6 +271,9 @@ def project_versions(request, project_slug):
     wiped_version = versions.filter(slug=wiped)
     if wiped and wiped_version.count():
         messages.success(request, 'Version wiped: ' + wiped)
+
+    # Optimize for the future project permission checks
+    prefetch_related_objects([project], 'users')
 
     return render(
         request,


### PR DESCRIPTION
This page was timing out due to permission checks `{% if request.user|is_admin:project %}` performed in a loop of all versions for a project with ~1k versions. That permission check was generating a database query per version (2 actually). This changes the view such that users for a project are cached and the permission check won't hit the database again.

Fixes #5458