### PR TITLE
    Fix bug that caused search objects not to delete

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1331,6 +1331,12 @@ def _manage_imported_files(version, path, commit):
     # Safely delete from database
     delete_queryset.delete()
 
+    # Delete ImportedFiles from previous versions
+    (
+        ImportedFile.objects.filter(project=version.project,
+                                    version=version).exclude(commit=commit
+                                                             ).delete()
+    )
     changed_files = [
         resolve_path(
             version.project,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1331,12 +1331,6 @@ def _manage_imported_files(version, path, commit):
     # Safely delete from database
     delete_queryset.delete()
 
-    # Delete ImportedFiles from previous versions
-    (
-        ImportedFile.objects.filter(project=version.project,
-                                    version=version).exclude(commit=commit
-                                                             ).delete()
-    )
     changed_files = [
         resolve_path(
             version.project,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1324,10 +1324,12 @@ def _manage_imported_files(version, path, commit):
     )
     # Keep the objects into memory to send it to signal
     instance_list = list(delete_queryset)
+    # Always pass the list of instance, not queryset.
+    # These objects must exist though,
+    # because the task will query the DB for the objects before deleting
+    bulk_post_delete.send(sender=HTMLFile, instance_list=instance_list)
     # Safely delete from database
     delete_queryset.delete()
-    # Always pass the list of instance, not queryset.
-    bulk_post_delete.send(sender=HTMLFile, instance_list=instance_list)
 
     # Delete ImportedFiles from previous versions
     (


### PR DESCRIPTION
The comment mostly explains it,
but the delete objects code does another query:

https://github.com/rtfd/readthedocs.org/blob/3340364802a8cdcc5f4145fbde2a5dd4f7087771/readthedocs/search/tasks.py#L59-L62

This should now fix search deletion.