### PR TITLE
Ignore pytest-xdist from pyupdate

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -9,7 +9,7 @@ pytest==4.1.1  # pyup: <4.2
 # previous tests
 pytest-django==3.4.6  # pyup: <3.4.7
 # pytest-xdist >1.27 requires pytest >4.1
-pytest-xdist==1.27.0
+pytest-xdist==1.27.0  # pyup: ignore
 pytest-cov==2.6.1
 apipkg==1.5
 execnet==1.6.0


### PR DESCRIPTION
Sorry I merged https://github.com/rtfd/readthedocs.org/pull/5580, but I forgot about ignoring the update :(