### PR TITLE
Unify usage of settings and remove the usage of getattr for settings

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -41,11 +41,11 @@ VERSION_TYPES = (
     (UNKNOWN, _('Unknown')),
 )
 
-LATEST = getattr(settings, 'RTD_LATEST', 'latest')
-LATEST_VERBOSE_NAME = getattr(settings, 'RTD_LATEST_VERBOSE_NAME', 'latest')
+LATEST = settings.RTD_LATEST
+LATEST_VERBOSE_NAME = settings.RTD_LATEST_VERBOSE_NAME
 
-STABLE = getattr(settings, 'RTD_STABLE', 'stable')
-STABLE_VERBOSE_NAME = getattr(settings, 'RTD_STABLE_VERBOSE_NAME', 'stable')
+STABLE = settings.RTD_STABLE
+STABLE_VERBOSE_NAME = settings.RTD_STABLE_VERBOSE_NAME
 
 # Those names are specialcased version names. They do not correspond to
 # branches/tags in a project's repository.

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -49,11 +49,7 @@ from .utils import (
 from .version_slug import VersionSlugField
 
 
-DEFAULT_VERSION_PRIVACY_LEVEL = getattr(
-    settings,
-    'DEFAULT_VERSION_PRIVACY_LEVEL',
-    'public',
-)
+DEFAULT_VERSION_PRIVACY_LEVEL = settings.DEFAULT_VERSION_PRIVACY_LEVEL
 
 log = logging.getLogger(__name__)
 

--- a/readthedocs/builds/syncers.py
+++ b/readthedocs/builds/syncers.py
@@ -5,7 +5,6 @@ Classes to copy files between build and web servers.
 local machine.
 """
 
-import getpass
 import logging
 import os
 import shutil

--- a/readthedocs/builds/syncers.py
+++ b/readthedocs/builds/syncers.py
@@ -64,8 +64,8 @@ class RemoteSyncer(BaseSyncer):
 
         Respects the ``MULTIPLE_APP_SERVERS`` setting when copying.
         """
-        sync_user = getattr(settings, 'SYNC_USER', getpass.getuser())
-        app_servers = getattr(settings, 'MULTIPLE_APP_SERVERS', [])
+        sync_user = settings.SYNC_USER
+        app_servers = settings.MULTIPLE_APP_SERVERS
         if app_servers:
             log.info('Remote Copy %s to %s on %s', path, target, app_servers)
             for server in app_servers:
@@ -103,8 +103,8 @@ class DoubleRemotePuller(BaseSyncer):
 
         Respects the ``MULTIPLE_APP_SERVERS`` setting when copying.
         """
-        sync_user = getattr(settings, 'SYNC_USER', getpass.getuser())
-        app_servers = getattr(settings, 'MULTIPLE_APP_SERVERS', [])
+        sync_user = settings.SYNC_USER
+        app_servers = settings.MULTIPLE_APP_SERVERS
         if not is_file:
             path += '/'
         log.info('Remote Copy %s to %s', path, target)
@@ -143,7 +143,7 @@ class RemotePuller(BaseSyncer):
 
         Respects the ``MULTIPLE_APP_SERVERS`` setting when copying.
         """
-        sync_user = getattr(settings, 'SYNC_USER', getpass.getuser())
+        sync_user = settings.SYNC_USER
         if not is_file:
             path += '/'
         log.info('Remote Pull %s to %s', path, target)

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -66,18 +66,12 @@ SUBMODULES_INVALID = 'submodules-invalid'
 INVALID_KEYS_COMBINATION = 'invalid-keys-combination'
 INVALID_KEY = 'invalid-key'
 
-DOCKER_DEFAULT_IMAGE = getattr(
-    settings, 'DOCKER_DEFAULT_IMAGE', 'readthedocs/build'
-)
-DOCKER_DEFAULT_VERSION = getattr(settings, 'DOCKER_DEFAULT_VERSION', '2.0')
+DOCKER_DEFAULT_IMAGE = settings.DOCKER_DEFAULT_IMAGE
+DOCKER_DEFAULT_VERSION = settings.DOCKER_DEFAULT_VERSION
 # These map to corresponding settings in the .org,
 # so they haven't been renamed.
-DOCKER_IMAGE = getattr(
-    settings,
-    'DOCKER_IMAGE',
-    '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION),
-)
-DOCKER_IMAGE_SETTINGS = getattr(settings, 'DOCKER_IMAGE_SETTINGS', {})
+DOCKER_IMAGE = settings.DOCKER_IMAGE
+DOCKER_IMAGE_SETTINGS =settings.DOCKER_IMAGE_SETTINGS
 
 LATEST_CONFIGURATION_VERSION = 2
 

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -71,7 +71,7 @@ DOCKER_DEFAULT_VERSION = settings.DOCKER_DEFAULT_VERSION
 # These map to corresponding settings in the .org,
 # so they haven't been renamed.
 DOCKER_IMAGE = settings.DOCKER_IMAGE
-DOCKER_IMAGE_SETTINGS =settings.DOCKER_IMAGE_SETTINGS
+DOCKER_IMAGE_SETTINGS = settings.DOCKER_IMAGE_SETTINGS
 
 LATEST_CONFIGURATION_VERSION = 2
 

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -10,7 +10,7 @@ def readthedocs_processor(request):
     exports = {
         'PUBLIC_DOMAIN': settings.PUBLIC_DOMAIN,
         'PRODUCTION_DOMAIN': settings.PRODUCTION_DOMAIN,
-        'USE_SUBDOMAINS': settings.USE_SUBDOMAINS,
+        'USE_SUBDOMAINS': settings.USE_SUBDOMAIN,
         'GLOBAL_ANALYTICS_CODE': settings.GLOBAL_ANALYTICS_CODE,
         'DASHBOARD_ANALYTICS_CODE': settings.DASHBOARD_ANALYTICS_CODE,
         'SITE_ROOT': settings.SITE_ROOT + '/',

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -10,7 +10,7 @@ def readthedocs_processor(request):
     exports = {
         'PUBLIC_DOMAIN': settings.PUBLIC_DOMAIN,
         'PRODUCTION_DOMAIN': settings.PRODUCTION_DOMAIN,
-        'USE_SUBDOMAINS': settings.USE_SUBDOMAIN,
+        'USE_SUBDOMAIN': settings.USE_SUBDOMAIN,
         'GLOBAL_ANALYTICS_CODE': settings.GLOBAL_ANALYTICS_CODE,
         'DASHBOARD_ANALYTICS_CODE': settings.DASHBOARD_ANALYTICS_CODE,
         'SITE_ROOT': settings.SITE_ROOT + '/',

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -8,21 +8,14 @@ from django.conf import settings
 def readthedocs_processor(request):
     # pylint: disable=unused-argument
     exports = {
-        'PUBLIC_DOMAIN': getattr(settings, 'PUBLIC_DOMAIN', None),
-        'PRODUCTION_DOMAIN': getattr(settings, 'PRODUCTION_DOMAIN', None),
-        'USE_SUBDOMAINS': getattr(settings, 'USE_SUBDOMAINS', None),
-        'GLOBAL_ANALYTICS_CODE': getattr(settings, 'GLOBAL_ANALYTICS_CODE'),
-        'DASHBOARD_ANALYTICS_CODE': getattr(
-            settings,
-            'DASHBOARD_ANALYTICS_CODE',
-        ),
-        'SITE_ROOT': getattr(settings, 'SITE_ROOT', '') + '/',
-        'TEMPLATE_ROOT': getattr(settings, 'TEMPLATE_ROOT', '') + '/',
-        'DO_NOT_TRACK_ENABLED': getattr(
-            settings,
-            'DO_NOT_TRACK_ENABLED',
-            False,
-        ),
-        'USE_PROMOS': getattr(settings, 'USE_PROMOS', False),
+        'PUBLIC_DOMAIN': settings.PUBLIC_DOMAIN,
+        'PRODUCTION_DOMAIN': settings.PRODUCTION_DOMAIN,
+        'USE_SUBDOMAINS': settings.USE_SUBDOMAINS,
+        'GLOBAL_ANALYTICS_CODE': settings.GLOBAL_ANALYTICS_CODE,
+        'DASHBOARD_ANALYTICS_CODE': settings.DASHBOARD_ANALYTICS_CODE,
+        'SITE_ROOT': settings.SITE_ROOT + '/',
+        'TEMPLATE_ROOT': settings.TEMPLATE_ROOT + '/',
+        'DO_NOT_TRACK_ENABLED': settings.DO_NOT_TRACK_ENABLED,
+        'USE_PROMOS': settings.USE_PROMOS,
     }
     return exports

--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -15,16 +15,8 @@ from readthedocs.projects.models import Domain, Project
 log = logging.getLogger(__name__)
 
 LOG_TEMPLATE = '(Middleware) {msg} [{host}{path}]'
-SUBDOMAIN_URLCONF = getattr(
-    settings,
-    'SUBDOMAIN_URLCONF',
-    'readthedocs.core.urls.subdomain',
-)
-SINGLE_VERSION_URLCONF = getattr(
-    settings,
-    'SINGLE_VERSION_URLCONF',
-    'readthedocs.core.urls.single_version',
-)
+SUBDOMAIN_URLCONF = settings.SUBDOMAIN_URLCONF
+SINGLE_VERSION_URLCONF = settings.SINGLE_VERSION_URLCONF
 
 
 class SubdomainMiddleware(MiddlewareMixin):
@@ -39,18 +31,14 @@ class SubdomainMiddleware(MiddlewareMixin):
         is not set and the request is for a subdomain on ``PRODUCTION_DOMAIN``,
         process the request as a request a documentation project.
         """
-        if not getattr(settings, 'USE_SUBDOMAIN', False):
+        if not settings.USE_SUBDOMAIN:
             return None
 
         full_host = host = request.get_host().lower()
         path = request.get_full_path()
         log_kwargs = dict(host=host, path=path)
-        public_domain = getattr(settings, 'PUBLIC_DOMAIN', None)
-        production_domain = getattr(
-            settings,
-            'PRODUCTION_DOMAIN',
-            'readthedocs.org',
-        )
+        public_domain = settings.PUBLIC_DOMAIN
+        production_domain = settings.PRODUCTION_DOMAIN
 
         if public_domain is None:
             public_domain = production_domain

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -157,7 +157,7 @@ class ResolverBase:
         if self._use_subdomain():
             return self._get_project_subdomain(canonical_project)
 
-        return getattr(settings, 'PRODUCTION_DOMAIN')
+        return settings.PRODUCTION_DOMAIN
 
     def resolve(
             self, project, require_https=False, filename='', query_params='',
@@ -178,10 +178,10 @@ class ResolverBase:
         elif self._use_subdomain():
             domain = self._get_project_subdomain(canonical_project)
         else:
-            domain = getattr(settings, 'PRODUCTION_DOMAIN')
+            domain = settings.PRODUCTION_DOMAIN
 
-        public_domain = getattr(settings, 'PUBLIC_DOMAIN', None)
-        use_https = getattr(settings, 'PUBLIC_DOMAIN_USES_HTTPS', False)
+        public_domain = settings.PUBLIC_DOMAIN
+        use_https = settings.PUBLIC_DOMAIN_USES_HTTPS
 
         use_https_protocol = any([
             # Rely on the ``Domain.https`` field
@@ -229,7 +229,7 @@ class ResolverBase:
 
     def _get_project_subdomain(self, project):
         """Determine canonical project domain as subdomain."""
-        public_domain = getattr(settings, 'PUBLIC_DOMAIN', None)
+        public_domain = settings.PUBLIC_DOMAIN
         if self._use_subdomain():
             project = self._get_canonical_project(project)
             subdomain_slug = project.slug.replace('_', '-')
@@ -241,11 +241,7 @@ class ResolverBase:
             version = project.versions.get(slug=version_slug)
             private = version.privacy_level == PRIVATE
         except Version.DoesNotExist:
-            private = getattr(
-                settings,
-                'DEFAULT_PRIVACY_LEVEL',
-                PUBLIC,
-            ) == PRIVATE
+            private = settings.DEFAULT_PRIVACY_LEVEL == PRIVATE
         return private
 
     def _fix_filename(self, project, filename):
@@ -270,8 +266,8 @@ class ResolverBase:
 
     def _use_subdomain(self):
         """Make decision about whether to use a subdomain to serve docs."""
-        use_subdomain = getattr(settings, 'USE_SUBDOMAIN', False)
-        public_domain = getattr(settings, 'PUBLIC_DOMAIN', None)
+        use_subdomain = settings.USE_SUBDOMAIN
+        public_domain = settings.PUBLIC_DOMAIN
         return use_subdomain and public_domain is not None
 
 

--- a/readthedocs/core/templatetags/core_tags.py
+++ b/readthedocs/core/templatetags/core_tags.py
@@ -61,7 +61,7 @@ def restructuredtext(value, short=False):
             'file_insertion_enabled': False,
         }
         docutils_settings.update(
-            getattr(settings, 'RESTRUCTUREDTEXT_FILTER_SETTINGS', {}),
+            settings.RESTRUCTUREDTEXT_FILTER_SETTINGS,
         )
         try:
             parts = publish_parts(

--- a/readthedocs/core/urls/single_version.py
+++ b/readthedocs/core/urls/single_version.py
@@ -35,14 +35,14 @@ single_version_urls = [
 groups = [single_version_urls]
 
 # Needed to serve media locally
-if getattr(settings, 'DEBUG', False):
+if settings.DEBUG:
     groups.insert(
         0,
         static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
     )
 
 # Allow `/docs/<foo>` URL's when not using subdomains or during local dev
-if not getattr(settings, 'USE_SUBDOMAIN', False) or settings.DEBUG:
+if not settings.USE_SUBDOMAIN or settings.DEBUG:
     docs_url = [
         url(
             (

--- a/readthedocs/core/urls/subdomain.py
+++ b/readthedocs/core/urls/subdomain.py
@@ -51,7 +51,7 @@ subdomain_urls = [
 groups = [subdomain_urls]
 
 # Needed to serve media locally
-if getattr(settings, 'DEBUG', False):
+if settings.DEBUG:
     groups.insert(
         0,
         static(

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import
 
 import errno
-import getpass
 import logging
 import os
 import re
@@ -21,7 +20,7 @@ from readthedocs.doc_builder.constants import DOCKER_LIMITS
 
 log = logging.getLogger(__name__)
 
-SYNC_USER = getattr(settings, 'SYNC_USER', getpass.getuser())
+SYNC_USER = settings.SYNC_USER
 
 
 def broadcast(type, task, args, kwargs=None, callback=None):  # pylint: disable=redefined-builtin
@@ -37,11 +36,11 @@ def broadcast(type, task, args, kwargs=None, callback=None):  # pylint: disable=
         raise ValueError('allowed value of `type` are web, app and build.')
     if kwargs is None:
         kwargs = {}
-    default_queue = getattr(settings, 'CELERY_DEFAULT_QUEUE', 'celery')
+
     if type in ['web', 'app']:
-        servers = getattr(settings, 'MULTIPLE_APP_SERVERS', [default_queue])
+        servers = settings.MULTIPLE_APP_SERVERS
     elif type in ['build']:
-        servers = getattr(settings, 'MULTIPLE_BUILD_SERVERS', [default_queue])
+        servers = settings.MULTIPLE_BUILD_SERVERS
 
     tasks = []
     for server in servers:

--- a/readthedocs/core/utils/extend.py
+++ b/readthedocs/core/utils/extend.py
@@ -23,7 +23,7 @@ def get_override_class(proxy_class, default_class=None):
         inspect.getmodule(proxy_class).__name__,
         proxy_class.__name__,
     ])
-    class_path = getattr(settings, 'CLASS_OVERRIDES', {}).get(class_id)
+    class_path = settings.CLASS_OVERRIDES.get(class_id)
     # pylint: disable=protected-access
     if class_path is None and proxy_class._override_setting is not None:
         class_path = getattr(settings, proxy_class._override_setting, None)

--- a/readthedocs/core/utils/tasks/public.py
+++ b/readthedocs/core/utils/tasks/public.py
@@ -14,7 +14,7 @@ __all__ = (
     'get_public_task_data',
 )
 
-STATUS_UPDATES_ENABLED = not getattr(settings, 'CELERY_ALWAYS_EAGER', False)
+STATUS_UPDATES_ENABLED = not settings.CELERY_ALWAYS_EAGER
 
 
 class PublicTask(Task):

--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -53,14 +53,10 @@ class SupportView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        support_email = getattr(settings, 'SUPPORT_EMAIL', None)
+        support_email = settings.SUPPORT_EMAIL
         if not support_email:
             support_email = 'support@{domain}'.format(
-                domain=getattr(
-                    settings,
-                    'PRODUCTION_DOMAIN',
-                    'readthedocs.org',
-                ),
+                domain=settings.PRODUCTION_DOMAIN
             )
 
         context['support_email'] = support_email

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -158,7 +158,7 @@ def _serve_file(request, filename, basepath):
     :raises: ``Http404`` on ``UnicodeEncodeError``
     """
     # Serve the file from the proper location
-    if settings.DEBUG or getattr(settings, 'PYTHON_MEDIA', False):
+    if settings.DEBUG or settings.PYTHON_MEDIA:
         # Serve from Python
         return serve(request, filename, basepath)
 
@@ -242,7 +242,7 @@ def _serve_symlink_docs(request, project, privacy_level, filename=''):
 
     files_tried = []
 
-    serve_docs = getattr(settings, 'SERVE_DOCS', [constants.PRIVATE])
+    serve_docs = settings.SERVE_DOCS
 
     if (settings.DEBUG or constants.PUBLIC in serve_docs) and privacy_level != constants.PRIVATE:  # yapf: disable  # noqa
         public_symlink = PublicSymlink(project)

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -29,7 +29,7 @@ def get_absolute_static_url():
     static_url = settings.STATIC_URL
 
     if not static_url.startswith('http'):
-        domain = getattr(settings, 'PRODUCTION_DOMAIN')
+        domain = settings.PRODUCTION_DOMAIN
         static_url = 'http://{}{}'.format(domain, static_url)
 
     return static_url
@@ -213,18 +213,10 @@ class BaseMkdocs(BaseBuilder):
             'builder': 'mkdocs',
             'docroot': docs_dir,
             'source_suffix': '.md',
-            'api_host': getattr(
-                settings,
-                'PUBLIC_API_URL',
-                'https://readthedocs.org',
-            ),
+            'api_host': settings.PUBLIC_API_URL,
             'ad_free': not self.project.show_advertising,
             'commit': self.version.project.vcs_repo(self.version.slug).commit,
-            'global_analytics_code': getattr(
-                settings,
-                'GLOBAL_ANALYTICS_CODE',
-                'UA-17997319-1',
-            ),
+            'global_analytics_code': settings.GLOBAL_ANALYTICS_CODE,
             'user_analytics_code': analytics_code,
         }
         data_json = json.dumps(readthedocs_data, indent=4)

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -104,7 +104,7 @@ class BaseSphinx(BaseBuilder):
         display_gitlab = gitlab_user is not None
 
         # Avoid hitting database and API if using Docker build environment
-        if getattr(settings, 'DONT_HIT_API', False):
+        if settings.DONT_HIT_API:
             versions = self.project.active_versions()
             downloads = self.version.get_downloads(pretty=True)
         else:
@@ -119,11 +119,7 @@ class BaseSphinx(BaseBuilder):
             'version': self.version,
             'settings': settings,
             'conf_py_path': conf_py_path,
-            'api_host': getattr(
-                settings,
-                'PUBLIC_API_URL',
-                'https://readthedocs.org',
-            ),
+            'api_host': settings.PUBLIC_API_URL,
             'commit': self.project.vcs_repo(self.version.slug).commit,
             'versions': versions,
             'downloads': downloads,

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -21,16 +21,12 @@ MKDOCS_TEMPLATE_DIR = os.path.join(
 PDF_RE = re.compile('Output written on (.*?)')
 
 # Docker
-DOCKER_SOCKET = getattr(
-    settings,
-    'DOCKER_SOCKET',
-    'unix:///var/run/docker.sock',
-)
-DOCKER_VERSION = getattr(settings, 'DOCKER_VERSION', 'auto')
-DOCKER_IMAGE = getattr(settings, 'DOCKER_IMAGE', 'readthedocs/build:2.0')
-DOCKER_IMAGE_SETTINGS = getattr(settings, 'DOCKER_IMAGE_SETTINGS', {})
+DOCKER_SOCKET = settings.DOCKER_SOCKET
+DOCKER_VERSION = settings.DOCKER_VERSION
+DOCKER_IMAGE = settings.DOCKER_IMAGE
+DOCKER_IMAGE_SETTINGS = settings.DOCKER_IMAGE_SETTINGS
 
-old_config = getattr(settings, 'DOCKER_BUILD_IMAGES', None)
+old_config = settings.DOCKER_BUILD_IMAGES
 if old_config:
     log.warning(
         'Old config detected, DOCKER_BUILD_IMAGES->DOCKER_IMAGE_SETTINGS',
@@ -38,7 +34,7 @@ if old_config:
     DOCKER_IMAGE_SETTINGS.update(old_config)
 
 DOCKER_LIMITS = {'memory': '200m', 'time': 600}
-DOCKER_LIMITS.update(getattr(settings, 'DOCKER_LIMITS', {}))
+DOCKER_LIMITS.update(settings.DOCKER_LIMITS)
 
 DOCKER_TIMEOUT_EXIT_CODE = 42
 DOCKER_OOM_EXIT_CODE = 137

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -941,7 +941,7 @@ class DockerBuildEnvironment(BuildEnvironment):
             },
         }
 
-        if getattr(settings, 'GLOBAL_PIP_CACHE', False) and settings.DEBUG:
+        if settings.GLOBAL_PIP_CACHE and settings.DEBUG:
             binds.update({
                 self.project.pip_cache_path: {
                     'bind': self.project.pip_cache_path,

--- a/readthedocs/doc_builder/loader.py
+++ b/readthedocs/doc_builder/loader.py
@@ -7,20 +7,8 @@ from django.conf import settings
 
 
 # Managers
-mkdocs = import_module(
-    getattr(
-        settings,
-        'MKDOCS_BACKEND',
-        'readthedocs.doc_builder.backends.mkdocs',
-    ),
-)
-sphinx = import_module(
-    getattr(
-        settings,
-        'SPHINX_BACKEND',
-        'readthedocs.doc_builder.backends.sphinx',
-    ),
-)
+mkdocs = import_module(settings.MKDOCS_BACKEND)
+sphinx = import_module(settings.SPHINX_BACKEND)
 
 BUILDER_BY_NAME = {
     # Possible HTML Builders

--- a/readthedocs/notifications/backends.py
+++ b/readthedocs/notifications/backends.py
@@ -26,7 +26,7 @@ def send_notification(request, notification):
     should be a list of class paths to be loaded, using the standard Django
     string module loader.
     """
-    backends = getattr(settings, 'NOTIFICATION_BACKENDS', [])
+    backends = settings.NOTIFICATION_BACKENDS
     for cls_name in backends:
         backend = import_string(cls_name)(request)
         backend.send(notification)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -315,11 +315,11 @@ class GitHubService(Service):
     def get_token_for_project(cls, project, force_local=False):
         """Get access token for project by iterating over project users."""
         # TODO why does this only target GitHub?
-        if not getattr(settings, 'ALLOW_PRIVATE_REPOS', False):
+        if not settings.ALLOW_PRIVATE_REPOS:
             return None
         token = None
         try:
-            if getattr(settings, 'DONT_HIT_DB', True) and not force_local:
+            if settings.DONT_HIT_DB and not force_local:
                 token = api.project(project.pk).token().get()['token']
             else:
                 for user in project.users.all():

--- a/readthedocs/payments/utils.py
+++ b/readthedocs/payments/utils.py
@@ -11,7 +11,7 @@ import stripe
 from django.conf import settings
 
 
-stripe.api_key = getattr(settings, 'STRIPE_SECRET', None)
+stripe.api_key = settings.STRIPE_SECRET
 
 
 def delete_customer(customer_id):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -320,11 +320,7 @@ class Project(models.Model):
         _('Privacy Level'),
         max_length=20,
         choices=constants.PRIVACY_CHOICES,
-        default=getattr(
-            settings,
-            'DEFAULT_PRIVACY_LEVEL',
-            'public',
-        ),
+        default=settings.DEFAULT_PRIVACY_LEVEL,
         help_text=_(
             'Level of privacy that you want on the repository. '
             'Protected means public but not in listings.',
@@ -334,11 +330,7 @@ class Project(models.Model):
         _('Version Privacy Level'),
         max_length=20,
         choices=constants.PRIVACY_CHOICES,
-        default=getattr(
-            settings,
-            'DEFAULT_PRIVACY_LEVEL',
-            'public',
-        ),
+        default=settings.DEFAULT_PRIVACY_LEVEL,
         help_text=_(
             'Default level of privacy you want on built '
             'versions of documentation.',
@@ -495,7 +487,7 @@ class Project(models.Model):
         )
 
     def get_canonical_url(self):
-        if getattr(settings, 'DONT_HIT_DB', True):
+        if settings.DONT_HIT_DB:
             return api.project(self.pk).canonical_url().get()['url']
         return self.get_docs_url()
 
@@ -505,7 +497,7 @@ class Project(models.Model):
 
         This is used in search result linking
         """
-        if getattr(settings, 'DONT_HIT_DB', True):
+        if settings.DONT_HIT_DB:
             return [(proj['slug'], proj['canonical_url']) for proj in
                     (api.project(self.pk).subprojects().get()['subprojects'])]
         return [(proj.child.slug, proj.child.get_docs_url())
@@ -540,8 +532,7 @@ class Project(models.Model):
 
         :returns: Full path to media file or path
         """
-        if getattr(settings, 'DEFAULT_PRIVACY_LEVEL',
-                   'public') == 'public' or settings.DEBUG:
+        if settings.DEFAULT_PRIVACY_LEVEL == 'public' or settings.DEBUG:
             path = os.path.join(
                 settings.MEDIA_ROOT,
                 type_,
@@ -618,7 +609,7 @@ class Project(models.Model):
     @property
     def pip_cache_path(self):
         """Path to pip cache."""
-        if getattr(settings, 'GLOBAL_PIP_CACHE', False) and settings.DEBUG:
+        if settings.GLOBAL_PIP_CACHE and settings.DEBUG:
             return settings.GLOBAL_PIP_CACHE
         return os.path.join(self.doc_path, '.cache', 'pip')
 
@@ -808,8 +799,8 @@ class Project(models.Model):
         if max_lock_age is None:
             max_lock_age = (
                 self.container_time_limit or
-                getattr(settings, 'DOCKER_LIMITS', {}).get('time') or
-                getattr(settings, 'REPO_LOCK_SECONDS', 30)
+                settings.DOCKER_LIMITS.get('time') or
+                settings.REPO_LOCK_SECONDS
             )
 
         return NonBlockingLock(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1398,11 +1398,11 @@ def email_notification(version, build, email):
             'error': build.error,
         },
         'build_url': 'https://{}{}'.format(
-            getattr(settings, 'PRODUCTION_DOMAIN', 'readthedocs.org'),
+            settings.PRODUCTION_DOMAIN,
             build.get_absolute_url(),
         ),
         'unsub_url': 'https://{}{}'.format(
-            getattr(settings, 'PRODUCTION_DOMAIN', 'readthedocs.org'),
+            settings.PRODUCTION_DOMAIN,
             reverse('projects_notifications', args=[version.project.slug]),
         ),
     }

--- a/readthedocs/projects/utils.py
+++ b/readthedocs/projects/utils.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def version_from_slug(slug, version):
     from readthedocs.builds.models import Version, APIVersion
     from readthedocs.restapi.client import api
-    if getattr(settings, 'DONT_HIT_DB', True):
+    if settings.DONT_HIT_DB:
         version_data = api.version().get(
             project=slug,
             slug=version,

--- a/readthedocs/projects/validators.py
+++ b/readthedocs/projects/validators.py
@@ -59,14 +59,14 @@ class RepositoryURLValidator:
     re_git_user = re.compile(r'^[\w]+@.+')
 
     def __call__(self, value):
-        allow_private_repos = getattr(settings, 'ALLOW_PRIVATE_REPOS', False)
+        allow_private_repos = settings.ALLOW_PRIVATE_REPOS
         public_schemes = ['https', 'http', 'git', 'ftps', 'ftp']
         private_schemes = ['ssh', 'ssh+git']
         local_schemes = ['file']
         valid_schemes = public_schemes
         if allow_private_repos:
             valid_schemes += private_schemes
-        if getattr(settings, 'DEBUG'):  # allow `file://` urls in dev
+        if settings.DEBUG:  # allow `file://` urls in dev
             valid_schemes += local_schemes
         url = urlparse(value)
 

--- a/readthedocs/projects/views/base.py
+++ b/readthedocs/projects/views/base.py
@@ -16,7 +16,7 @@ from ..models import Project
 
 log = logging.getLogger(__name__)
 
-USER_MATURITY_DAYS = getattr(settings, 'USER_MATURITY_DAYS', 7)
+USER_MATURITY_DAYS = settings.USER_MATURITY_DAYS
 
 
 class ProjectOnboardMixin:

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -205,7 +205,7 @@ def project_download_media(request, project_slug, type_, version_slug):
         project__slug=project_slug,
         slug=version_slug,
     )
-    privacy_level = getattr(settings, 'DEFAULT_PRIVACY_LEVEL', 'public')
+    privacy_level = settings.DEFAULT_PRIVACY_LEVEL
     if privacy_level == 'public' or settings.DEBUG:
         storage_path = version.project.get_storage_path(
             type_=type_, version_slug=version_slug

--- a/readthedocs/restapi/client.py
+++ b/readthedocs/restapi/client.py
@@ -14,10 +14,10 @@ from slumber import API, serialize
 
 log = logging.getLogger(__name__)
 
-PRODUCTION_DOMAIN = getattr(settings, 'PRODUCTION_DOMAIN', 'readthedocs.org')
-API_HOST = getattr(settings, 'SLUMBER_API_HOST', 'https://readthedocs.org')
-USER = getattr(settings, 'SLUMBER_USERNAME', None)
-PASS = getattr(settings, 'SLUMBER_PASSWORD', None)
+PRODUCTION_DOMAIN = settings.PRODUCTION_DOMAIN
+API_HOST = settings.SLUMBER_API_HOST
+USER = settings.SLUMBER_USERNAME
+PASS = settings.SLUMBER_PASSWORD
 
 
 class DrfJsonSerializer(serialize.JsonSerializer):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -44,7 +44,6 @@ class CommunityBaseSettings(Settings):
     PUBLIC_DOMAIN = None
     PUBLIC_DOMAIN_USES_HTTPS = False
     USE_SUBDOMAIN = False
-    USE_SUBDOMAINS = None
     PUBLIC_API_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
 
     # slumber settings

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -4,6 +4,7 @@
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
+import getpass
 import os
 
 from celery.schedules import crontab
@@ -29,6 +30,7 @@ class CommunityBaseSettings(Settings):
     SITE_ID = 1
     ROOT_URLCONF = 'readthedocs.urls'
     SUBDOMAIN_URLCONF = 'readthedocs.core.urls.subdomain'
+    SINGLE_VERSION_URLCONF = 'readthedocs.core.urls.single_version'
     LOGIN_REDIRECT_URL = '/dashboard/'
     FORCE_WWW = False
     SECRET_KEY = 'replace-this-please'  # noqa
@@ -42,11 +44,18 @@ class CommunityBaseSettings(Settings):
     PUBLIC_DOMAIN = None
     PUBLIC_DOMAIN_USES_HTTPS = False
     USE_SUBDOMAIN = False
+    USE_SUBDOMAINS = None
     PUBLIC_API_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
+
+    # slumber settings
+    SLUMBER_API_HOST = 'https://readthedocs.org'
+    SLUMBER_USERNAME = None
+    SLUMBER_PASSWORD = None
 
     # Email
     DEFAULT_FROM_EMAIL = 'no-reply@readthedocs.org'
     SERVER_EMAIL = DEFAULT_FROM_EMAIL
+    SUPPORT_EMAIL = None
 
     # Sessions
     SESSION_COOKIE_DOMAIN = 'readthedocs.org'
@@ -60,6 +69,21 @@ class CommunityBaseSettings(Settings):
 
     # Read the Docs
     READ_THE_DOCS_EXTENSIONS = ext
+    RTD_LATEST = 'latest'
+    RTD_LATEST_VERBOSE_NAME = 'latest'
+    RTD_STABLE = 'stable'
+    RTD_STABLE_VERBOSE_NAME = 'stable'
+
+    # Database and API hitting settings
+    DONT_HIT_API = False
+    DONT_HIT_DB = True
+
+    SYNC_USER = getpass.getuser()
+
+    USER_MATURITY_DAYS = 7
+
+    # override classes
+    CLASS_OVERRIDES = {}
 
     # Application classes
     @property
@@ -179,6 +203,7 @@ class CommunityBaseSettings(Settings):
         'readthedocs.core.static.SelectiveFileSystemFinder',
         'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     ]
+    PYTHON_MEDIA = False
 
     TEMPLATES = [
         {
@@ -212,6 +237,7 @@ class CommunityBaseSettings(Settings):
         }
     }
     CACHE_MIDDLEWARE_SECONDS = 60
+    GLOBAL_PIP_CACHE = False
 
     # I18n
     TIME_ZONE = 'UTC'
@@ -270,13 +296,19 @@ class CommunityBaseSettings(Settings):
             'options': {'queue': 'web'},
         },
     }
+    MULTIPLE_APP_SERVERS = [CELERY_DEFAULT_QUEUE]
+    MULTIPLE_BUILD_SERVERS = [CELERY_DEFAULT_QUEUE]
 
     # Sentry
     SENTRY_CELERY_IGNORE_EXPECTED = True
 
     # Docker
     DOCKER_ENABLE = False
+    DOCKER_SOCKET = 'unix:///var/run/docker.sock'
+    DOCKER_BUILD_IMAGES = None
+    DOCKER_LIMITS = {}
     DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
+    DOCKER_VERSION = 'auto'
     DOCKER_DEFAULT_VERSION = 'latest'
     DOCKER_IMAGE = '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION)
     DOCKER_IMAGE_SETTINGS = {
@@ -346,6 +378,7 @@ class CommunityBaseSettings(Settings):
     DEFAULT_PRIVACY_LEVEL = 'public'
     GROK_API_HOST = 'https://api.grokthedocs.com'
     SERVE_DOCS = ['public']
+    ALLOW_ADMIN = True
 
     # Elasticsearch settings.
     ES_HOSTS = ['127.0.0.1:9200']

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -46,6 +46,10 @@ class CommunityBaseSettings(Settings):
     USE_SUBDOMAIN = False
     PUBLIC_API_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
 
+    # Doc Builder Backends
+    MKDOCS_BACKEND = 'readthedocs.doc_builder.backends.mkdocs'
+    SPHINX_BACKEND = 'readthedocs.doc_builder.backends.sphinx'
+
     # slumber settings
     SLUMBER_API_HOST = 'https://readthedocs.org'
     SLUMBER_USERNAME = None
@@ -376,6 +380,7 @@ class CommunityBaseSettings(Settings):
     REPO_LOCK_SECONDS = 30
     ALLOW_PRIVATE_REPOS = False
     DEFAULT_PRIVACY_LEVEL = 'public'
+    DEFAULT_VERSION_PRIVACY_LEVEL = 'public'
     GROK_API_HOST = 'https://api.grokthedocs.com'
     SERVE_DOCS = ['public']
     ALLOW_ADMIN = True

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -305,8 +305,9 @@ class CommunityBaseSettings(Settings):
     # Docker
     DOCKER_ENABLE = False
     DOCKER_SOCKET = 'unix:///var/run/docker.sock'
+    # This settings has been deprecated in favor of DOCKER_IMAGE_SETTINGS
     DOCKER_BUILD_IMAGES = None
-    DOCKER_LIMITS = {}
+    DOCKER_LIMITS = {'memory': '200m', 'time': 600}
     DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
     DOCKER_VERSION = 'auto'
     DOCKER_DEFAULT_VERSION = 'latest'

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -128,11 +128,11 @@ if settings.READ_THE_DOCS_EXTENSIONS:
         url(r'^', include('readthedocsext.urls'))
     ])
 
-if not getattr(settings, 'USE_SUBDOMAIN', False) or settings.DEBUG:
+if not settings.USE_SUBDOMAIN or settings.DEBUG:
     groups.insert(0, docs_urls)
-if getattr(settings, 'ALLOW_ADMIN', True):
+if settings.ALLOW_ADMIN:
     groups.append(admin_urls)
-if getattr(settings, 'DEBUG', False):
+if settings.DEBUG:
     import debug_toolbar
 
     debug_urls += [


### PR DESCRIPTION
I wasn't quite sure what to with this so I left it as it is:
https://github.com/rtfd/readthedocs.org/blob/7fa9002586b2c5c2fae5c78e5ad736d9d46f7ad4/readthedocs/core/utils/extend.py#L29

closes #2140 