### PR TITLE
Canonical consistency example

### DIFF
--- a/docs/canonical.rst
+++ b/docs/canonical.rst
@@ -36,7 +36,7 @@ you should see a bit of HTML like this:
 
 .. code-block:: html
 
-    <link rel="canonical" href="http://pip.readthedocs.io/en/latest/installing.html">
+    <link rel="canonical" href="http://docs.fabfile.org/en/2.4/" />
 
 Links
 -----


### PR DESCRIPTION
Use fabric to show the HTML block for consistency with the rest of the page.