### PR TITLE
Allow build mkdocs outside root

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -76,8 +76,6 @@ class BaseMkdocs(BaseBuilder):
                 self.project.checkout_path(self.version.slug),
                 'mkdocs.yml',
             )
-            if not os.path.exists(mkdoc_path):
-                return None
         return mkdoc_path
 
     def load_yaml_config(self):

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -110,9 +110,6 @@ class BaseMkdocs(BaseBuilder):
         :raises: ``MkDocsYAMLParseError`` if failed due to known type errors
                  (i.e. expecting a list and a string is found).
         """
-        if not self.yaml_file:
-            self.yaml_file = os.path.join(self.root_path, 'mkdocs.yml')
-
         user_config = self.load_yaml_config()
 
         # Handle custom docs dirs

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -45,12 +45,12 @@ class BaseMkdocs(BaseBuilder):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.yaml_file = self.get_yaml_config()
         self.old_artifact_path = os.path.join(
-            self.version.project.checkout_path(self.version.slug),
+            os.path.dirname(self.yaml_file),
             self.build_dir,
         )
         self.root_path = self.version.project.checkout_path(self.version.slug)
-        self.yaml_file = self.get_yaml_config()
 
         # README: historically, the default theme was ``readthedocs`` but in
         # https://github.com/rtfd/readthedocs.org/pull/4556 we change it to


### PR DESCRIPTION
Currently we are expecting that all mkdocs projects have their docs in
their root, but we generate the artifacts relative to their yaml file,
we do the same for sphinx.

https://github.com/rtfd/readthedocs.org/blob/d8a6c24013b7089074b302e7c04edd7998fe90ce/readthedocs/doc_builder/backends/sphinx.py#L42-L51

Fix https://github.com/rtfd/readthedocs.org/issues/5532#issuecomment-476316702
Closes #5559