### PR TITLE
Use version_pk to trigger builds

### DIFF
--- a/readthedocs/core/management/commands/update_repos.py
+++ b/readthedocs/core/management/commands/update_repos.py
@@ -73,9 +73,8 @@ class Command(BaseCommand):
 
                         # pylint: disable=no-value-for-parameter
                         tasks.update_docs_task(
-                            version.project_id,
+                            version.pk,
                             build_pk=build.pk,
-                            version_pk=version.pk,
                         )
                 else:
                     p = Project.all_objects.get(slug=slug)
@@ -90,15 +89,16 @@ class Command(BaseCommand):
                 ):
                     # pylint: disable=no-value-for-parameter
                     tasks.update_docs_task(
-                        version.project_id,
+                        version.pk,
                         force=force,
-                        version_pk=version.pk,
                     )
             else:
                 log.info('Updating all docs')
                 for project in Project.objects.all():
                     # pylint: disable=no-value-for-parameter
+                    default_version = project.get_default_version()
+                    version = project.versions.get(slug=default_version)
                     tasks.update_docs_task(
-                        project.pk,
+                        version.pk,
                         force=force,
                     )

--- a/readthedocs/core/management/commands/update_versions.py
+++ b/readthedocs/core/management/commands/update_versions.py
@@ -16,7 +16,6 @@ class Command(BaseCommand):
         for version in Version.objects.filter(active=True, built=False):
             # pylint: disable=no-value-for-parameter
             update_docs_task(
-                version.project_id,
+                version.pk,
                 record=False,
-                version_pk=version.pk,
             )

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Common utilty functions."""
 
 from __future__ import absolute_import
@@ -97,7 +95,6 @@ def prepare_build(
         version = project.versions.get(slug=default_version)
 
     kwargs = {
-        'version_pk': version.pk,
         'record': record,
         'force': force,
     }
@@ -131,7 +128,7 @@ def prepare_build(
 
     return (
         update_docs_task.signature(
-            args=(project.pk,),
+            args=(version.pk,),
             kwargs=kwargs,
             options=options,
             immutable=True,

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test core util functions."""
 
 import os
@@ -50,7 +49,6 @@ class CoreUtilTests(TestCase):
 
         trigger_build(project=project_1)
         kwargs = {
-            'version_pk': version_1.pk,
             'record': True,
             'force': False,
             'build_pk': mock.ANY,
@@ -58,7 +56,7 @@ class CoreUtilTests(TestCase):
 
         update_docs_task.signature.assert_has_calls([
             mock.call(
-                args=(project_1.pk,),
+                args=(version_1.pk,),
                 kwargs=kwargs,
                 options=mock.ANY,
                 immutable=True,
@@ -70,12 +68,11 @@ class CoreUtilTests(TestCase):
 
         trigger_build(project=self.project)
         default_version = self.project.get_default_version()
-        version_ = self.project.versions.get(slug=default_version)
+        version = self.project.versions.get(slug=default_version)
 
-        self.assertEqual(version_.slug, LATEST)
+        self.assertEqual(version.slug, LATEST)
 
         kwargs = {
-            'version_pk': version_.pk,
             'record': True,
             'force': False,
             'build_pk': mock.ANY,
@@ -83,7 +80,7 @@ class CoreUtilTests(TestCase):
 
         update_docs_task.signature.assert_has_calls([
             mock.call(
-                args=(self.project.pk,),
+                args=(version.pk,),
                 kwargs=kwargs,
                 options=mock.ANY,
                 immutable=True,
@@ -96,7 +93,6 @@ class CoreUtilTests(TestCase):
         self.project.build_queue = 'build03'
         trigger_build(project=self.project, version=self.version)
         kwargs = {
-            'version_pk': self.version.pk,
             'record': True,
             'force': False,
             'build_pk': mock.ANY,
@@ -108,7 +104,7 @@ class CoreUtilTests(TestCase):
         }
         update_docs.signature.assert_has_calls([
             mock.call(
-                args=(self.project.pk,),
+                args=(self.version.pk,),
                 kwargs=kwargs,
                 options=options,
                 immutable=True,
@@ -121,7 +117,6 @@ class CoreUtilTests(TestCase):
         """Pass of time limit."""
         trigger_build(project=self.project, version=self.version)
         kwargs = {
-            'version_pk': self.version.pk,
             'record': True,
             'force': False,
             'build_pk': mock.ANY,
@@ -133,7 +128,7 @@ class CoreUtilTests(TestCase):
         }
         update_docs.signature.assert_has_calls([
             mock.call(
-                args=(self.project.pk,),
+                args=(self.version.pk,),
                 kwargs=kwargs,
                 options=options,
                 immutable=True,
@@ -147,7 +142,6 @@ class CoreUtilTests(TestCase):
         self.project.container_time_limit = '200s'
         trigger_build(project=self.project, version=self.version)
         kwargs = {
-            'version_pk': self.version.pk,
             'record': True,
             'force': False,
             'build_pk': mock.ANY,
@@ -159,7 +153,7 @@ class CoreUtilTests(TestCase):
         }
         update_docs.signature.assert_has_calls([
             mock.call(
-                args=(self.project.pk,),
+                args=(self.version.pk,),
                 kwargs=kwargs,
                 options=options,
                 immutable=True,
@@ -173,7 +167,6 @@ class CoreUtilTests(TestCase):
         self.project.container_time_limit = 3
         trigger_build(project=self.project, version=self.version)
         kwargs = {
-            'version_pk': self.version.pk,
             'record': True,
             'force': False,
             'build_pk': mock.ANY,
@@ -185,7 +178,7 @@ class CoreUtilTests(TestCase):
         }
         update_docs.signature.assert_has_calls([
             mock.call(
-                args=(self.project.pk,),
+                args=(self.version.pk,),
                 kwargs=kwargs,
                 options=options,
                 immutable=True,


### PR DESCRIPTION
Currently we are using a mix of project_pk and version_pk.
But we only need a version_pk, the project
can be obtained from the version.

The default version is set at https://github.com/stsewd/readthedocs.org/blob/90211a2828dd874d4209caa4204eec806fdbc431/readthedocs/core/utils/__init__.py#L93-L95