### PR TITLE
fix sphinx startup guide to not to fail on rtd build as per #2569

### DIFF
--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -101,7 +101,6 @@ Then in your ``conf.py``:
 .. code-block:: python
 
    extensions = ['recommonmark']
-   master_doc = 'index'
 
 .. warning:: Markdown doesn't support a lot of the features of Sphinx,
           like inline markup and directives. However, it works for

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -101,6 +101,7 @@ Then in your ``conf.py``:
 .. code-block:: python
 
    extensions = ['recommonmark']
+   master_doc = 'index'
 
 .. warning:: Markdown doesn't support a lot of the features of Sphinx,
           like inline markup and directives. However, it works for

--- a/docs/intro/import-guide.rst
+++ b/docs/intro/import-guide.rst
@@ -75,6 +75,10 @@ such as specifying a certain version of Python or installing additional dependen
 You can configure these settings in a ``readthedocs.yml`` file.
 See our :doc:`/config-file/index` docs for more details.
 
+It is also important to note that the default version of Sphinx is ``v1.8.5``. If
+chosing to build your documentation other than this, it must be specified in a
+``requirements.txt``` file.
+
 Read the Docs will host multiple versions of your code. You can read more about
 how to use this well on our :doc:`/versions` page.
 


### PR DESCRIPTION
It's great to have a Github issue outlining how to work around an issue in the startup documentation ( see #2569), but it looks bad when this hasn't been integrated back into the documentation (for about 5 months when there was a breaking change), as ReadTheDocs is all about the docs - especially docs for starting/intro tutorials.

As per #2569 this PR specifies the missing step to get docs building correctly first time in RTD, without having to search for answers to build failures.