### PR TITLE
 Update contributing docs for RTD's own docs

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -1,1 +1,1 @@
-Please review our contributing documentation located at http://docs.readthedocs.org/en/latest/contribute.html
+Please review our contributing documentation located at https://docs.readthedocs.io/en/latest/contribute.html

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -2,7 +2,7 @@ Contributing to Read the Docs
 =============================
 
 You are here to help on Read the Docs? Awesome, feel welcome and read the
-following sections in order to know how to ask questions and how to work on something. 
+following sections in order to know how to ask questions and how to work on something.
 
 All members of our community are expected to follow our :doc:`/code-of-conduct`.
 Please make sure you are welcoming and friendly in all of our spaces.
@@ -96,6 +96,14 @@ command will be run immediately and will inform you of the changes and errors.
 .. _prospector: https://prospector.landscape.io/en/master
 .. _unify: https://github.com/myint/unify
 .. _yapf: https://github.com/google/yapf
+
+Contributing to documentation
+-----------------------------
+
+Documentation for Read the Docs itself is hosted by Read the Docs at https://docs.readthedocs.io (likely the website you are currently reading).
+
+There are guidelines around writing and formatting documentation for the project.
+For full details, including how to build it, see :doc:`docs`.
 
 Triaging tickets
 ----------------

--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -5,7 +5,16 @@ As one might expect,
 the documentation for Read the Docs is built using Sphinx and hosted on Read the Docs.
 The docs are kept in the ``docs/`` directory at the top of the source tree.
 
-You can build the docs by installing ``Sphinx`` and running::
+You can build the docs by first ensuring this project is set up locally according to the :doc:`Installation Guide <install>`.
+Follow the instructions just up to the point of activating the virtual enviroment and then continue here.
+
+Next, install the documentation dependencies using ``pip`` (make sure you are inside of the virtual environment)::
+
+    pip install -r requirements/local-docs-build.txt
+
+This installs ``Sphinx``, amongst other things.
+
+After that is done, build the documentation by running::
 
 	# in the docs directory
 	make html


### PR DESCRIPTION
This makes a few improvements to the documentation for Read the Docs itself:

* Better explains how to perform a local install for working on the docs
* Explains there's a separate page for guidelines for docs on the contributing page
* Updates the URL in GitHub's contributing doc to use https + new readthedocs.io domain
