### PR TITLE
Move community support to email

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -13,7 +13,7 @@ Our current build limits are:
 * 1GB of RAM memory
 
 We can increase build limits on a per-project basis,
-if you provide a good reason your documentation needs more resources.
+sending an email to support@readthedocs.org providing a good reason why your documentation needs more resources.
 
 You can see the current Docker build images that we use in our `docker repository <https://github.com/rtfd/readthedocs-docker-images>`_.
 `Docker Hub <https://hub.docker.com/r/readthedocs/build/>`_ also shows the latest set of images that have been built.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -21,7 +21,8 @@ You can delete and re-create the project with the proper name to get a new slug,
 but you really shouldn't do this if you have existing inbound links,
 as it `breaks the internet <http://www.w3.org/Provider/Style/URI.html>`_.
 
-If that isn't enough, you can ask to team to do this by `creating an issue <https://github.com/rtfd/readthedocs.org/issues/new>`__.
+If that isn't enough,
+you can request the change sending an email to support@readthedocs.org.
 
 
 How do I change the version slug of my project?
@@ -29,7 +30,8 @@ How do I change the version slug of my project?
 
 We don't support allowing folks to change the slug for their versions.
 But you can rename the branch/tag to achieve this.
-If that isn't enough, you can ask to team to do this by `creating an issue <https://github.com/rtfd/readthedocs.org/issues/new>`__.
+If that isn't enough,
+you can request the change sending an email to support@readthedocs.org.
 
 Help, my build passed but my documentation page is 404 Not Found!
 -----------------------------------------------------------------
@@ -72,10 +74,8 @@ My project requires different settings than those available under Admin
 
 Read the Docs offers some settings which can be used for a variety of purposes,
 such as to use the latest version of sphinx or pip. To enable these settings,
-please open a request issue on our `github`_ and we will change the settings for the project.
+please send an email to support@readthedocs.org and we will change the settings for the project.
 Read more about these settings :doc:`here <guides/feature-flags>`.
-
-.. _github: https://github.com/rtfd/readthedocs.org
 
 I get import errors on libraries that depend on C modules
 ---------------------------------------------------------

--- a/docs/guides/build-using-too-many-resources.rst
+++ b/docs/guides/build-using-too-many-resources.rst
@@ -52,3 +52,10 @@ To use these pre-installed libraries and avoid consuming time re-downloading/com
 you can use the :ref:`config-file/v2:python.system_packages` option to have access to them.
 
 .. _Docker image repository: https://github.com/rtfd/readthedocs-docker-images
+
+Requests more resources
+-----------------------
+
+If you still have problems building your documentation,
+we can increase build limits on a per-project basis,
+sending an email to support@readthedocs.org providing a good reason why your documentation needs more resources.

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -50,8 +50,8 @@ This includes:
 Specific Requests
 ~~~~~~~~~~~~~~~~~
 
-If you need a specific request for your project,
-like more resources or change of the project's slug.
+If you need a specific request for your project or account,
+like more resources, change of the project's slug or username.
 Send an email to support@readthedocs.org.
 
 Commercial Support

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -47,6 +47,13 @@ This includes:
 * Expected result
 * Actual result
 
+Specific Requests
+~~~~~~~~~~~~~~~~~
+
+If you need a specific request for your project,
+like more resources or change of the project's slug.
+Send an email to support@readthedocs.org.
+
 Commercial Support
 ------------------
 


### PR DESCRIPTION
With the aim of keeping the issue tracker related to code issues,
and have a more control over specific request.
We are moving admin-only actionable request to email.

I found these places only, not sure if anything else is missing or if we are pointing to the correct email :)