### PR TITLE
Wrote a check to see if the yaml config returns a dict ot not

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -90,9 +90,9 @@ class BaseMkdocs(BaseBuilder):
         try:
             yaml_config = yaml.safe_load(open(self.yaml_file, 'r'),)
             if not isinstance(yaml_config, dict): 
-                raise ParseError('Expected dict') 
+                raise MkDocsYAMLParseError('Expected dict') 
             if not yaml_config: 
-                raise ParseError('Unable to load YAML config') 
+                raise MkDocsYAMLParseError('Unable to load YAML config') 
             return yaml_config
         except IOError:
             return {

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -87,7 +87,12 @@ class BaseMkdocs(BaseBuilder):
         :raises: ``MkDocsYAMLParseError`` if failed due to syntax errors.
         """
         try:
-            return yaml.safe_load(open(self.yaml_file, 'r'),)
+            yaml_config = yaml.safe_load(open(self.yaml_file, 'r'),)
+            if not isinstance(yaml_config, dict): 
+                raise ParseError('Expected dict') 
+            if not config: 
+                raise ParseError('Unable to load YAML config') 
+            return yaml_config
         except IOError:
             return {
                 'site_name': self.version.project.name,

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -16,7 +16,6 @@ from django.template import loader as template_loader
 from readthedocs.doc_builder.base import BaseBuilder
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.projects.models import Feature
-from readthedocs.config import ParseError
 
 
 log = logging.getLogger(__name__)

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -16,6 +16,7 @@ from django.template import loader as template_loader
 from readthedocs.doc_builder.base import BaseBuilder
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.projects.models import Feature
+from readthedocs.config import ParseError
 
 
 log = logging.getLogger(__name__)
@@ -90,7 +91,7 @@ class BaseMkdocs(BaseBuilder):
             yaml_config = yaml.safe_load(open(self.yaml_file, 'r'),)
             if not isinstance(yaml_config, dict): 
                 raise ParseError('Expected dict') 
-            if not config: 
+            if not yaml_config: 
                 raise ParseError('Unable to load YAML config') 
             return yaml_config
         except IOError:


### PR DESCRIPTION
the function load_yaml_config in readthedocs.org/readthedocs/doc_builder/backends/mkdocs.py always does not return a dict, and we expect a dict there #5481