### PR TITLE
Disable changing domain when editing the object

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -666,6 +666,11 @@ class DomainBaseForm(forms.ModelForm):
         self.project = kwargs.pop('project', None)
         super().__init__(*args, **kwargs)
 
+        # Disable domain manipulation on Update, but allow on Create
+        instance = getattr(self, 'instance', None)
+        if instance and instance.pk:
+            self.fields['domain'].disabled = True
+
     def clean_project(self):
         return self.project
 

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -105,13 +105,14 @@ class FormTests(TestCase):
         self.assertEqual(form.errors['canonical'][0], 'Only 1 Domain can be canonical at a time.')
 
         form = DomainForm(
-            {'domain': 'example2.com', 'canonical': True},
+            {'canonical': False},
             project=self.project,
             instance=domain,
         )
         self.assertTrue(form.is_valid())
         domain = form.save()
-        self.assertEqual(domain.domain, 'example2.com')
+        self.assertEqual(domain.domain, 'example.com')
+        self.assertFalse(domain.canonical)
 
 
 class TestAPI(TestCase):


### PR DESCRIPTION
When the user clicks on a Domain object to edit it, we don't allow to change the `domain` field since it does not make sense. In case there was a mistake, the domain needs to be re-created.