### PR TITLE
Project advertising page/form update

### DIFF
--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -30,18 +30,18 @@
   <ul class="project-ads-guidelines">
     <li>
       {% blocktrans trimmed %}
-        We don't give sponsors access to user information
+        We don't give sponsors access to user information.
       {% endblocktrans %}
     </li>
     <li>
       {% blocktrans trimmed %}
-        We only report the number of impressions and number of ad clicks
+        We only report the number of impressions and number of ad clicks.
       {% endblocktrans %}
     </li>
     <li>
       {% blocktrans trimmed %}
-        We only allow and image and text, no Javascript besides our existing
-        tracking
+        We only allow and image and text ads which we host ourselves.
+        There are no advertiser-supplied scripts running on Read the Docs.
       {% endblocktrans %}
     </li>
   </ul>
@@ -50,7 +50,8 @@
     {% blocktrans trimmed %}
       For more details on advertising on Read the Docs
       including the privacy protections we have in place for users
-      and community advertising we run on behalf of the open source community,
+      and <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html#community-ads">community advertising</a>
+      we run on behalf of the open source community,
       see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html">our documentation</a>.
     {% endblocktrans %}
   </p>
@@ -58,85 +59,58 @@
   <h4>{% trans "Opting out" %}</h4>
 
   <p>
+    {% url 'account_advertising' as ads_preferences_url %}
     {% blocktrans trimmed %}
-      If you do not wish to support Read the Docs with use of this ad space,
-      we ask that you help support Read the Docs in one of following ways:
+      In addition to the advertising preferences we have for <a href="{{ ads_preferences_url }}">individual users</a>,
+      we have multiple ways for projects to opt out of advertising on Read the Docs.
     {% endblocktrans %}
   </p>
 
   <ul class="module-list project-ads-support">
     <li class="module-item">
       {% blocktrans trimmed %}
-        If you have an open source project, and can contribute financially,
-        consider a gold subscription. Gold members have an ad-free
-        experience while using Read the Docs.
+        If you are part of a company that uses Read the Docs to host documentation for a commercial product,
+        we offer <a href="https://readthedocs.com/pricing/">paid plans</a> on readthedocs.com
+        that offer a completely ad-free experience,
+        private repositories, private documentation, additional build resources, and CDN support.
       {% endblocktrans %}
-
-      <form method="get" action="{% url "gold_subscription" %}">
-        <input type="submit" value="{% trans "I can contribute financially" %}" />
-      </form>
     </li>
 
     <li class="module-item">
       {% blocktrans trimmed %}
-        If your project is an open source project, you most certainly also
-        lack funding.  If you can't contribute financially to Read the Docs,
-        consider donating your time. We can always use help with support
-        requests, documentation updates, and of course feature development.
+        Project owners can <a href="#removing-paid-advertising">opt out of paid advertisements</a>
+        for their projects.
+        Readers will still see community ads for open source projects and conferences.
       {% endblocktrans %}
-
-      <form method="get" action="https://docs.readthedocs.io/page/contribute.html">
-        <input type="submit" value="{% trans "I can contribute my time" %}" />
-      </form>
     </li>
 
     <li class="module-item">
       {% blocktrans trimmed %}
-        If you are part of a company that uses Read the Docs to host
-        documentation for a commercial product, we offer paid plans that
-        offer email support, additional build resources, and features like
-        CDN support and private documentation.
+        If you would like to completely remove advertising from your open source project,
+        but our commercial plans don't seem like the right fit,
+        please <a href="mailto:ads@readthedocs.org?subject=Alternatives+to+advertising">get in touch</a>
+        to discuss alternatives to advertising.
       {% endblocktrans %}
-
-      <form method="get" action="https://readthedocs.com/pricing/">
-        <input type="submit" value="{% trans "Learn more about a paid plan" %}" />
-      </form>
     </li>
   </ul>
 
-  <h4>{% trans "Still can't help?" %}</h4>
-
-  <p>
-    {% blocktrans trimmed %}
-      If you can't contribute your support for your open source project, but
-      are conflicted by allowing support through advertising, we still would
-      like to give you the option to disable showing promotions inside your
-      documentation. We might be in contact in the future to see if you would
-      reconsider offering your support.
-    {% endblocktrans %}
-  </p>
-
-  <p>
-    {% blocktrans trimmed %}
-      If you are a company hosting commercial documentation on our community
-      site, but can't offer support for Read the Docs, we do not allow
-      removing sponsor advertisements on your documentation. This goes
-      against the spirit of supporting the open source community, please find
-      a way to offer your support.
-    {% endblocktrans %}
-  </p>
-
-  <p>
-    {% blocktrans trimmed %}
-      To discuss alternatives to advertising, please <a href="mailto:ads@readthedocs.org?subject=Alternatives+to+advertising">contact us</a>.
-    {% endblocktrans %}
-  </p>
+  <a name="removing-paid-advertising"></a>
 
   <form method="post" action=".">
     {% csrf_token %}
     {{ form.as_p }}
+
+    <p class="help_text">
+      <small>
+      {% blocktrans trimmed %}
+        If you are a company hosting commercial documentation on our community site,
+        we do not allow removing sponsor advertisements on your documentation.
+      {% endblocktrans %}
+      </small>
+    </p>
+
     <p>
-      <input style="display: inline;" type="submit" value="{% trans "Update advertisement preference" %}">
+      <input type="submit" value="{% trans "Update advertising preference" %}">
     </p>
   </form>
 {% endblock %}


### PR DESCRIPTION
- Remove the forms to contribute to Read the Docs. We don't really get any contributions this way
- Build value for the commercial product a bit more
- More prominent get in touch for alternatives
- Remove mentions of gold. Gold doesn't remove ads from projects anymore. However, projects can get in touch.

![Screen Shot 2019-06-07 at 1 54 21 PM](https://user-images.githubusercontent.com/185043/59133096-cb5d5000-892b-11e9-96ca-26bc9283bd29.png)
