### PR TITLE
Non mobile fixed footer ads

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -167,13 +167,20 @@ div.ethical-footer {
     z-index: 100;
     background-color: #eee;
     border-top: 1px solid #bfbfbf;
-    font-size: 13px;
+    font-size: 12px;
     line-height: 1.5;
     padding: 0.5em 1.5em;
     text-align: center;
     color: #404040;
     width: 100%;    /* Fallback for Opera Mini */
     width: 100vw;
+}
+@media (min-width: 769px) {
+    /* Improve viewing on non-mobile */
+    .ethical-fixedfooter {
+        font-size: 13px;
+        padding: 1em 1.5em;
+    }
 }
 .ethical-fixedfooter .ethical-text:before {
     margin-right: 4px;
@@ -185,7 +192,8 @@ div.ethical-footer {
 }
 .ethical-fixedfooter .ethical-callout {
     color: #999;
-    padding-left: 4px;
+    padding-left: 6px;
+    white-space: nowrap;
 }
 .ethical-fixedfooter a,
 .ethical-fixedfooter a:hover,
@@ -198,8 +206,8 @@ div.ethical-footer {
     position: absolute;
     top: 0;
     right: 5px;
-    font-size: 15px;
-    line-height: 15px;
+    font-size: 20px;
+    line-height: 20px;
 }
 
 /* RTD Theme specific customizations */

--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -167,20 +167,32 @@ div.ethical-footer {
     z-index: 100;
     background-color: #eee;
     border-top: 1px solid #bfbfbf;
-    font-size: 12px;
-    line-height: 16px;
-    padding: 0.5em 2.5em;
+    font-size: 13px;
+    line-height: 1.5;
+    padding: 0.5em 1.5em;
     text-align: center;
     color: #404040;
     width: 100%;    /* Fallback for Opera Mini */
     width: 100vw;
 }
+.ethical-fixedfooter .ethical-text:before {
+    margin-right: 4px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background-color: #4caf50;
+    color: #fff;
+    content: "Sponsored";
+}
+.ethical-fixedfooter .ethical-callout {
+    color: #999;
+    padding-left: 4px;
+}
 .ethical-fixedfooter a,
 .ethical-fixedfooter a:hover,
 .ethical-fixedfooter a:active,
 .ethical-fixedfooter a:visited {
-    color: #004B6B;
-    text-decoration: underline;
+    color: #404040;
+    text-decoration: none;
 }
 .ethical-fixedfooter .ethical-close {
     position: absolute;
@@ -188,10 +200,6 @@ div.ethical-footer {
     right: 5px;
     font-size: 15px;
     line-height: 15px;
-}
-.ethical-fixedfooter .ethical-close a {
-    color: black;
-    text-decoration: none;
 }
 
 /* RTD Theme specific customizations */
@@ -206,6 +214,13 @@ div.ethical-footer {
 
     font-size: 14px;
     line-height: 20px;
+}
+
+@media (min-width: 769px) {
+    /* Make sure the fixed footer ad is under the RTD theme version selector */
+    .wy-body-for-nav .ethical-fixedfooter {
+        padding-left: 300px;
+    }
 }
 
 /* Alabaster specific customizations */

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -67,9 +67,6 @@ function create_sidebar_placement() {
         if (!offset || offset.top > $(window).height()) {
             // If this is off screen, lower the priority
             priority = constants.LOW_PROMO_PRIORITY;
-        } else if (bowser && !bowser.mobile) {
-            // If this isn't mobile, then the ad will be ATF, so raise the priority
-            priority = constants.MAXIMUM_PROMO_PRIORITY;
         }
 
         return {
@@ -131,20 +128,21 @@ function create_footer_placement() {
 function create_fixed_footer_placement() {
     var element_id = 'rtd-' + (Math.random() + 1).toString(36).substring(4);
     var display_type = constants.PROMO_TYPES.FIXED_FOOTER;
+    var priority = constants.DEFAULT_PROMO_PRIORITY;
 
-    // Only propose the fixed footer ad for mobile
     if (bowser && bowser.mobile) {
-        $('<div />').attr('id', element_id).appendTo('body');
-        return {
-            'div_id': element_id,
-            'display_type': display_type,
-
-            // Prioritize mobile ads when on mobile
-            'priority': constants.MAXIMUM_PROMO_PRIORITY,
-        };
+        // If this is mobile, then prioritize fixed footer
+        priority = constants.MAXIMUM_PROMO_PRIORITY;
     }
 
-    return null;
+    $('<div />').attr('id', element_id).appendTo('body');
+    return {
+        'div_id': element_id,
+        'display_type': display_type,
+
+        // Prioritize mobile ads when on mobile
+        'priority': priority,
+    };
 }
 
 function Promo(data) {


### PR DESCRIPTION
This allows (but doesn't mandate) fixed footer text-only advertisements. The plan is to roll these out as a test to see if users react to them (do they perform? do users hate them?).

- For starters, we'll roll them out on our docs only followed by community ads
- As they expand perhaps they can target themes that previously didn't have ads or on docs where ads are either all the way at the bottom of the page (never viewed) or have a long sidebar (again, the ad isn't viewed)

![image](https://user-images.githubusercontent.com/185043/55501805-12fbee80-5600-11e9-99b5-3dca46dad689.png)
