### PR TITLE
Link to the docdir of the remote repo in non-rtd themes for mkdocs

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -359,6 +359,7 @@ class Version(models.Model):
         repo = repo.rstrip('/')
 
         if not filename:
+            # If there isn't a filename, we don't need a suffix
             source_suffix = ''
 
         return GITHUB_URL.format(
@@ -399,6 +400,7 @@ class Version(models.Model):
         repo = repo.rstrip('/')
 
         if not filename:
+            # If there isn't a filename, we don't need a suffix
             source_suffix = ''
 
         return GITLAB_URL.format(
@@ -427,6 +429,7 @@ class Version(models.Model):
         repo = repo.rstrip('/')
 
         if not filename:
+            # If there isn't a filename, we don't need a suffix
             source_suffix = ''
 
         return BITBUCKET_URL.format(

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -345,10 +345,8 @@ class Version(models.Model):
         if not docroot:
             return ''
 
-        if docroot[0] != '/':
-            docroot = '/{}'.format(docroot)
-        if docroot[-1] != '/':
-            docroot = '{}/'.format(docroot)
+        # Normalize /docroot/
+        docroot = '/' + docroot.strip('/') + '/'
 
         if action == 'view':
             action_string = 'blob'
@@ -359,6 +357,10 @@ class Version(models.Model):
         if not user and not repo:
             return ''
         repo = repo.rstrip('/')
+
+        if not filename:
+            filename = ''
+            source_suffix = ''
 
         return GITHUB_URL.format(
             user=user,
@@ -384,10 +386,8 @@ class Version(models.Model):
         if not docroot:
             return ''
 
-        if docroot[0] != '/':
-            docroot = '/{}'.format(docroot)
-        if docroot[-1] != '/':
-            docroot = '{}/'.format(docroot)
+        # Normalize /docroot/
+        docroot = '/' + docroot.strip('/') + '/'
 
         if action == 'view':
             action_string = 'blob'
@@ -398,6 +398,10 @@ class Version(models.Model):
         if not user and not repo:
             return ''
         repo = repo.rstrip('/')
+
+        if not filename:
+            filename = ''
+            source_suffix = ''
 
         return GITLAB_URL.format(
             user=user,
@@ -416,10 +420,17 @@ class Version(models.Model):
         if not docroot:
             return ''
 
+        # Normalize /docroot/
+        docroot = '/' + docroot.strip('/') + '/'
+
         user, repo = get_bitbucket_username_repo(repo_url)
         if not user and not repo:
             return ''
         repo = repo.rstrip('/')
+
+        if not filename:
+            filename = ''
+            source_suffix = ''
 
         return BITBUCKET_URL.format(
             user=user,

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -359,7 +359,6 @@ class Version(models.Model):
         repo = repo.rstrip('/')
 
         if not filename:
-            filename = ''
             source_suffix = ''
 
         return GITHUB_URL.format(
@@ -400,7 +399,6 @@ class Version(models.Model):
         repo = repo.rstrip('/')
 
         if not filename:
-            filename = ''
             source_suffix = ''
 
         return GITLAB_URL.format(
@@ -429,7 +427,6 @@ class Version(models.Model):
         repo = repo.rstrip('/')
 
         if not filename:
-            filename = ''
             source_suffix = ''
 
         return BITBUCKET_URL.format(

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Endpoint to generate footer HTML."""
 
 from django.conf import settings
@@ -71,7 +69,7 @@ def footer_html(request):
     # pylint: disable=too-many-locals
     project_slug = request.GET.get('project', None)
     version_slug = request.GET.get('version', None)
-    page_slug = request.GET.get('page', None)
+    page_slug = request.GET.get('page') or ''
     theme = request.GET.get('theme', False)
     docroot = request.GET.get('docroot', '')
     subproject = request.GET.get('subproject', False)

--- a/readthedocs/restapi/views/footer_views.py
+++ b/readthedocs/restapi/views/footer_views.py
@@ -69,7 +69,7 @@ def footer_html(request):
     # pylint: disable=too-many-locals
     project_slug = request.GET.get('project', None)
     version_slug = request.GET.get('version', None)
-    page_slug = request.GET.get('page') or ''
+    page_slug = request.GET.get('page', '')
     theme = request.GET.get('theme', False)
     docroot = request.GET.get('docroot', '')
     subproject = request.GET.get('subproject', False)

--- a/readthedocs/rtd_tests/tests/test_repo_parsing.py
+++ b/readthedocs/rtd_tests/tests/test_repo_parsing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.test import TestCase
 
 from readthedocs.projects.models import Project
@@ -36,10 +35,6 @@ class TestRepoParsing(TestCase):
 
         self.pip.repo = 'https://github.com/user/repo/'
         self.assertEqual(
-            self.version.get_github_url(docroot='/docs/', filename=None),
-            'https://github.com/user/repo/blob/master/docs/',
-        )
-        self.assertEqual(
             self.version.get_github_url(docroot='/docs/', filename=''),
             'https://github.com/user/repo/blob/master/docs/',
         )
@@ -75,10 +70,6 @@ class TestRepoParsing(TestCase):
 
         self.pip.repo = 'https://gitlab.com/user/repo.git'
         self.assertEqual(
-            self.version.get_gitlab_url(docroot='/foo/bar/', filename=None),
-            'https://gitlab.com/user/repo/blob/master/foo/bar/',
-        )
-        self.assertEqual(
             self.version.get_gitlab_url(docroot='/foo/bar/', filename=''),
             'https://gitlab.com/user/repo/blob/master/foo/bar/',
         )
@@ -113,10 +104,6 @@ class TestRepoParsing(TestCase):
         self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git/src/master/foo/bar/file.rst')
 
         self.pip.repo = 'https://bitbucket.org/user/repo/'
-        self.assertEqual(
-            self.version.get_bitbucket_url(docroot='/foo/bar/', filename=None),
-            'https://bitbucket.org/user/repo/src/master/foo/bar/',
-        )
         self.assertEqual(
             self.version.get_bitbucket_url(docroot='/foo/bar/', filename=''),
             'https://bitbucket.org/user/repo/src/master/foo/bar/',

--- a/readthedocs/rtd_tests/tests/test_repo_parsing.py
+++ b/readthedocs/rtd_tests/tests/test_repo_parsing.py
@@ -34,6 +34,16 @@ class TestRepoParsing(TestCase):
         self.pip.repo = 'https://github.com/user/repo.git.git'
         self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo.git/blob/master/docs/file.rst')
 
+        self.pip.repo = 'https://github.com/user/repo/'
+        self.assertEqual(
+            self.version.get_github_url(docroot='/docs/', filename=None),
+            'https://github.com/user/repo/blob/master/docs/',
+        )
+        self.assertEqual(
+            self.version.get_github_url(docroot='/docs/', filename=''),
+            'https://github.com/user/repo/blob/master/docs/',
+        )
+
     def test_github_ssh(self):
         self.pip.repo = 'git@github.com:user/repo.git'
         self.assertEqual(self.version.get_github_url(docroot='/docs/', filename='file'), 'https://github.com/user/repo/blob/master/docs/file.rst')
@@ -63,6 +73,16 @@ class TestRepoParsing(TestCase):
         self.pip.repo = 'https://gitlab.com/user/repo.git.git'
         self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo.git/blob/master/foo/bar/file.rst')
 
+        self.pip.repo = 'https://gitlab.com/user/repo.git'
+        self.assertEqual(
+            self.version.get_gitlab_url(docroot='/foo/bar/', filename=None),
+            'https://gitlab.com/user/repo/blob/master/foo/bar/',
+        )
+        self.assertEqual(
+            self.version.get_gitlab_url(docroot='/foo/bar/', filename=''),
+            'https://gitlab.com/user/repo/blob/master/foo/bar/',
+        )
+
     def test_gitlab_ssh(self):
         self.pip.repo = 'git@gitlab.com:user/repo.git'
         self.assertEqual(self.version.get_gitlab_url(docroot='/foo/bar/', filename='file'), 'https://gitlab.com/user/repo/blob/master/foo/bar/file.rst')
@@ -91,6 +111,16 @@ class TestRepoParsing(TestCase):
 
         self.pip.repo = 'https://bitbucket.org/user/repo.git.git'
         self.assertEqual(self.version.get_bitbucket_url(docroot='/foo/bar/', filename='file'), 'https://bitbucket.org/user/repo.git/src/master/foo/bar/file.rst')
+
+        self.pip.repo = 'https://bitbucket.org/user/repo/'
+        self.assertEqual(
+            self.version.get_bitbucket_url(docroot='/foo/bar/', filename=None),
+            'https://bitbucket.org/user/repo/src/master/foo/bar/',
+        )
+        self.assertEqual(
+            self.version.get_bitbucket_url(docroot='/foo/bar/', filename=''),
+            'https://bitbucket.org/user/repo/src/master/foo/bar/',
+        )
 
     def test_bitbucket_https(self):
         self.pip.repo = 'https://user@bitbucket.org/user/repo.git'


### PR DESCRIPTION
Currently we depend on
https://github.com/mkdocs/mkdocs/blob/d101522aa197aaa212f1424180d693dd5d497875/mkdocs/themes/readthedocs/base.html#L35-L40
which is only available in the rtd theme.

For non-rtd themes we are generating a link like `https://github.com/mkdocs/mkdocs/blob/master/docs/.md`

I'm proposing the solution of just linking to the docsdir `https://github.com/mkdocs/mkdocs/blob/master/docs/`

Another option is just to link to the repo, and only show the `view on` link :)

What do you think?

Also, looks like we can refactor this code, let me know if you feel like something that can be done here or we can create an issue later.