### PR TITLE
Fix extra origin in urls

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -241,17 +241,12 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
         )
 
         default_choice = (None, '-' * 9)
-        all_versions = self.instance.versions.only(
-            # commit_name only needs access to these attributes
-            'slug',
-            'type',
-            'verbose_name',
-        )
+        all_versions_choices = [
+            (v.commit_name, v.verbose_name)
+            for v in self.instance.versions
+        ]
         self.fields['default_branch'].widget = forms.Select(
-            choices=(
-                [default_choice] +
-                [(v.commit_name, v.verbose_name) for v in all_versions]
-            ),
+            choices=([default_choice] + all_versions_choices),
         )
 
         active_versions = self.get_all_active_versions()

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -241,12 +241,16 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
         )
 
         default_choice = (None, '-' * 9)
-        all_versions = self.instance.versions.values_list(
+        all_versions = self.instance.versions.only(
+            # commit_name only needs access to this attributes
+            'slug',
             'verbose_name',
-            flat=True
         )
         self.fields['default_branch'].widget = forms.Select(
-            choices=[default_choice] + list(zip(all_versions, all_versions)),
+            choices=(
+                [default_choice] +
+                [(v.commit_name, v.verbose_name) for v in all_versions]
+            ),
         )
 
         active_versions = self.get_all_active_versions()

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -242,7 +242,7 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
 
         default_choice = (None, '-' * 9)
         all_versions = self.instance.versions.only(
-            # commit_name only needs access to this attributes
+            # commit_name only needs access to these attributes
             'slug',
             'verbose_name',
         )

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -241,6 +241,8 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
         )
 
         default_choice = (None, '-' * 9)
+        # commit_name is used as the id because it handles
+        # the special cases of LATEST and STABLE.
         all_versions_choices = [
             (v.commit_name, v.verbose_name)
             for v in self.instance.versions.all()

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -244,6 +244,7 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
         all_versions = self.instance.versions.only(
             # commit_name only needs access to these attributes
             'slug',
+            'type',
             'verbose_name',
         )
         self.fields['default_branch'].widget = forms.Select(

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -243,7 +243,7 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
         default_choice = (None, '-' * 9)
         all_versions_choices = [
             (v.commit_name, v.verbose_name)
-            for v in self.instance.versions
+            for v in self.instance.versions.all()
         ]
         self.fields['default_branch'].widget = forms.Select(
             choices=([default_choice] + all_versions_choices),

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -246,7 +246,7 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
             for v in self.instance.versions.all()
         ]
         self.fields['default_branch'].widget = forms.Select(
-            choices=([default_choice] + all_versions_choices),
+            choices=[default_choice] + all_versions_choices,
         )
 
         active_versions = self.get_all_active_versions()

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -232,11 +232,11 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
 
         default_choice = (None, '-' * 9)
         all_versions = self.instance.versions.values_list(
-            'identifier',
             'verbose_name',
+            flat=True
         )
         self.fields['default_branch'].widget = forms.Select(
-            choices=[default_choice] + list(all_versions),
+            choices=[default_choice] + list(zip(all_versions, all_versions)),
         )
 
         active_versions = self.get_all_active_versions()

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -16,6 +16,7 @@ from readthedocs.projects.constants import (
 )
 from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.forms import (
+    EmailHookForm,
     EnvironmentVariableForm,
     ProjectAdvancedForm,
     ProjectBasicsForm,
@@ -23,7 +24,6 @@ from readthedocs.projects.forms import (
     TranslationForm,
     UpdateProjectForm,
     WebHookForm,
-    EmailHookForm
 )
 from readthedocs.projects.models import EnvironmentVariable, Project
 
@@ -201,6 +201,7 @@ class TestProjectAdvancedForm(TestCase):
             active=True,
             privacy_level=PUBLIC,
             identifier='public-1',
+            verbose_name='public-1',
         )
         get(
             Version,
@@ -209,6 +210,7 @@ class TestProjectAdvancedForm(TestCase):
             active=True,
             privacy_level=PUBLIC,
             identifier='public-2',
+            verbose_name='public-2',
         )
         get(
             Version,
@@ -217,6 +219,7 @@ class TestProjectAdvancedForm(TestCase):
             active=False,
             privacy_level=PROTECTED,
             identifier='public-3',
+            verbose_name='public-3',
         )
         get(
             Version,
@@ -225,6 +228,7 @@ class TestProjectAdvancedForm(TestCase):
             active=False,
             privacy_level=PUBLIC,
             identifier='public/4',
+            verbose_name='public/4',
         )
         get(
             Version,
@@ -233,6 +237,7 @@ class TestProjectAdvancedForm(TestCase):
             active=True,
             privacy_level=PRIVATE,
             identifier='private',
+            verbose_name='private',
         )
         get(
             Version,
@@ -241,6 +246,7 @@ class TestProjectAdvancedForm(TestCase):
             active=True,
             privacy_level=PROTECTED,
             identifier='protected',
+            verbose_name='protected',
         )
 
     def test_list_only_active_versions_on_default_version(self):


### PR DESCRIPTION
`verbose_name` is unique in each project, because we only have one remote.
`identifier` includes origin for branches and also it can point to the
same commit in tags.

Fixes #5518