### PR TITLE
Pytest Timezone Warning Fixed

### DIFF
--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.timezone import make_aware
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
@@ -19,8 +20,8 @@ class APIEndpointTests(TestCase):
     fixtures = []
 
     def setUp(self):
-        created = datetime.datetime(2019, 4, 29, 10, 0, 0)
-        modified = datetime.datetime(2019, 4, 29, 12, 0, 0)
+        created = make_aware(datetime.datetime(2019, 4, 29, 10, 0, 0))
+        modified = make_aware(datetime.datetime(2019, 4, 29, 12, 0, 0))
 
         self.me = fixture.get(
             User,


### PR DESCRIPTION
While running `tox -e py36` was getting fludded with pytest warnings like this:
```
readthedocs/api/v3/tests/test_projects.py::APIEndpointTests::test_unauthed_others_projects_detail
  /home/saad/dev/readthedocs.org/.tox/py36/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField User.date_joined received a naive datetime (2019-04-29 10:00:00) while time zone support is active.
    RuntimeWarning)
  /home/saad/dev/readthedocs.org/.tox/py36/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField Project.pub_date received a naive datetime (2019-04-29 10:00:00) while time zone support is active.
    RuntimeWarning)
  /home/saad/dev/readthedocs.org/.tox/py36/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField Project.modified_date received a naive datetime (2019-04-29 12:00:00) while time zone support is active.
    RuntimeWarning)
  /home/saad/dev/readthedocs.org/.tox/py36/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField Project.pub_date received a naive datetime (2019-04-29 10:00:00) while time zone support is active.
    RuntimeWarning)
  /home/saad/dev/readthedocs.org/.tox/py36/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField Project.modified_date received a naive datetime (2019-04-29 12:00:00) while time zone support is active.
```

made the datetime objects timezone aware to avoid getting these warnings.