### PR TITLE
Fix mkdocs relpath

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -248,7 +248,7 @@ class BaseMkdocs(BaseBuilder):
             '--site-dir',
             self.build_dir,
             '--config-file',
-            self.yaml_file,
+            os.path.relpath(self.yaml_file, self.root_path),
         ]
         if self.config.mkdocs.fail_on_warning:
             build_command.append('--strict')

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -69,13 +69,13 @@ class BaseMkdocs(BaseBuilder):
 
     def get_yaml_config(self):
         """Find the ``mkdocs.yml`` file in the project root."""
-        mkdoc_path = self.config.mkdocs.configuration
-        if not mkdoc_path:
-            mkdoc_path = os.path.join(
-                self.project.checkout_path(self.version.slug),
-                'mkdocs.yml',
-            )
-        return mkdoc_path
+        mkdocs_path = self.config.mkdocs.configuration
+        if not mkdocs_path:
+            mkdocs_path = 'mkdocs.yml'
+        return os.path.join(
+            self.project.checkout_path(self.version.slug),
+            mkdocs_path,
+        )
 
     def load_yaml_config(self):
         """


### PR DESCRIPTION
After https://github.com/rtfd/readthedocs.org/pull/5377/
The code calling the config module is in charge of getting the full
path.