### PR TITLE
Don't depend of enabled pdf/epub to show downloads 

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Models for the builds app."""
 
 import datetime
@@ -258,32 +256,25 @@ class Version(models.Model):
     def get_downloads(self, pretty=False):
         project = self.project
         data = {}
-        if pretty:
-            if project.has_pdf(self.slug):
-                data['PDF'] = project.get_production_media_url('pdf', self.slug)
-            if project.has_htmlzip(self.slug):
-                data['HTML'] = project.get_production_media_url(
-                    'htmlzip',
-                    self.slug,
-                )
-            if project.has_epub(self.slug):
-                data['Epub'] = project.get_production_media_url(
-                    'epub',
-                    self.slug,
-                )
-        else:
-            if project.has_pdf(self.slug):
-                data['pdf'] = project.get_production_media_url('pdf', self.slug)
-            if project.has_htmlzip(self.slug):
-                data['htmlzip'] = project.get_production_media_url(
-                    'htmlzip',
-                    self.slug,
-                )
-            if project.has_epub(self.slug):
-                data['epub'] = project.get_production_media_url(
-                    'epub',
-                    self.slug,
-                )
+
+        def prettify(k):
+            return k if pretty else k.lower()
+
+        if project.has_pdf(self.slug):
+            data[prettify('PDF')] = project.get_production_media_url(
+                'pdf',
+                self.slug,
+            )
+        if project.has_htmlzip(self.slug):
+            data[prettify('HTML')] = project.get_production_media_url(
+                'htmlzip',
+                self.slug,
+            )
+        if project.has_epub(self.slug):
+            data[prettify('Epub')] = project.get_production_media_url(
+                'epub',
+                self.slug,
+            )
         return data
 
     def get_conf_py_path(self):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -744,8 +744,6 @@ class Project(models.Model):
         return self.aliases.exists()
 
     def has_pdf(self, version_slug=LATEST):
-        if not self.enable_pdf_build:
-            return False
         path = self.get_production_media_path(
             type_='pdf', version_slug=version_slug
         )
@@ -755,8 +753,6 @@ class Project(models.Model):
         return os.path.exists(path) or storage.exists(storage_path)
 
     def has_epub(self, version_slug=LATEST):
-        if not self.enable_epub_build:
-            return False
         path = self.get_production_media_path(
             type_='epub', version_slug=version_slug
         )

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -60,10 +60,8 @@ class Testmaker(APITestCase):
             response = self.render()
         self.assertIn('pdf', response.data['html'])
 
-    def test_pdf_not_mentioned_in_footer_when_build_is_disabled(self):
-        self.pip.enable_pdf_build = False
-        self.pip.save()
-        with fake_paths_by_regex(r'\.pdf$'):
+    def test_pdf_not_mentioned_in_footer_when_doesnt_exists(self):
+        with fake_paths_by_regex(r'\.pdf$', exists=False):
             response = self.render()
         self.assertNotIn('pdf', response.data['html'])
 
@@ -72,10 +70,8 @@ class Testmaker(APITestCase):
             response = self.render()
         self.assertIn('epub', response.data['html'])
 
-    def test_epub_not_mentioned_in_footer_when_build_is_disabled(self):
-        self.pip.enable_epub_build = False
-        self.pip.save()
-        with fake_paths_by_regex(r'\.epub$'):
+    def test_epub_not_mentioned_in_footer_when_doesnt_exists(self):
+        with fake_paths_by_regex(r'\.epub$', exists=False):
             response = self.render()
         self.assertNotIn('epub', response.data['html'])
 

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -55,10 +55,10 @@ class TestProject(ProjectMixin, TestCase):
             self.assertFalse(self.pip.has_pdf(LATEST))
 
     def test_has_pdf_with_pdf_build_disabled(self):
-        # The project has NO pdf if pdf builds are disabled
+        # The project doesn't depend on `enable_pdf_build`
         self.pip.enable_pdf_build = False
         with fake_paths_by_regex(r'\.pdf$'):
-            self.assertFalse(self.pip.has_pdf(LATEST))
+            self.assertTrue(self.pip.has_pdf(LATEST))
 
     def test_has_epub(self):
         # The project has a epub if the PDF file exists on disk.
@@ -70,10 +70,10 @@ class TestProject(ProjectMixin, TestCase):
             self.assertFalse(self.pip.has_epub(LATEST))
 
     def test_has_epub_with_epub_build_disabled(self):
-        # The project has NO epub if epub builds are disabled
+        # The project doesn't depend on `enable_epub_build`
         self.pip.enable_epub_build = False
         with fake_paths_by_regex(r'\.epub$'):
-            self.assertFalse(self.pip.has_epub(LATEST))
+            self.assertTrue(self.pip.has_epub(LATEST))
 
     @patch('readthedocs.projects.models.Project.find')
     def test_conf_file_found(self, find_method):

--- a/readthedocs/templates/core/project_downloads.html
+++ b/readthedocs/templates/core/project_downloads.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% for version, dict in version_data.items %}
-  {% if dict.pdf and version.project.enable_pdf_build %}
+  {% if dict.pdf %}
   <li class="module-item col-span">
     <a class="module-item-title" href="{{ dict.pdf }}">
         {{ version.slug }} PDF
@@ -17,7 +17,7 @@
   </li>
   {% endif %}
 
-  {% if dict.epub and version.project.enable_epub_build %}
+  {% if dict.epub %}
   <li class="module-item col-span">
     <a class="module-item-title" href="{{ dict.epub }}">
         {{ version.slug }} Epub


### PR DESCRIPTION
Fixes #5497

We just need to rely if the epub/pdf exists, we already do this with the localmedia download.