### PR TITLE
Fix advanced settings form

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -4,7 +4,7 @@ from re import fullmatch
 from urllib.parse import urlparse
 
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Fieldset, Layout, HTML
+from crispy_forms.layout import Fieldset, Layout, HTML, Submit
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -239,6 +239,7 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
                 *self.Meta.per_version_settings,
             ),
         )
+        self.helper.add_input(Submit('save', _('Save')))
 
         default_choice = (None, '-' * 9)
         all_versions = self.instance.versions.values_list(

--- a/readthedocs/templates/projects/project_advanced.html
+++ b/readthedocs/templates/projects/project_advanced.html
@@ -13,10 +13,5 @@
 {% block project_edit_content_header %}{% trans "Advanced Settings" %}{% endblock %}
 
 {% block project_edit_content %}
-  <form method="post" action=".">{% csrf_token %}
-    {% crispy form %}
-    <p>
-      <input style="display: inline;" type="submit" value="{% trans "Save" %}">
-    </p>
-  </form>
+  {% crispy form %}
 {% endblock %}


### PR DESCRIPTION
Turns out, that crispy already renders all the forms tags

Save button looks the same

![Screenshot_2019-03-27 Edit Advanced Project Settings Read the Docs](https://user-images.githubusercontent.com/4975310/55091089-319d3b00-507e-11e9-9642-4e9bfb791fa2.png)
