### PR TITLE
Use nonstopmode for latexmk

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -478,6 +478,7 @@ class PdfBuilder(BaseSphinx):
             '-dvi-',
             '-ps-',
             f'-jobname={self.project.slug}',
+            '-interaction=nonstopmode',
             warn_only=True,
             cwd=latex_cwd,
         )


### PR DESCRIPTION
This option helps latexmk to do not wait for a user input if any of latex commands fail. We are already using it when building with `pdflatex` and now I'm adding it to the `latexmk` flow.
