### PR TITLE
Pin kombu to 4.3.0

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -36,7 +36,7 @@ Pygments==2.4.1
 # https://github.com/sebleier/django-redis-cache/pull/162
 redis==2.10.6  # pyup: ignore
 # Kombu >4.3 requires redis>=3.2
-kombu==4.3.0
+kombu==4.3.0  # pyup: ignore
 # Celery 4.2 is incompatible with our code
 # when ALWAYS_EAGER = True
 celery==4.1.1  # pyup: ignore

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -35,6 +35,8 @@ Pygments==2.4.1
 # https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey
 # https://github.com/sebleier/django-redis-cache/pull/162
 redis==2.10.6  # pyup: ignore
+# Kombu >4.3 requires redis>=3.2
+kombu==4.3.0
 # Celery 4.2 is incompatible with our code
 # when ALWAYS_EAGER = True
 celery==4.1.1  # pyup: ignore


### PR DESCRIPTION
Celery can install kombu>=4.2.0
https://github.com/celery/celery/blob/v4.1.1/requirements/default.txt#L3

But kombu>4.3.0 requires redis>=3.2
https://github.com/celery/kombu/blob/v4.5.0/requirements/extras/redis.txt#L1