### PR TITLE
Update mkdocs

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
-
 """
 MkDocs_ backend for building docs.
 
 .. _MkDocs: http://www.mkdocs.org/
 """
+
 import json
 import logging
 import os

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """An abstraction over virtualenv and Conda environments."""
 
 import copy
@@ -8,8 +6,6 @@ import json
 import logging
 import os
 import shutil
-
-from django.conf import settings
 
 from readthedocs.config import PIP, SETUPTOOLS
 from readthedocs.config.models import PythonInstall, PythonInstallRequirements
@@ -295,7 +291,7 @@ class Virtualenv(PythonEnvironment):
         ]
 
         if self.config.doctype == 'mkdocs':
-            requirements.append('mkdocs==0.17.3')
+            requirements.append('mkdocs<1.1')
         else:
             # We will assume semver here and only automate up to the next
             # backward incompatible release: 2.x

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -291,7 +291,13 @@ class Virtualenv(PythonEnvironment):
         ]
 
         if self.config.doctype == 'mkdocs':
-            requirements.append('mkdocs<1.1')
+            requirements.append(
+                self.project.get_feature_value(
+                    Feature.DEFAULT_TO_MKDOCS_0_17_3,
+                    positive='mkdocs==0.17.3',
+                    negative='mkdocs<1.1',
+                ),
+            )
         else:
             # We will assume semver here and only automate up to the next
             # backward incompatible release: 2.x

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1312,6 +1312,7 @@ class Feature(models.Model):
     USE_TESTING_BUILD_IMAGE = 'use_testing_build_image'
     SHARE_SPHINX_DOCTREE = 'share_sphinx_doctree'
     USE_PDF_LATEXMK = 'use_pdf_latexmk'
+    DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1345,6 +1346,10 @@ class Feature(models.Model):
         (
             SHARE_SPHINX_DOCTREE,
             _('Use shared directory for doctrees'),
+        ),
+        (
+            DEFAULT_TO_MKDOCS_0_17_3,
+            _('Install mkdocs 0.17.3 by default')
         ),
     )
 


### PR DESCRIPTION
Things I'm seeing so far:

- The edit/view link is wrong (with the current version actually)
- ~~Previous theme (readthedocs) isn't used~~
- The versions list is covered by the header of the mkdocs theme when there are a lot of versions (this is a problem with our z-index)

![Screenshot_2019-03-19 Writing Your Docs - MkDocs](https://user-images.githubusercontent.com/4975310/54644566-985f9a80-4a67-11e9-94a6-124657fdc432.png)

Closes #5332

1) ~~is a problem already present, we can fix that in another PR~~
2) ~~I think this is what we want, but I can deep a little more if we are correctly editing the mkdocs.yml file~~
3) ~~This is only present when the user has a lot of versions, we can fix it later or in another PR I think~~
