### PR TITLE
Move version "Clean" button to details page

### DIFF
--- a/readthedocs/templates/projects/project_version_detail.html
+++ b/readthedocs/templates/projects/project_version_detail.html
@@ -21,7 +21,7 @@
       {% if not version.active and version.built %}
         <p class="empty">
           {% url "project_version_delete_html" project.slug version.slug as version_delete_url %}
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             This version is inactive but its documentation is still available online.
             You can <a href="{{ version_delete_url }}">delete this version's documentation</a> if you want to remove it completely.
           {% endblocktrans %}

--- a/readthedocs/templates/projects/project_version_detail.html
+++ b/readthedocs/templates/projects/project_version_detail.html
@@ -1,6 +1,7 @@
 {% extends "projects/base_project.html" %}
 
 {% load i18n %}
+{% load privacy_tags %}
 
 {% block title %}{{ version.slug }} - {{ version.project.name }}{% endblock %}
 
@@ -15,6 +16,20 @@
 
 {% block content %}
     <h2> Editing {{ version.slug }} </h2>
+
+    {% if request.user|is_admin:project %}
+      {% if not version.active and version.built %}
+        <p class="empty">
+          {% url "project_version_delete_html" project.slug version.slug as version_delete_url %}
+          {% blocktrans %}
+            This version is inactive but its documentation is still available online.
+            You can <a href="{{ version_delete_url }}">delete this version's documentation</a> if you want to remove it completely.
+          {% endblocktrans %}
+        </p>
+      {% endif %}
+    {% endif %}
+
+
     <form method="post" action=".">
       {% csrf_token %}
       {{ form.as_p }}

--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -104,9 +104,6 @@ Versions
 
                       {% if request.user|is_admin:project %}
                         <ul class="module-item-menu">
-                          {% if version.built %}
-                            <li><a href="{% url "project_version_delete_html" project.slug version.slug %}">{% trans "Clean" %}</a></li>
-                          {% endif %}
                           <li><a href="{% url "project_version_detail" project.slug version.slug %}">{% trans "Edit" %}</a></li>
                         </ul>
                       {% endif %}


### PR DESCRIPTION
Instead of showing the "Clean" button next to a version in the "Inactive Versions" listing, this button is moved to the detail page with an explanation about what it does.

Changed from,

![Screenshot_2019-05-17_13-10-27](https://user-images.githubusercontent.com/244656/57924341-28259780-78a5-11e9-94dc-33a3c8ecb849.png)

to,

![Screenshot_2019-05-17_13-18-35](https://user-images.githubusercontent.com/244656/57924764-4f309900-78a6-11e9-9ad6-152cb7966e3a.png)

This change is made because we found that multiple buttons in a row breaks in other languages when translated (because of margin/padding). Also, this button is [not shown at all in the corporate site](https://github.com/rtfd/readthedocs-corporate/issues/534) and it should be --but we don't want to show it in the listing.