### PR TITLE
Use `--upgrade` instead of `--force-reinstall` for pip installs

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -96,7 +96,9 @@ class PythonEnvironment:
                 '-m',
                 'pip',
                 'install',
-                '--force-reinstall',
+                '--upgrade',
+                '--upgrade-strategy',
+                'eager',
                 '--cache-dir',
                 self.project.pip_cache_path,
                 '{path}{extra_requirements}'.format(


### PR DESCRIPTION
As discussed in #5545, the `--force-reinstall` causes a lot of issues for Conda builds,
whereby some packages (for example `docutils`) cannot be uninstalled by pip.

A more comprehensive solution may be to include additional options in the `.readthedocs.yaml`,
to control the flags used when pip installing.
But, at least as an intermediary solution, I see no drawbacks in using `--upgrade --upgrade-strategy eager` to achieve the same objective, of ensuring dependencies are up-to-date (but without unnecessary uninstall/reinstall of dependencies).