### PR TITLE
Support Docker 5.0 image

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -245,7 +245,11 @@ class BuildConfigBase:
     @property
     def python_interpreter(self):
         ver = self.python_full_version
-        return 'python{}'.format(ver)
+        if not ver or isinstance(ver, (int, float)):
+            return 'python{}'.format(ver)
+
+        # Allow to specify ``pypy3.5`` as Python interpreter
+        return ver
 
     @property
     def python_full_version(self):
@@ -254,7 +258,8 @@ class BuildConfigBase:
             # Get the highest version of the major series version if user only
             # gave us a version of '2', or '3'
             ver = max(
-                v for v in self.get_valid_python_versions() if v < ver + 1
+                v for v in self.get_valid_python_versions()
+                if not isinstance(v, str) and v < ver + 1
             )
         return ver
 

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -348,12 +348,21 @@ class TestValidatePythonVersion:
 
     def test_it_supports_other_versions(self):
         build = get_build_config(
-            {'python': {'version': 3.5}},
+            {'python': {'version': 3.7}},
         )
         build.validate()
-        assert build.python.version == 3.5
-        assert build.python_interpreter == 'python3.5'
-        assert build.python_full_version == 3.5
+        assert build.python.version == 3.7
+        assert build.python_interpreter == 'python3.7'
+        assert build.python_full_version == 3.7
+
+    def test_it_supports_string_versions(self):
+        build = get_build_config(
+            {'python': {'version': 'pypy3.5'}},
+        )
+        build.validate()
+        assert build.python.version == 'pypy3.5'
+        assert build.python_interpreter == 'pypy3.5'
+        assert build.python_full_version == 'pypy3.5'
 
     def test_it_validates_versions_out_of_range(self):
         build = get_build_config(
@@ -375,12 +384,12 @@ class TestValidatePythonVersion:
 
     def test_it_validates_wrong_type_right_value(self):
         build = get_build_config(
-            {'python': {'version': '3.5'}},
+            {'python': {'version': '3.6'}},
         )
         build.validate()
-        assert build.python.version == 3.5
-        assert build.python_interpreter == 'python3.5'
-        assert build.python_full_version == 3.5
+        assert build.python.version == 3.6
+        assert build.python_interpreter == 'python3.6'
+        assert build.python_full_version == 3.6
 
         build = get_build_config(
             {'python': {'version': '3'}},
@@ -716,7 +725,7 @@ def test_as_dict(tmpdir):
             'version': 1,
             'formats': ['pdf'],
             'python': {
-                'version': 3.5,
+                'version': 3.7,
             },
             'requirements_file': 'requirements.txt',
         },
@@ -733,7 +742,7 @@ def test_as_dict(tmpdir):
         'version': '1',
         'formats': ['pdf'],
         'python': {
-            'version': 3.5,
+            'version': 3.7,
             'install': [{
                 'requirements': str(tmpdir.join('requirements.txt')),
             }],
@@ -944,8 +953,8 @@ class TestBuildConfigV2:
     @pytest.mark.parametrize(
         'image,versions',
         [
-            ('latest', [2, 2.7, 3, 3.5, 3.6]),
-            ('stable', [2, 2.7, 3, 3.5, 3.6]),
+            ('latest', [2, 2.7, 3, 3.6, 3.7, 'pypy3.5']),
+            ('stable', [2, 2.7, 3, 3.6, 3.7]),
         ],
     )
     def test_python_version(self, image, versions):

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -953,8 +953,8 @@ class TestBuildConfigV2:
     @pytest.mark.parametrize(
         'image,versions',
         [
-            ('latest', [2, 2.7, 3, 3.6, 3.7, 'pypy3.5']),
-            ('stable', [2, 2.7, 3, 3.6, 3.7]),
+            ('latest', [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5']),
+            ('stable', [2, 2.7, 3, 3.5, 3.6, 3.7]),
         ],
     )
     def test_python_version(self, image, versions):

--- a/readthedocs/rtd_tests/tests/test_config_integration.py
+++ b/readthedocs/rtd_tests/tests/test_config_integration.py
@@ -144,7 +144,7 @@ class LoadConfigTests(TestCase):
         config = load_yaml_config(self.version)
         self.assertEqual(
             config.get_valid_python_versions(),
-            [2, 2.7, 3, 3.6, 3.7, 'pypy3.5'],
+            [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5'],
         )
 
     @mock.patch('readthedocs.doc_builder.config.load_config')

--- a/readthedocs/rtd_tests/tests/test_config_integration.py
+++ b/readthedocs/rtd_tests/tests/test_config_integration.py
@@ -144,7 +144,7 @@ class LoadConfigTests(TestCase):
         config = load_yaml_config(self.version)
         self.assertEqual(
             config.get_valid_python_versions(),
-            [2, 2.7, 3, 3.5, 3.6, 3.7],
+            [2, 2.7, 3, 3.6, 3.7, 'pypy3.5'],
         )
 
     @mock.patch('readthedocs.doc_builder.config.load_config')

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -330,7 +330,7 @@ class CommunityBaseSettings(Settings):
             'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7]},
         },
         'readthedocs/build:5.0': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.6, 3.7]},
+            'python': {'supported_versions': [2, 2.7, 3, 3.6, 3.7, 'pypy3.5']},
         },
     }
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -330,7 +330,7 @@ class CommunityBaseSettings(Settings):
             'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7]},
         },
         'readthedocs/build:5.0': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.6, 3.7, 'pypy3.5']},
+            'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5']},
         },
     }
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -329,12 +329,15 @@ class CommunityBaseSettings(Settings):
         'readthedocs/build:4.0': {
             'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7]},
         },
+        'readthedocs/build:5.0': {
+            'python': {'supported_versions': [2, 2.7, 3, 3.6, 3.7]},
+        },
     }
 
     # Alias tagged via ``docker tag`` on the build servers
     DOCKER_IMAGE_SETTINGS.update({
-        'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:3.0'),
-        'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:4.0'),
+        'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:4.0'),
+        'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
     })
 
     # All auth


### PR DESCRIPTION
Changes on this PR:

* Use `4.0` as `stable` and `5.0` as `latest` for our Docker images
* Allow to specify `pypy3.5` as Python version (see #5658)
* Adapt tests relying in Python `3.5` to use `3.6` or `3.7` ~~since `3.5` is not supported anymore~~

Required by https://github.com/rtfd/readthedocs-docker-images/pull/103.

