### PR TITLE
Guide users to the YAML config from the build detail page

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -16,6 +16,7 @@ from guardian.shortcuts import assign
 from jsonfield import JSONField
 from taggit.managers import TaggableManager
 
+from readthedocs.config import LATEST_CONFIGURATION_VERSION
 from readthedocs.core.utils import broadcast
 from readthedocs.projects.constants import (
     BITBUCKET_URL,
@@ -639,6 +640,9 @@ class Build(models.Model):
         """Return if build state is triggered & date more than 5m ago."""
         mins_ago = timezone.now() - datetime.timedelta(minutes=5)
         return self.state == BUILD_STATE_TRIGGERED and self.date < mins_ago
+
+    def using_latest_config(self):
+        return int(self.config.get('version', '1')) == LATEST_CONFIGURATION_VERSION
 
 
 class BuildCommandResultMixin:

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -48,6 +48,7 @@ __all__ = (
     'InvalidConfig',
     'PIP',
     'SETUPTOOLS',
+    'LATEST_CONFIGURATION_VERSION',
 )
 
 ALL = 'all'
@@ -77,6 +78,8 @@ DOCKER_IMAGE = getattr(
     '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION),
 )
 DOCKER_IMAGE_SETTINGS = getattr(settings, 'DOCKER_IMAGE_SETTINGS', {})
+
+LATEST_CONFIGURATION_VERSION = 2
 
 
 class ConfigError(Exception):

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -562,3 +562,21 @@ class BuildModelTests(TestCase):
         self.assertFalse(build_one.is_stale)
         self.assertTrue(build_two.is_stale)
         self.assertFalse(build_three.is_stale)
+
+    def test_using_latest_config(self):
+        now = timezone.now()
+
+        build = get(
+            Build,
+            project=self.project,
+            version=self.version,
+            date=now - datetime.timedelta(minutes=8),
+            state='finished',
+        )
+
+        self.assertFalse(build.using_latest_config())
+
+        build.config = {'version': 2}
+        build.save()
+
+        self.assertTrue(build.using_latest_config())

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -142,7 +142,7 @@ $(document).ready(function () {
               <strong>Configure your documentation builds!</strong>
               Adding a <a href="{{ config_file_link }}">.readthedocs.yml</a> file to your project
               is the recommended way to configure your documentation builds.
-              You can declare dependencies, set up submodules, build for different output formats, and many other great features.
+              You can declare dependencies, set up submodules, and many other great features.
             {% endblocktrans %}
           </p>
         </div>

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -135,6 +135,18 @@ $(document).ready(function () {
           </p>
         </div>
       {% endif %}
+      {% if build.finished and not build.using_latest_config %}
+        <div class="build-ideas">
+          <p>
+            {% blocktrans trimmed with config_file_link="https://docs.readthedocs.io/page/config-file/v2.html" %}
+              <strong>Configure your documentation builds!</strong>
+              Adding a <a href="{{ config_file_link }}">.readthedocs.yml</a> file to your project
+              is the recommended way to configure your documentation builds.
+              You can declare dependencies, set up submodules, build for different output formats, and many other great features.
+            {% endblocktrans %}
+          </p>
+        </div>
+      {% endif %}
     {% endif %}
 
     {% if build.output %}


### PR DESCRIPTION
Add a "build idea" to the build detail screen (only for project maintainers) to guide them to using the `.readthedocs.yml` configuration file. The message shows regardless of whether the build was successful or not but doesn't show if the build used the v2 YAML file.

On a semi-related note, I know we support the YAML file being named `\.?readthedocs.ya?ml` but I think we should recommend one particular way even if we support multiple. I'm propose we recommend `.readthedocs.yml`. Opinions?

Fixes #5500

![Screen Shot 2019-03-21 at 3 55 28 PM](https://user-images.githubusercontent.com/185043/54790018-c4a72280-4bf1-11e9-9bbc-41c489c2bb13.png)
