### PR TITLE
Handle 401, 403 and 404  when setting up webhooks

### DIFF
--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -239,6 +239,15 @@ class BitbucketService(Service):
                     project,
                 )
                 return (True, resp)
+
+            if resp.status_code in [401, 403, 404]:
+                log.info(
+                    'Bitbucket project does not exist or user does not have '
+                    'permissions: project=%s',
+                    project,
+                )
+                return (False, resp)
+
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             log.exception(

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -301,6 +301,15 @@ class GitLabService(Service):
                     project,
                 )
                 return (True, resp)
+
+            if resp.status_code in [401, 403, 404]:
+                log.info(
+                    'Gitlab project does not exist or user does not have '
+                    'permissions: project=%s',
+                    project,
+                )
+                return (False, resp)
+
         except (RequestException, ValueError):
             log.exception(
                 'GitLab webhook creation failed for project: %s',


### PR DESCRIPTION
Instead of doing it Like this I propose having a method (`create_webhook`) to handle webhook creation for Github, Gitlab and Bitbucket. The method might contain something like this:

https://github.com/rtfd/readthedocs.org/blob/b356689f26f380c38dcec828fd256d17b86ec849/readthedocs/oauth/services/bitbucket.py#L233-L249

closes #5092 