### PR TITLE
Upgrade docker python package to latest release

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -77,11 +77,7 @@ git+https://github.com/mozilla/unicode-slugify@b696c37#egg=unicode-slugify==0.1.
 django-formtools==2.1
 django-crispy-forms==1.7.2 
 
-# docker is pinned to 3.1.3 because we found some strange behavior
-# related to timeouts on EXEC with 3.2.1 and 3.3.0 that's not present
-# with 3.1.3
-# https://github.com/rtfd/readthedocs.org/issues/3999
-docker==3.1.3  # pyup: ignore
+docker==3.7.2
 
 django-textclassifier==1.0
 django-annoying==0.10.4


### PR DESCRIPTION
`docker` is upgraded in production `build03` and it's not reporting errors. It seems it's safe to merge this and include in the next deploy.

Closes #3999 