### PR TITLE
Configure the security middleware

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -70,6 +70,12 @@ class CommunityBaseSettings(Settings):
     CSRF_COOKIE_HTTPONLY = True
     CSRF_COOKIE_AGE = 30 * 24 * 60 * 60
 
+    # Security & X-Frame-Options Middleware
+    # https://docs.djangoproject.com/en/1.11/ref/middleware/#django.middleware.security.SecurityMiddleware
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = 'DENY'
+
     # Read the Docs
     READ_THE_DOCS_EXTENSIONS = ext
     RTD_LATEST = 'latest'
@@ -160,6 +166,7 @@ class CommunityBaseSettings(Settings):
         'django.middleware.common.CommonMiddleware',
         'django.middleware.security.SecurityMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'dj_pagination.middleware.PaginationMiddleware',


### PR DESCRIPTION
Configures the Django security middleware and the `XFrameOptionsMiddleware` which sets 3 headers on our HTTP responses served by Django.

* The [XSS_FILTER](https://docs.djangoproject.com/en/1.11/ref/middleware/#x-xss-protection) option will cause browsers that support it to implement a very basic XSS protection mechanism. Our site is probably not vulnerable to something this would prevent, but this is a best practice and may help prevent some future attacks against us
* The [NOSNIFF](https://docs.djangoproject.com/en/1.11/ref/middleware/#x-content-type-options-nosniff) option helps prevent user uploaded files from being interpreted by a content type other than what the server sends. We don't serve any user uploaded files currently from Django (we do in nginx and we do in RTD corporate) so I don't see this being a problem. We probably aren't currently vulnerable to anything that this would prevent but again this helps future proof us.
* We already set `X-Frame-Options` header in our nginx configs but this will help anyone with a private setup or in the event we forgot the header on an inherited block in nginx. This [middleware and header](https://docs.djangoproject.com/en/1.11/ref/clickjacking/) help prevent clickjacking and basically prevents other sites from iframing RTD.