### PR TITLE
UX improvements around SSL certificates

### DIFF
--- a/readthedocs/templates/projects/domain_form.html
+++ b/readthedocs/templates/projects/domain_form.html
@@ -13,7 +13,7 @@
 {% block project_edit_content_header %}
 
 {% if domain %}
-{% trans "Edit Domain" %}
+{% trans "Domain Details" %}
 {% else %}
 {% trans "Create Domain" %}
 {% endif %}
@@ -24,7 +24,7 @@
   {% if domain.domainssl %}
     {# This references optional code to get the SSL certificate status #}
     <p>
-      <strong>HTTPS status: </strong>
+      <strong>{% trans 'SSL certificate status' %}: </strong>
       <span>{{ domain.domainssl.status }}</span>
     </p>
   {% endif %}
@@ -36,8 +36,9 @@
   {% endif %}
   <form method="post" action="{{ action_url }}">{% csrf_token %}
     {{ form.as_p }}
-    <p>
-      <input style="display: inline;" type="submit" value="{% trans "Submit" %}">
-    </p>
+    <input type="submit" value="{% trans "Save Domain" %}">
+    {% if domain.domainssl %}
+      <p class="help-block">{% trans 'Saving the domain will revalidate the SSL certificate' %}</p>
+    {% endif %}
   </form>
 {% endblock %}

--- a/readthedocs/templates/projects/domain_list.html
+++ b/readthedocs/templates/projects/domain_list.html
@@ -26,7 +26,7 @@
     {% for domain in object_list %}
         <li class="{% if domain.machine %}domain-machine{% endif %} {% if domain.canonical %}domain-canonical{% endif %}" >
         {{ domain.domain }}
-        (<a href="{% url 'projects_domains_edit' project.slug domain.pk %}">{% trans "Edit" %}</a>)
+        (<a href="{% url 'projects_domains_edit' project.slug domain.pk %}">{% trans "Details" %}</a>)
         (<a href="{% url 'projects_domains_delete' project.slug domain.pk %}">{% trans "Remove" %}</a>)
         </li>
     {% endfor %}


### PR DESCRIPTION
- Use domain details instead of "edit" - more obvious
- Use "save domain" instead of "submit" for the form
- Show that the cert will revalidate when saved

![Screen Shot 2019-04-24 at 3 18 30 PM](https://user-images.githubusercontent.com/185043/56697711-4502ec80-66a4-11e9-86d3-1e279c002208.png)
