### PR TITLE
Remove Haystack reference in Docs thus addressing issue #5462

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -60,7 +60,7 @@ When you build your project on RTD, we automatically build a PDF of your project
 Search
 ------
 
-We provide full-text search across all of the pages of documentation hosted on our site. This uses the excellent Haystack project and Elasticsearch as the search backend. We hope to be integrating this into the site more fully in the future.
+We provide full-text search across all of the pages of documentation hosted on our site. This uses Elasticsearch as the search backend. We hope to be integrating this into the site more fully in the future.
 
 Alternate Domains
 -----------------


### PR DESCRIPTION
Addressing issue #5462. Haystack in the docs can be confusing because it can be confusing. Since the dependency was removed a time ago #4039