### PR TITLE
Add meta descriptions to top documentation

### DIFF
--- a/docs/advertising/ethical-advertising.rst
+++ b/docs/advertising/ethical-advertising.rst
@@ -2,7 +2,7 @@ Ethical Ads
 ===========
 
 .. meta::
-   :description: To fund Read the Docs, we built an ad platform that doesn't track users and respects their privacy.
+   :description lang=en: To fund Read the Docs, we built an ad platform that doesn't track users and respects their privacy.
 
 
 Read the Docs is a large, free web service.

--- a/docs/advertising/ethical-advertising.rst
+++ b/docs/advertising/ethical-advertising.rst
@@ -1,6 +1,10 @@
 Ethical Ads
 ===========
 
+.. meta::
+   :description: To fund Read the Docs, we built an ad platform that doesn't track users and respects their privacy.
+
+
 Read the Docs is a large, free web service.
 There is one proven business model to support this kind of site: **Advertising**.
 We are building the advertising model we want to exist,

--- a/docs/advertising/index.rst
+++ b/docs/advertising/index.rst
@@ -1,6 +1,10 @@
 Advertising
 ===========
 
+.. meta::
+   :description: Read the Docs is a large open source project funded by ethical advertising which respects user privacy and doesn't track people.
+
+
 Advertising is the single largest source of funding for Read the Docs.
 It allows us to:
 

--- a/docs/advertising/index.rst
+++ b/docs/advertising/index.rst
@@ -2,7 +2,7 @@ Advertising
 ===========
 
 .. meta::
-   :description: Read the Docs is a large open source project funded by ethical advertising which respects user privacy and doesn't track people.
+   :description lang=en: Read the Docs is a large open source project funded by ethical advertising which respects user privacy and doesn't track people.
 
 
 Advertising is the single largest source of funding for Read the Docs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,10 @@
 Read the Docs: Documentation Simplified
 =======================================
 
+.. meta::
+   :description: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
+
+
 `Read the Docs`_ simplifies software documentation
 by automating building, versioning, and hosting of your docs for you.
 Think of it as *Continuous Documentation*.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Read the Docs: Documentation Simplified
 =======================================
 
 .. meta::
-   :description: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
+   :description lang=en: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
 
 
 `Read the Docs`_ simplifies software documentation

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,6 +1,10 @@
 Installation
 ============
 
+.. meta::
+   :description: Install a local instance of Read the Docs on your own servers with our step by step guide.
+
+
 Here is a step by step guide on how to install Read the Docs.
 It will get you to a point of having a local running instance.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 .. meta::
-   :description: Install a local instance of Read the Docs on your own servers with our step by step guide.
+   :description lang=en: Install a local instance of Read the Docs on your own servers with our step by step guide.
 
 
 Here is a step by step guide on how to install Read the Docs.

--- a/docs/intro/getting-started-with-mkdocs.rst
+++ b/docs/intro/getting-started-with-mkdocs.rst
@@ -1,6 +1,10 @@
 Getting Started with MkDocs
 ===========================
 
+.. meta::
+   :description: Get started writing technical documentation with MkDocs and publishing to Read the Docs.
+
+
 MkDocs is a documentation generator that focuses on speed and simplicity.
 It has many great features including:
 

--- a/docs/intro/getting-started-with-mkdocs.rst
+++ b/docs/intro/getting-started-with-mkdocs.rst
@@ -2,7 +2,7 @@ Getting Started with MkDocs
 ===========================
 
 .. meta::
-   :description: Get started writing technical documentation with MkDocs and publishing to Read the Docs.
+   :description lang=en: Get started writing technical documentation with MkDocs and publishing to Read the Docs.
 
 
 MkDocs is a documentation generator that focuses on speed and simplicity.

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -2,7 +2,7 @@ Getting Started with Sphinx
 ===========================
 
 .. meta::
-   :description: Get started writing technical documentation with Sphinx and publishing to Read the Docs.
+   :description lang=en: Get started writing technical documentation with Sphinx and publishing to Read the Docs.
 
 
 Sphinx is a powerful documentation generator that

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -1,6 +1,10 @@
 Getting Started with Sphinx
 ===========================
 
+.. meta::
+   :description: Get started writing technical documentation with Sphinx and publishing to Read the Docs.
+
+
 Sphinx is a powerful documentation generator that
 has many great features for writing technical documentation including:
 

--- a/docs/intro/import-guide.rst
+++ b/docs/intro/import-guide.rst
@@ -2,7 +2,7 @@ Importing Your Documentation
 ============================
 
 .. meta::
-   :description: Import your existing technical documentation from source control into Read the Docs.
+   :description lang=en: Import your existing technical documentation from source control into Read the Docs.
 
 
 To import a documentation repository, visit your `Read the Docs dashboard`_ and click Import_.

--- a/docs/intro/import-guide.rst
+++ b/docs/intro/import-guide.rst
@@ -1,6 +1,10 @@
 Importing Your Documentation
 ============================
 
+.. meta::
+   :description: Import your existing technical documentation from source control into Read the Docs.
+
+
 To import a documentation repository, visit your `Read the Docs dashboard`_ and click Import_.
 
 If you have :doc:`connected your Read the Docs account <../connected-accounts>` to GitHub, Bitbucket, or GitLab,

--- a/docs/intro/import-guide.rst
+++ b/docs/intro/import-guide.rst
@@ -2,7 +2,7 @@ Importing Your Documentation
 ============================
 
 .. meta::
-   :description lang=en: Import your existing technical documentation from source control into Read the Docs.
+   :description lang=en: Import your existing technical documentation from version control into Read the Docs.
 
 
 To import a documentation repository, visit your `Read the Docs dashboard`_ and click Import_.


### PR DESCRIPTION
Initially my goal here is to just have slightly better blurbs on search engine result pages (SERPs).

<img width="708" alt="Screen Shot 2019-04-15 at 11 41 09 AM" src="https://user-images.githubusercontent.com/185043/56146057-85ab8900-5f73-11e9-9803-cf59acfb4d1b.png">
<img width="734" alt="Screen Shot 2019-04-15 at 11 42 02 AM" src="https://user-images.githubusercontent.com/185043/56146058-85ab8900-5f73-11e9-88b4-67bffed9e297.png">
