### PR TITLE
Call mkdocs using -m

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -247,8 +247,9 @@ class BaseMkdocs(BaseBuilder):
     def build(self):
         checkout_path = self.project.checkout_path(self.version.slug)
         build_command = [
-            'python',
-            self.python_env.venv_bin(filename='mkdocs'),
+            self.python_env.venv_bin(filename='python'),
+            '-m',
+            'mkdocs',
             self.builder,
             '--clean',
             '--site-dir',


### PR DESCRIPTION
There are some cases were rtd uses the old installed version of mkdocs
instead of the one installed by the user, like in
https://github.com/rtfd/readthedocs.org/issues/5532#issuecomment-476308877

Which gives an error because it's using a yaml file
supported only in new mkdocs versions.

This is similar to https://github.com/rtfd/readthedocs.org/pull/5107