### PR TITLE
Use latexmk if Sphinx > 1.6

### DIFF
--- a/docs/guides/feature-flags.rst
+++ b/docs/guides/feature-flags.rst
@@ -12,8 +12,6 @@ or disable one or more of these featured flags for a particular project.
 Available Flags
 ---------------
 
-``USE_PDF_LATEXMK``: :featureflags:`USE_PDF_LATEXMK`
-
 ``USE_SPHINX_LATEST``: :featureflags:`USE_SPHINX_LATEST`
 
 ``ALLOW_DEPRECATED_WEBHOOKS``: :featureflags:`ALLOW_DEPRECATED_WEBHOOKS`

--- a/docs/guides/pdf-non-ascii-languages.rst
+++ b/docs/guides/pdf-non-ascii-languages.rst
@@ -1,13 +1,6 @@
 Build PDF format for non-ASCII languages
 ========================================
 
-
-.. warning::
-
-   To be able to follow this guide and build PDF with this method,
-   you need to ask the Read the Docs core team to enable ``USE_PDF_LATEXMK`` :doc:`feature flag </guides/feature-flags>` in your project.
-   Please, `open an issue`_ in our repository asking for this, and wait for one of the core team to enable it.
-
 .. _open an issue: https://github.com/rtfd/readthedocs.org/issues/new
 
 Sphinx offers different `LaTeX engines`_ that support Unicode characters and non-ASCII languages,

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -149,9 +149,6 @@ class BaseSphinx(BaseBuilder):
             'dont_overwrite_sphinx_context': self.project.has_feature(
                 Feature.DONT_OVERWRITE_SPHINX_CONTEXT,
             ),
-            'use_pdf_latexmk': self.project.has_feature(
-                Feature.USE_PDF_LATEXMK,
-            ),
         }
 
         finalize_sphinx_context_data.send(

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -242,16 +242,17 @@ class BaseSphinx(BaseBuilder):
         In this case, the output will be ``2.0.0``.
         """
 
-
         command = [
             self.python_env.venv_bin(filename='python'),
             '-c'
-            '"import sphinx;print(sphinx.__version__)"',
+            '"import sphinx; print(sphinx.__version__)"',
         ]
+
         cmd_ret = self.run(
             *command,
-            cwd=self.project.checkout_path(self.version.slug),
             bin_path=self.python_env.venv_bin(),
+            cwd=self.project.checkout_path(self.version.slug),
+            escape_command=False,
         )
         return cmd_ret.output
 

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -259,7 +259,7 @@ class BaseSphinx(BaseBuilder):
             shell=True,  # used on BuildCommand
             record=False,
         )
-        return True if cmd_ret.exit_code == 0 else False
+        return cmd_ret.exit_code == 0
 
 
 class HtmlBuilder(BaseSphinx):

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from django.conf import settings
 from django.template import loader as template_loader
 from django.template.loader import render_to_string
-from packaging.version import Version
 
 from readthedocs.builds import utils as version_utils
 from readthedocs.projects.exceptions import ProjectConfigurationError

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -252,8 +252,8 @@ class BaseSphinx(BaseBuilder):
             *command,
             bin_path=self.python_env.venv_bin(),
             cwd=self.project.checkout_path(self.version.slug),
-            escape_command=False,
-            shell=True,
+            escape_command=False,  # used on DockerBuildCommand
+            shell=True,  # used on BuildCommand
             record=False,
         )
         return cmd_ret.output

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -244,7 +244,7 @@ class BaseSphinx(BaseBuilder):
 
         command = [
             self.python_env.venv_bin(filename='python'),
-            '-c'
+            '-c',
             '"import sphinx; print(sphinx.__version__)"',
         ]
 
@@ -253,6 +253,7 @@ class BaseSphinx(BaseBuilder):
             bin_path=self.python_env.venv_bin(),
             cwd=self.project.checkout_path(self.version.slug),
             escape_command=False,
+            shell=True,
             record=False,
         )
         return cmd_ret.output

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -253,6 +253,7 @@ class BaseSphinx(BaseBuilder):
             bin_path=self.python_env.venv_bin(),
             cwd=self.project.checkout_path(self.version.slug),
             escape_command=False,
+            record=False,
         )
         return cmd_ret.output
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -83,6 +83,7 @@ class BuildCommand(BuildCommandResultMixin):
     :param build_env: build environment to use to execute commands
     :param bin_path: binary path to add to PATH resolution
     :param description: a more grokable description of the command being run
+    :param kwargs: allow to subclass this class and extend it
     """
 
     def __init__(
@@ -97,6 +98,7 @@ class BuildCommand(BuildCommandResultMixin):
             bin_path=None,
             description=None,
             record_as_success=False,
+            **kwargs,
     ):
         self.command = command
         self.shell = shell

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -296,14 +296,20 @@ class DockerBuildCommand(BuildCommand):
     Build command to execute in docker container
     """
 
-    def run(self):
+    def __init__(self, *args, escape_command=True, **kwargs):
         """
-        Execute command in existing Docker container.
+        Override default to extend behavior.
 
-        :param cmd_input: input to pass to command in STDIN
-        :type cmd_input: str
-        :param combine_output: combine STDERR into STDOUT
+        :param escape_command: whether escape special chars the command before
+            executing it in the container. This should only be disabled on
+            trusted or internal commands.
+        :type escape_command: bool
         """
+        self.escape_command = escape_command
+        super(DockerBuildCommand, self).__init__(*args, **kwargs)
+
+    def run(self):
+        """Execute command in existing Docker container."""
         log.info(
             "Running in container %s: '%s' [%s]",
             self.build_env.container_id,
@@ -352,13 +358,15 @@ class DockerBuildCommand(BuildCommand):
 
     def get_wrapped_command(self):
         """
-        Escape special bash characters in command to wrap in shell.
+        Wrap command in a shell and optionally escape special bash characters.
 
         In order to set the current working path inside a docker container, we
-        need to wrap the command in a shell call manually. Some characters will
-        be interpreted as shell characters without escaping, such as: ``pip
-        install requests<0.8``. This escapes a good majority of those
-        characters.
+        need to wrap the command in a shell call manually.
+
+        Some characters will be interpreted as shell characters without
+        escaping, such as: ``pip install requests<0.8``. When passing
+        ``escape_command=True`` in the init method this escapes a good majority
+        of those characters.
         """
         bash_escape_re = re.compile(
             r"([\t\ \!\"\#\$\&\'\(\)\*\:\;\<\>\?\@"
@@ -367,16 +375,18 @@ class DockerBuildCommand(BuildCommand):
         prefix = ''
         if self.bin_path:
             prefix += 'PATH={}:$PATH '.format(self.bin_path)
+
+        command = (
+            ' '.join([
+                bash_escape_re.sub(r'\\\1', part) if self.escape_command else part
+                for part in self.command
+            ])
+        )
         return (
             "/bin/sh -c 'cd {cwd} && {prefix}{cmd}'".format(
                 cwd=self.cwd,
                 prefix=prefix,
-                cmd=(
-                    ' '.join([
-                        bash_escape_re.sub(r'\\\1', part)
-                        for part in self.command
-                    ])
-                ),
+                cmd=command,
             )
         )
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -168,8 +168,13 @@ class BuildCommand(BuildCommandResultMixin):
             environment['PATH'] = ':'.join(env_paths)
 
         try:
+            # When using ``shell=True`` the command should be flatten
+            command = self.command
+            if self.shell:
+                command = self.get_command()
+
             proc = subprocess.Popen(
-                self.command,
+                command,
                 shell=self.shell,
                 # This is done here for local builds, but not for docker,
                 # as we want docker to expand inside the container

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -141,7 +141,6 @@ if 'extensions' in globals():
 else:
     extensions = ["readthedocs_ext.readthedocs"]
 
-{% if use_pdf_latexmk %}
 project_language = '{{ project.language }}'
 
 # User's Sphinx configurations
@@ -173,4 +172,3 @@ if chinese:
     latex_elements = latex_elements_user or latex_elements_rtd
 elif japanese:
     latex_engine = latex_engine_user or 'platex'
-{% endif %}

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1337,12 +1337,10 @@ class Feature(models.Model):
     DONT_SHALLOW_CLONE = 'dont_shallow_clone'
     USE_TESTING_BUILD_IMAGE = 'use_testing_build_image'
     SHARE_SPHINX_DOCTREE = 'share_sphinx_doctree'
-    USE_PDF_LATEXMK = 'use_pdf_latexmk'
     DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
-        (USE_PDF_LATEXMK, _('Use latexmk to build the PDF')),
         (ALLOW_DEPRECATED_WEBHOOKS, _('Allow deprecated webhook views')),
         (PIP_ALWAYS_UPGRADE, _('Always run pip install --upgrade')),
         (SKIP_SUBMODULES, _('Skip git submodule checkout')),

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -220,7 +220,7 @@ class BuildEnvironmentTests(TestCase):
         returns = [
             ((b'', b''), 0),  # sphinx-build html
             ((b'', b''), 0),  # sphinx-build pdf
-            ((b'1.5', b''), 0),  # sphinx version check
+            ((b'', b''), 1),  # sphinx version check
             ((b'', b''), 1),  # latex
             ((b'', b''), 0),  # makeindex
             ((b'', b''), 0),  # latex
@@ -272,7 +272,7 @@ class BuildEnvironmentTests(TestCase):
         returns = [
             ((b'', b''), 0),  # sphinx-build html
             ((b'', b''), 0),  # sphinx-build pdf
-            ((b'1.6', b''), 0),  # sphinx version check
+            ((b'', b''), 1),  # sphinx version check
             ((b'Output written on foo.pdf', b''), 1),  # latex
             ((b'', b''), 0),  # makeindex
             ((b'', b''), 0),  # latex

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -220,6 +220,7 @@ class BuildEnvironmentTests(TestCase):
         returns = [
             ((b'', b''), 0),  # sphinx-build html
             ((b'', b''), 0),  # sphinx-build pdf
+            ((b'1.5', b''), 0),  # sphinx version check
             ((b'', b''), 1),  # latex
             ((b'', b''), 0),  # makeindex
             ((b'', b''), 0),  # latex
@@ -236,7 +237,7 @@ class BuildEnvironmentTests(TestCase):
 
         with build_env:
             task.build_docs()
-        self.assertEqual(self.mocks.popen.call_count, 7)
+        self.assertEqual(self.mocks.popen.call_count, 8)
         self.assertTrue(build_env.failed)
 
     @mock.patch('readthedocs.doc_builder.config.load_config')
@@ -271,6 +272,7 @@ class BuildEnvironmentTests(TestCase):
         returns = [
             ((b'', b''), 0),  # sphinx-build html
             ((b'', b''), 0),  # sphinx-build pdf
+            ((b'1.6', b''), 0),  # sphinx version check
             ((b'Output written on foo.pdf', b''), 1),  # latex
             ((b'', b''), 0),  # makeindex
             ((b'', b''), 0),  # latex
@@ -287,7 +289,7 @@ class BuildEnvironmentTests(TestCase):
 
         with build_env:
             task.build_docs()
-        self.assertEqual(self.mocks.popen.call_count, 7)
+        self.assertEqual(self.mocks.popen.call_count, 8)
         self.assertTrue(build_env.successful)
 
     @mock.patch('readthedocs.projects.tasks.api_v2')


### PR DESCRIPTION
- Checks for the Sphinx version installed in the user virtualenv to decide if `latexmk` or `pdflatex` should be called to build the PDF.
- Removes the USE_PDF_LATEXMK feature flag since it's not needed anymore.

Closes #5655 