### PR TITLE
Support single version subprojects URLs to serve from Django

### DIFF
--- a/readthedocs/core/urls/subdomain.py
+++ b/readthedocs/core/urls/subdomain.py
@@ -46,6 +46,18 @@ subdomain_urls = [
         serve_docs,
         name='docs_detail',
     ),
+
+    # Special case for single-version subprojects
+    # docs.customdomain.org/projects/subproject/_static/readthedocs-data.js
+    # docs.customdomain.org/projects/subproject/chapter/section/page.html
+    url(
+        (
+            r'^projects/(?P<subproject_slug>{project_slug})/'
+            r'(?P<filename>{filename_slug})$'.format(**pattern_opts)
+        ),
+        serve_docs,
+        name='docs_detail_singleversion_subproject',
+    ),
 ]
 
 groups = [subdomain_urls]

--- a/readthedocs/core/urls/subdomain.py
+++ b/readthedocs/core/urls/subdomain.py
@@ -47,17 +47,6 @@ subdomain_urls = [
         name='docs_detail',
     ),
 
-    # Special case for single-version subprojects
-    # docs.customdomain.org/projects/subproject/_static/readthedocs-data.js
-    # docs.customdomain.org/projects/subproject/chapter/section/page.html
-    url(
-        (
-            r'^projects/(?P<subproject_slug>{project_slug})/'
-            r'(?P<filename>{filename_slug})$'.format(**pattern_opts)
-        ),
-        serve_docs,
-        name='docs_detail_singleversion_subproject',
-    ),
 ]
 
 groups = [subdomain_urls]

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -120,7 +120,7 @@ def redirect_project_slug(request, project, subproject):  # pylint: disable=unus
             # community. This can be removed once the middleware incorporates
             # more data or redirects happen outside this application
             # See: https://github.com/rtfd/readthedocs.org/pull/5690
-            from readthedocsinc.core.views import serve_docs as corporate_serve_docs
+            from readthedocsinc.core.views import serve_docs as corporate_serve_docs  # noqa
             return corporate_serve_docs(request, project, project.slug, subproject, subproject.slug)
         except Exception:
             pass

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -115,14 +115,21 @@ def redirect_project_slug(request, project, subproject):  # pylint: disable=unus
     # ``subproject`` is a single-version, we don't have to redirect but to serve
     # the index file instead.
     if subproject and subproject.single_version:
-        # TODO: find a way to import ``serve_docs`` from corporate
-        return serve_docs(request, project, project.slug, subproject, subproject.slug)
+        try:
+            # HACK: this only affects corporate site and won't be hit on the
+            # community. This can be removed once the middleware incorporates
+            # more data or redirects happen outside this application
+            # See: https://github.com/rtfd/readthedocs.org/pull/5690
+            from readthedocsinc.core.views import serve_docs as corporate_serve_docs
+            return corporate_serve_docs(request, project, project.slug, subproject, subproject.slug)
+        except Exception:
+            pass
 
     return HttpResponseRedirect(
         resolve(
             subproject or project,
             query_params=urlparse_result.query,
-        )
+        ),
     )
 
 

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -120,10 +120,11 @@ def redirect_project_slug(request, project, subproject):  # pylint: disable=unus
             # community. This can be removed once the middleware incorporates
             # more data or redirects happen outside this application
             # See: https://github.com/rtfd/readthedocs.org/pull/5690
+            log.warning('Serving docs for a single-version subproject instead redirecting')
             from readthedocsinc.core.views import serve_docs as corporate_serve_docs  # noqa
             return corporate_serve_docs(request, project, project.slug, subproject, subproject.slug)
         except Exception:
-            pass
+            log.exception('Error trying to redirect a single-version subproject')
 
     return HttpResponseRedirect(
         resolve(

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -110,6 +110,14 @@ def map_project_slug(view_func):
 def redirect_project_slug(request, project, subproject):  # pylint: disable=unused-argument
     """Handle / -> /en/latest/ directs on subdomains."""
     urlparse_result = urlparse(request.get_full_path())
+
+    # When accessing docs.customdomain.org/projects/subproject/ and the
+    # ``subproject`` is a single-version, we don't have to redirect but to serve
+    # the index file instead.
+    if subproject and subproject.single_version:
+        # TODO: find a way to import ``serve_docs`` from corporate
+        return serve_docs(request, project, project.slug, subproject, subproject.slug)
+
     return HttpResponseRedirect(
         resolve(
             subproject or project,


### PR DESCRIPTION
Currently, Read the Docs Community does not have this problem because we serve directly from NGINX without passing through Django to get the `X-Accel-Redirect` header in its response.

Although, on Corporate we are returning an infinite redirect when accessing `/projects/subproject/` URL when subproject is a Single Version project.

- We have a `redirect_project_slug` view that is called when hitting `/projects/subproject/` to redirect to its default lang/version --this does not apply on single version subproject
- This redirect URL is only registered on `urls/subdomain.py` file (and not on `urls/single_version.py`), which should not be called when accessing a single version project is hit
- Our `SingleVersionMiddleware` (which overrides the `request.urlconf`) is not detecting that we are accessing to a single version project, because it uses the `request.slug` (which is the superproject) to check it. Related to https://github.com/rtfd/readthedocs.org/issues/5557#issuecomment-481292664

The current changes on this PR makes it work locally when `USE_SUBDOMAIN=True`, although it's not the best fix for this. To define this URL where it belongs to, we need to touch our `SubdomainMiddleware` to properly set `subproject_slug` and use that in different places instead --which could be a bigger refactor/improvement.