### PR TITLE
Fix the sidebar ad color

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -250,7 +250,7 @@ div.ethical-footer {
 
 /* Dark theme */
 .ethical-dark-theme .ethical-sidebar {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: #4e4b4b;
     border: 1px solid #a0a0a0;
     color: #c2c2c2 !important;
 }


### PR DESCRIPTION
- Using transparency was a mistake especially when the sidebar color can be changed
- This color is 10% lighter than the default background color on the RTD theme which is what the transparency attempted to accomplish.
- Fixes: #5563