### PR TITLE
Remove django guardian from querysets

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -17,12 +17,12 @@ class VersionQuerySetBase(models.QuerySet):
 
     def _add_user_repos(self, queryset, user):
         if user.has_perm('builds.view_version'):
-            return self.all()
+            return self.all().distinct()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)
             user_queryset = self.filter(project__in=projects_pk)
             queryset = user_queryset | queryset
-        return queryset
+        return queryset.distinct()
 
     def public(self, user=None, project=None, only_active=True):
         queryset = self.filter(privacy_level=constants.PUBLIC)
@@ -89,12 +89,12 @@ class BuildQuerySetBase(models.QuerySet):
 
     def _add_user_repos(self, queryset, user=None):
         if user.has_perm('builds.view_version'):
-            return self.all()
+            return self.all().distinct()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)
             user_queryset = self.filter(project__in=projects_pk)
             queryset = user_queryset | queryset
-        return queryset
+        return queryset.distinct()
 
     def public(self, user=None, project=None):
         queryset = self.filter(version__privacy_level=constants.PUBLIC)
@@ -127,7 +127,7 @@ class RelatedBuildQuerySetBase(models.QuerySet):
 
     def _add_user_repos(self, queryset, user=None):
         if user.has_perm('builds.view_version'):
-            return self.all()
+            return self.all().distinct()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)
             user_queryset = self.filter(build__project__in=projects_pk)

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -16,11 +16,11 @@ class ProjectQuerySetBase(models.QuerySet):
 
     def _add_user_repos(self, queryset, user):
         if user.has_perm('projects.view_project'):
-            return self.all()
+            return self.all().distinct()
         if user.is_authenticated:
             user_queryset = user.projects.all()
             queryset = user_queryset | queryset
-        return queryset
+        return queryset.distinct()
 
     def for_user_and_viewer(self, user, viewer):
         """Show projects that a user owns, that another user can see."""
@@ -131,12 +131,12 @@ class RelatedProjectQuerySetBase(models.QuerySet):
 
     def _add_user_repos(self, queryset, user=None):
         if user.has_perm('projects.view_project'):
-            return self.all()
+            return self.all().distinct()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)
             user_queryset = self.filter(project__in=projects_pk)
             queryset = user_queryset | queryset
-        return queryset
+        return queryset.distinct()
 
     def public(self, user=None, project=None):
         kwargs = {'%s__privacy_level' % self.project_field: constants.PUBLIC}


### PR DESCRIPTION
We set these permissions when we save a project or a version

https://github.com/rtfd/readthedocs.org/blob/1ee57dec16f352d14ca17c1bcd8877a9a88a8f0a/readthedocs/projects/models.py#L424-L425
https://github.com/rtfd/readthedocs.org/blob/1ee57dec16f352d14ca17c1bcd8877a9a88a8f0a/readthedocs/builds/models.py#L249-L250

We set them to all the owners of a project,
we already know all projects of an user with `user.projects`.

For now I'm just removing guardian from the querysets,
in another PR I'm going to remove the dep of guardian

~This also removes the use of `distinct` (this generates problems when trying to do another or `|`)~ (This failed, I'm keeping distinct :/)
- self.all() - This doesn't look like it's going to return duplicated results
- self.filter() - this is filtering for selected pk's only, I don't think we can have duplicated results neither