### PR TITLE
Enable auth validate passwords

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -181,6 +181,24 @@ class CommunityBaseSettings(Settings):
         'allauth.account.auth_backends.AuthenticationBackend',
     )
 
+    AUTH_PASSWORD_VALIDATORS = [
+        {
+            'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        },
+        {
+            'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+            'OPTIONS': {
+                'min_length': 9,
+            }
+        },
+        {
+            'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        },
+        {
+            'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        },
+    ]
+
     MESSAGE_STORAGE = 'readthedocs.notifications.storages.FallbackUniqueStorage'
 
     NOTIFICATION_BACKENDS = [

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -51,6 +51,9 @@ class CommunityDevSettings(CommunityBaseSettings):
     # Disable auto syncing elasticsearch documents in development
     ELASTICSEARCH_DSL_AUTOSYNC = False
 
+    # Disable password validators on development
+    AUTH_PASSWORD_VALIDATORS = []
+
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super().LOGGING


### PR DESCRIPTION
Define some simple validators to use when creating a new user or
changing the password.

https://docs.djangoproject.com/en/1.11/topics/auth/passwords/#module-django.contrib.auth.password_validation

Closes #5551