### PR TITLE
Try to fix Elastic connection pooling issues

### DIFF
--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -3,6 +3,8 @@ import logging
 from django.conf import settings
 from django_elasticsearch_dsl import DocType, Index, fields
 
+from elasticsearch import Elasticsearch
+
 from readthedocs.projects.models import HTMLFile, Project
 from readthedocs.sphinx_domains.models import SphinxDomain
 
@@ -22,8 +24,19 @@ domain_index.settings(**domain_conf['settings'])
 log = logging.getLogger(__name__)
 
 
+class RTDDocTypeMixin(object):
+
+    def update(self, *args, **kwargs):
+        # Hack a fix to our broken connection pooling
+        # This creates a new connection on every request,
+        # but actually works :)
+        log.info('Hacking Elastic indexing to fix connection pooling')
+        self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL['default'])
+        super().update(*args, **kwargs)
+
+
 @domain_index.doc_type
-class SphinxDomainDocument(DocType):
+class SphinxDomainDocument(RTDDocTypeMixin, DocType):
     project = fields.KeywordField(attr='project.slug')
     version = fields.KeywordField(attr='version.slug')
     role_name = fields.KeywordField(attr='role_name')
@@ -63,7 +76,7 @@ class SphinxDomainDocument(DocType):
 
 
 @project_index.doc_type
-class ProjectDocument(DocType):
+class ProjectDocument(RTDDocTypeMixin, DocType):
 
     # Metadata
     url = fields.TextField(attr='get_absolute_url')
@@ -97,7 +110,7 @@ class ProjectDocument(DocType):
 
 
 @page_index.doc_type
-class PageDocument(DocType):
+class PageDocument(RTDDocTypeMixin, DocType):
 
     # Metadata
     project = fields.KeywordField(attr='project.slug')

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -24,7 +24,7 @@ domain_index.settings(**domain_conf['settings'])
 log = logging.getLogger(__name__)
 
 
-class RTDDocTypeMixin(object):
+class RTDDocTypeMixin:
 
     def update(self, *args, **kwargs):
         # Hack a fix to our broken connection pooling

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -46,7 +46,7 @@ class RTDFacetedSearch(FacetedSearch):
         # Hack a fix to our broken connection pooling
         # This creates a new connection on every request,
         # but actually works :)
-        log.info('Hacking Elastic to test connection pooling')
+        log.info('Hacking Elastic to fix search connection pooling')
         self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL['default'])
 
         super().__init__(**kwargs)

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -1,7 +1,10 @@
 import logging
 
+from elasticsearch import Elasticsearch
 from elasticsearch_dsl import FacetedSearch, TermsFacet
 from elasticsearch_dsl.query import Bool, SimpleQueryString
+
+from django.conf import settings
 
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.search.documents import (
@@ -39,6 +42,12 @@ class RTDFacetedSearch(FacetedSearch):
         for f in ALL_FACETS:
             if f in kwargs:
                 del kwargs[f]
+
+        # Hack a fix to our broken connection pooling
+        # This creates a new connection on every request,
+        # but actually works :)
+        log.info('Hacking Elastic to test connection pooling')
+        self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL['default'])
 
         super().__init__(**kwargs)
 

--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -60,7 +60,11 @@ def delete_objects_in_es(app_label, model_name, document_class, objects_id):
     queryset = doc_obj.get_queryset()
     queryset = queryset.filter(id__in=objects_id)
     log.info("Deleting model: %s, '%s' objects", model.__name__, queryset.count())
-    doc_obj.update(queryset.iterator(), action='delete')
+    try:
+        # This is a common case that we should be handling a better way
+        doc_obj.update(queryset.iterator(), action='delete')
+    except Exception:
+        log.warning('Unable to delete a subset of files. Continuing.')
 
 
 @app.task(queue='web')


### PR DESCRIPTION
This creates a new connection on every request,
hopefully working around the issues with the connection pool.

This will go out on 1 web and see if it resolves the issues at all.

This is branched from `rel`, which seems to have caused some weirdness :/