### PR TITLE
Added note warning about using sqlite 3.26.0 in development

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,6 +11,12 @@ First, obtain `Python 3.6`_ and virtualenv_ if you do not already have them.
 Using a virtual environment is strongly recommended,
 since it will help you to avoid clutter in your system-wide libraries.
 
+.. note::
+
+    Currently the recommended version of python is Python 3.6.7. Which uses a 
+    lower version of sqlite3. The next version of Python can be used when the 
+    project starts using the latest Django version.
+
 Additionally Read the Docs depends on:
 
 * `Git`_ (version >=2.17.0)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,7 @@ First, obtain `Python 3.6`_ and virtualenv_ if you do not already have them.
 Using a virtual environment is strongly recommended,
 since it will help you to avoid clutter in your system-wide libraries.
 
-.. note::
+.. warning::
 
     Currently the recommended version of python is Python 3.6.7. Which uses a 
     lower version of sqlite3. The next version of Python can be used when the 


### PR DESCRIPTION
Added a note in the developer guide which asks the developer to use python version 3.6.7 instead of python 3.6.8 which would use a higher version of sqlite3 giving rise to issur #5477