### PR TITLE
Redirect project slugs with underscores

### DIFF
--- a/readthedocs/projects/urls/public.py
+++ b/readthedocs/projects/urls/public.py
@@ -18,6 +18,11 @@ urlpatterns = [
         name='projects_list',
     ),
     url(
+        r'^(?P<invalid_project_slug>{project_slug}_{project_slug})/'.format(**pattern_opts),
+        public.project_redirect,
+        name='project_redirect',
+    ),
+    url(
         r'^(?P<project_slug>{project_slug})/$'.format(**pattern_opts),
         ProjectDetailView.as_view(),
         name='projects_detail',

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -15,7 +15,7 @@ from django.core.cache import cache
 from django.core.files.storage import get_storage_class
 from django.db.models import prefetch_related_objects
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse
 from django.views.decorators.cache import never_cache
 from django.views.generic import DetailView, ListView
@@ -68,6 +68,16 @@ class ProjectIndex(ListView):
         context['person'] = self.user
         context['tag'] = self.tag
         return context
+
+
+def project_redirect(request, invalid_project_slug):
+    """Redirect old project slugs that had underscores which are no longer allowed"""
+    new_project_slug = invalid_project_slug.replace('_', '-')
+    new_path = request.path.replace(invalid_project_slug, new_project_slug)
+    return redirect('{}?{}'.format(
+        new_path,
+        request.GET.urlencode(),
+    ))
 
 
 class ProjectDetailView(BuildTriggerMixin, ProjectOnboardMixin, DetailView):

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -171,6 +171,7 @@ class ProjectMixin(URLAccessMixin):
             'integration_pk': self.integration.pk,
             'exchange_pk': self.webhook_exchange.pk,
             'environmentvariable_pk': self.environment_variable.pk,
+            'invalid_project_slug': 'invalid_slug',
         }
 
 
@@ -185,6 +186,7 @@ class PublicProjectMixin(ProjectMixin):
         # Public
         '/projects/pip/downloads/pdf/latest/': {'status_code': 302},
         '/projects/pip/badge/': {'status_code': 200},
+        '/projects/invalid_slug/': {'status_code': 302},
     }
 
     def test_public_urls(self):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -499,6 +499,13 @@ class TestBadges(TestCase):
         # The social badge (but not the other badges) has this element
         self.assertContains(res, 'rlink')
 
+    def test_badge_redirect(self):
+        # Test that a project with an underscore redirects
+        badge_url = reverse('project_badge', args=['project_slug'])
+        resp = self.client.get(badge_url, {'version': 'latest'})
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue('project-slug' in resp['location'])
+
 
 class TestTags(TestCase):
     def test_project_filtering_work_with_tags_with_space_in_name(self):


### PR DESCRIPTION
This is a PR related to data cleanup. It redirects all requests to `/project/<project_slug>/*` where `project_slug` contains an underscore to a version of the project slug with a `-`.

* We currently have 7 projects with a `_` in them. New projects already can't have an underscore in their slug. We should modify the offending project slugs.
* Technically, this won't redirect projects with a slug starting or ending with a `_` but I think that's ok.

Related to: #5633