### PR TITLE
Remove internal filtering from Version and Build listing

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -92,7 +92,7 @@ class BuildList(BuildBase, BuildTriggerMixin, ListView):
             Project.objects.protected(self.request.user),
             slug=self.project_slug,
         )
-        queryset = Build.internal.public(
+        queryset = Build.objects.public(
             user=self.request.user,
             project=self.project,
         ).select_related('project', 'version')

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -93,7 +93,7 @@ class ProjectDetailView(BuildTriggerMixin, ProjectOnboardMixin, DetailView):
         context = super().get_context_data(**kwargs)
 
         project = self.get_object()
-        context['versions'] = Version.internal.public(
+        context['versions'] = Version.objects.public(
             user=self.request.user,
             project=project,
         )
@@ -268,7 +268,7 @@ def project_versions(request, project_slug):
         slug=project_slug,
     )
 
-    versions = Version.internal.public(
+    versions = Version.objects.public(
         user=request.user,
         project=project,
         only_active=False,

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -385,24 +385,17 @@ class TestPublicViews(MockBuildTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
-    def test_project_detail_view_only_shows_internal_versons(self):
+    def test_project_detail_view_shows_external_versons(self):
         url = reverse('projects_detail', args=[self.pip.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(self.external_version, response.context['versions'])
+        self.assertIn(self.external_version, response.context['versions'])
 
     def test_project_downloads_only_shows_internal_versons(self):
         url = reverse('project_downloads', args=[self.pip.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(self.external_version, response.context['versions'])
-
-    def test_project_versions_only_shows_internal_versons(self):
-        url = reverse('project_version_list', args=[self.pip.slug])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertNotIn(self.external_version, response.context['active_versions'])
-        self.assertNotIn(self.external_version, response.context['inactive_versions'])
 
 
 class TestPrivateViews(MockBuildTestCase):

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -296,4 +296,3 @@ class BuildViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertIn(external_version_build, response.context['build_qs'])
-        self.assertIn(external_version_build, response.context['active_builds'])

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -278,7 +278,7 @@ class BuildViewTests(TestCase):
             '/projects/pip/builds/%s/' % build.pk,
         )
 
-    def test_build_list_does_not_include_external_versions(self):
+    def test_build_list_includes_external_versions(self):
         external_version = get(
             Version,
             project = self.pip,
@@ -295,5 +295,5 @@ class BuildViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        self.assertNotIn(external_version_build, response.context['build_qs'])
-        self.assertNotIn(external_version_build, response.context['active_builds'])
+        self.assertIn(external_version_build, response.context['build_qs'])
+        self.assertIn(external_version_build, response.context['active_builds'])


### PR DESCRIPTION
this is mainly for testing and the UI/UX might change for the listings.

ref: #5807