### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/readthedocs/config/tests/test_validation.py
+++ b/readthedocs/config/tests/test_validation.py
@@ -43,7 +43,7 @@ class TestValidateChoice:
 
     def test_it_accepts_valid_choice(self):
         result = validate_choice('choice', ('choice', 'another_choice'))
-        assert result is 'choice'
+        assert result == 'choice'
 
         with raises(ValidationError) as excinfo:
             validate_choice('c', 'abc')


### PR DESCRIPTION
Identity is not the same thing as equality in Python.  In this instance, we want the latter.

Use ==/!= to compare str, bytes, and int literals.

$ __python__
```python
>>> result = 'choic'
>>> result += 'e'
>>> result == 'choice'
True
>>> result is 'choice'
False
```