### PR TITLE
Don't fetch the whole object when checking permissions

### DIFF
--- a/readthedocs/core/permissions.py
+++ b/readthedocs/core/permissions.py
@@ -9,11 +9,11 @@ class AdminPermissionBase:
 
     @classmethod
     def is_admin(cls, user, project):
-        return user in project.users.all() or user.is_superuser
+        return user.is_superuser or project.users.filter(pk=user.pk).exists()
 
     @classmethod
     def is_member(cls, user, obj):
-        return user in obj.users.all() or user.is_superuser
+        return user.is_superuser or obj.users.filter(pk=user.pk).exists()
 
 
 class AdminPermission(SettingsOverrideObject):


### PR DESCRIPTION
This also checks for is_superuser first

Kind of related to #5460