### PR TITLE
Use HTTPS for intersphinx mappings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,9 +53,9 @@ release = version
 exclude_patterns = ['_build']
 default_role = 'obj'
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.io/en/latest/', None),
-    'django': ('http://django.readthedocs.io/en/1.9.x/', None),
-    'sphinx': ('http://sphinx.readthedocs.io/en/latest/', None),
+    'python': ('https://python.readthedocs.io/en/latest/', None),
+    'django': ('https://django.readthedocs.io/en/1.9.x/', None),
+    'sphinx': ('https://sphinx.readthedocs.io/en/latest/', None),
 }
 htmlhelp_basename = 'ReadTheDocsdoc'
 latex_documents = [


### PR DESCRIPTION
This avoids the insecure initial load of port 80 (http://) just to get redirected to https.  This also speeds up the builds of the docs by a tiny fraction.