### PR TITLE
Use a real SessionBase object on FooterNoSessionMiddleware

### DIFF
--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.contrib.sessions.backends.base import SessionBase
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.http import Http404, HttpResponseBadRequest
@@ -205,7 +206,7 @@ class FooterNoSessionMiddleware(SessionMiddleware):
                 settings.SESSION_COOKIE_NAME not in request.COOKIES
             ):
                 # Hack request.session otherwise the Authentication middleware complains.
-                request.session = {}
+                request.session = SessionBase()  # create an empty session
                 return
         super().process_request(request)
 

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -1,4 +1,5 @@
 import mock
+from django.contrib.sessions.backends.base import SessionBase
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory, APITestCase
 
@@ -80,7 +81,8 @@ class Testmaker(APITestCase):
         # Null session here
         request = self.factory.get('/api/v2/footer_html/')
         mid.process_request(request)
-        self.assertEqual(request.session, {})
+        self.assertIsInstance(request.session, SessionBase)
+        self.assertEqual(list(request.session.keys()), [])
 
         # Proper session here
         home_request = self.factory.get('/')


### PR DESCRIPTION
Instead of forcing to be an empty dict `{}`, we force it to be a real SessionBase object which it's what Django uses internally. This avoid issues where other pieces expects the `SessionBase`.

Django docs: https://docs.djangoproject.com/en/1.11/topics/http/sessions/#django.contrib.sessions.backends.base.SessionBase