### PR TITLE
Enable Django Debug Toolbar in development

### DIFF
--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -59,6 +59,18 @@ class CommunityDevSettings(CommunityBaseSettings):
         logging['disable_existing_loggers'] = False
         return logging
 
+    @property
+    def INSTALLED_APPS(self):
+        apps = super().INSTALLED_APPS
+        apps.append('debug_toolbar')
+        return apps
+
+    @property
+    def MIDDLEWARE(self):
+        middlewares = list(super().MIDDLEWARE)
+        middlewares.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+        return middlewares
+
 
 CommunityDevSettings.load_settings(__name__)
 

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -133,6 +133,11 @@ if not getattr(settings, 'USE_SUBDOMAIN', False) or settings.DEBUG:
 if getattr(settings, 'ALLOW_ADMIN', True):
     groups.append(admin_urls)
 if getattr(settings, 'DEBUG', False):
+    import debug_toolbar
+
+    debug_urls += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]
     groups.append(debug_urls)
 
 urlpatterns = reduce(add, groups)

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -95,3 +95,6 @@ django-cors-middleware==1.3.1
 
 # User agent parsing - used for analytics purposes
 user-agents<1.2.0
+
+# Required only in development and linting
+django-debug-toolbar==1.11


### PR DESCRIPTION
In the past few days I have found a few performance issues that could have been caught easier with Django Debug Toolbar (#5451 and #5460). I propose we enable it in development.