### PR TITLE
Optimize requests to APIv3

### DIFF
--- a/readthedocs/api/v3/mixins.py
+++ b/readthedocs/api/v3/mixins.py
@@ -81,8 +81,7 @@ class ProjectQuerySetMixin(NestedParentObjectMixin):
         4. raise a ``NotFound`` exception otherwise
         """
 
-        # NOTE: ``super().get_queryset`` produces the filter by ``NestedViewSetMixin``
-        # we need to have defined the class attribute as ``queryset = Model.objects.all()``
+        # We need to have defined the class attribute as ``queryset = Model.objects.all()``
         queryset = super().get_queryset()
 
         # Detail requests are public
@@ -90,8 +89,4 @@ class ProjectQuerySetMixin(NestedParentObjectMixin):
             return self.detail_objects(queryset, self.request.user)
 
         # List view are only allowed if user is owner of parent project
-        listing_objects = self.listing_objects(queryset, self.request.user)
-        if listing_objects:
-            return listing_objects
-
-        raise NotFound
+        return self.listing_objects(queryset, self.request.user)


### PR DESCRIPTION
Doing `if queryset` as this does actually evaluates the queryset which can be quite expensive. Rather than doing that, this will just return it. If the project slug is invalid, it should have already 404ed and returning an empty list in the other case seems reasonable. You could see this in the Django Debug Toolbar query tab.

More generally, there is a lot of multi-inheritance in the APIv3 and maybe we could do something to simplify it.

I removed the comment 

    # NOTE: ``super().get_queryset`` produces the filter by ``NestedViewSetMixin``

In actuality, this method is called by `NestedViewSetMixin.get_queryset` and not the other way around.