### PR TITLE
Fix tests on master

### DIFF
--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -79,13 +79,14 @@ class TestCeleryBuilding(RTDTestCase):
     @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.build_docs', new=MagicMock)
     @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_vcs', new=MagicMock)
     def test_update_docs(self):
+        version = self.project.versions.first()
         build = get(
             Build, project=self.project,
-            version=self.project.versions.first(),
+            version=version,
         )
         with mock_api(self.repo) as mapi:
             result = tasks.update_docs_task.delay(
-                self.project.pk,
+                version.pk,
                 build_pk=build.pk,
                 record=False,
                 intersphinx=False,
@@ -99,13 +100,14 @@ class TestCeleryBuilding(RTDTestCase):
     def test_update_docs_unexpected_setup_exception(self, mock_setup_vcs):
         exc = Exception()
         mock_setup_vcs.side_effect = exc
+        version = self.project.versions.first()
         build = get(
             Build, project=self.project,
-            version=self.project.versions.first(),
+            version=version,
         )
         with mock_api(self.repo) as mapi:
             result = tasks.update_docs_task.delay(
-                self.project.pk,
+                version.pk,
                 build_pk=build.pk,
                 record=False,
                 intersphinx=False,
@@ -119,13 +121,14 @@ class TestCeleryBuilding(RTDTestCase):
     def test_update_docs_unexpected_build_exception(self, mock_build_docs):
         exc = Exception()
         mock_build_docs.side_effect = exc
+        version = self.project.versions.first()
         build = get(
             Build, project=self.project,
-            version=self.project.versions.first(),
+            version=version,
         )
         with mock_api(self.repo) as mapi:
             result = tasks.update_docs_task.delay(
-                self.project.pk,
+                version.pk,
                 build_pk=build.pk,
                 record=False,
                 intersphinx=False,
@@ -138,14 +141,16 @@ class TestCeleryBuilding(RTDTestCase):
     @patch('readthedocs.projects.tasks.UpdateDocsTaskStep.setup_vcs')
     def test_no_notification_on_version_locked_error(self, mock_setup_vcs, mock_send_notifications):
         mock_setup_vcs.side_effect = VersionLockedError()
+        
+        version = self.project.versions.first()
 
         build = get(
             Build, project=self.project,
-            version=self.project.versions.first(),
+            version=version,
         )
-        with mock_api(self.repo) as mapi:
+        with mock_api(self.repo):
             result = tasks.update_docs_task.delay(
-                self.project.pk,
+                version.pk,
                 build_pk=build.pk,
                 record=False,
                 intersphinx=False,

--- a/readthedocs/vcs_support/utils.py
+++ b/readthedocs/vcs_support/utils.py
@@ -95,9 +95,10 @@ class NonBlockingLock:
     """
 
     def __init__(self, project, version, max_lock_age=None):
+        self.base_path = project.doc_path
         self.fpath = os.path.join(
-            project.doc_path,
-            '%s__rtdlock' % version.slug,
+            self.base_path,
+            f'{version.slug}__rtdlock',
         )
         self.max_lock_age = max_lock_age
         self.name = project.slug
@@ -118,6 +119,8 @@ class NonBlockingLock:
                 )
         elif path_exists:
             raise LockTimeout('Lock ({}): Lock still active'.format(self.name),)
+        # Create dirs if they don't exists
+        os.makedirs(self.base_path, exist_ok=True)
         open(self.fpath, 'w').close()
         return self
 


### PR DESCRIPTION
Two PRs got merged and one modified the behaviour that the
other one was depending on.

This was giving an error in the lock creation
because the base dir wasn't created yet.

The rest of tests something I forgot to change project_pk -> version_pk
(I did a grep, didn't find more)