### PR TITLE
Create a funding file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://readthedocs.org/sustainability/


### PR DESCRIPTION
Adding this file will create a "sponsor" button on the GitHub UI for our repository next to "watch/unwatch". This button will open a modal which links to our external sustainability page (see screenshot).

There are a lot of possibilities here but before we spend any real time on it I'm interested to see if we get any engagement.

See:

* https://github.blog/2019-05-23-announcing-github-sponsors-a-new-way-to-contribute-to-open-source/
* https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository

![Screen Shot 2019-05-23 at 10 56 48 AM](https://user-images.githubusercontent.com/185043/58275275-7cb78f80-7d49-11e9-8915-12a274b37b83.png)
