### PR TITLE
Use downloads.html in template

### DIFF
--- a/readthedocs/templates/core/project_downloads.html
+++ b/readthedocs/templates/core/project_downloads.html
@@ -9,9 +9,9 @@
   </li>
   {% endif %}
 
-  {% if dict.htmlzip %}
+  {% if dict.html %}
   <li class="module-item col-span">
-    <a class="module-item-title" href="{{ dict.htmlzip }}">
+    <a class="module-item-title" href="{{ dict.html }}">
         {{ version.slug }} HTMLZip
     </a>
   </li>


### PR DESCRIPTION
In #5502 we refactored the function
but we used to depend on `pretty` to change the name of the key from
`html` to `htmlzip`, we use `html` in the footer and in the theme.

So, it's safe to change the value in the template.

See https://github.com/rtfd/readthedocs.org/pull/5502/files#r272787188